### PR TITLE
fix for google drive

### DIFF
--- a/src/main/application/sync/gdrive/drive.js
+++ b/src/main/application/sync/gdrive/drive.js
@@ -10,7 +10,7 @@ export default class Drive {
 
   async readFile(id) {
     const { data } = await this.drive.files.get({ fileId: id, alt: 'media' })
-    return data
+    return data.text()
   }
 
   async updateFile(id, content) {

--- a/src/main/application/sync/index.js
+++ b/src/main/application/sync/index.js
@@ -2,7 +2,6 @@ import GDrive from './gdrive'
 import { mergeData } from './base/merge'
 
 const NO_INTERNET_CONNECTION = 'Swifty seems to be offline'
-const NOT_CONFIGURED = 'Sync is not configured'
 const FAILED_TO_FIND_REMOTE_VAULT = 'Failed to find remote vault file'
 const FAILED_TO_CREATE_REMOTE_VAULT = 'Failed to create remote vault file'
 const FAILED_TO_READ_REMOTE_VAULT = 'Failed to read remote vault file'
@@ -19,7 +18,9 @@ export default class Sync {
   }
 
   async perform() {
-    if (!this.isConfigured()) throw Error(NOT_CONFIGURED)
+    if (!this.isConfigured()) {
+      this.provider.setup()
+    }
 
     if (!(await this.remoteVaultExists())) {
       await this.createRemoteVault()


### PR DESCRIPTION
- Authenticate instead of throwing not configured error, this was causing issues when user tries to connect to google drive from the settings using the "connect your Google drive" button.

- return text instead of blob received from drive, drive returns a blob returning it as text resolves the issue with not being able to decrypt the file.