### PR TITLE
Update category

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "publisherName": "Developer ID Application: Oleksandr Chaplinsky (UFBL3F444A)"
     },
     "linux": {
-      "category": "Utilities",
+      "category": "Utility",
       "target": [
         "deb",
         "rpm",


### PR DESCRIPTION
I'm getting this warning from Gentoo Quality Assurance:

```
 * QA Notice: This package installs one or more .desktop files that do not
 * pass validation.
 * 
 * 	/usr/share/applications/swifty.desktop: error: value "Utilities;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Utilities"; values extending the format should start with "X-"
 *
```

This PR updates this variable according to [specifications](https://specifications.freedesktop.org/menu-spec/latest/apa.html) from `Utilities` to `Utility`.