### PR TITLE
PR-2: migrate Redux Toolkit to Zustand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "swifty",
       "dependencies": {
-        "@reduxjs/toolkit": "^2.2.7",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2.7.2",
@@ -14,7 +13,7 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-redux": "^9.1.2",
+        "zustand": "^5.0.15",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
@@ -222,8 +221,6 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.6.0", "", { "os": "win32", "cpu": "x64" }, "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A=="],
 
-    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
-
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
@@ -279,8 +276,6 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.63.1", "", { "os": "win32", "cpu": "x64" }, "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@svgr/babel-plugin-add-jsx-attribute": ["@svgr/babel-plugin-add-jsx-attribute@8.0.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="],
 
@@ -371,8 +366,6 @@
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
-
-    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.68.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.68.0", "@typescript-eslint/type-utils": "8.68.0", "@typescript-eslint/utils": "8.68.0", "@typescript-eslint/visitor-keys": "8.68.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.68.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q=="],
 
@@ -556,8 +549,6 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "immer": ["immer@11.1.18", "", {}, "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ=="],
-
     "immutable": ["immutable@5.1.9", "", {}, "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -680,21 +671,13 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
-
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "readdirp": ["readdirp@5.1.1", "", {}, "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
-    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
-
-    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
-
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "reselect": ["reselect@5.3.0", "", {}, "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -764,8 +747,6 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
     "vite-plugin-svgr": ["vite-plugin-svgr@5.2.0", "", { "dependencies": { "@rollup/pluginutils": "^5.3.0", "@svgr/core": "^8.1.0", "@svgr/plugin-jsx": "^8.1.0" }, "peerDependencies": { "vite": ">=3.0.0" } }, "sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ=="],
@@ -793,6 +774,8 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zustand": ["zustand@5.0.15", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^2.2.7",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
@@ -31,7 +30,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-redux": "^9.1.2"
+    "zustand": "^5.0.15"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,13 @@
 import { useEffect } from 'react'
 import { isBiometricAvailable, isInitialized } from './lib/commands'
-import { useAppDispatch, useAppSelector } from './store'
-import { flowAuth, flowSetup } from './store/flowSlice'
+import { useStore, flowAuth, flowSetup } from './store'
 import { subscribeToEvents } from './store/events'
 import Start from './components/Start'
 import Auth from './components/Auth'
 import Main from './components/Main'
 
 function Shell() {
-  const flow = useAppSelector(state => state.flow)
+  const flow = useStore(state => state.flow)
   switch (flow.name) {
     case 'setup':
       return <Start />
@@ -20,18 +19,17 @@ function Shell() {
 }
 
 export default function App() {
-  const dispatch = useAppDispatch()
-  const locale = useAppSelector(state => state.i18n.locale)
+  const locale = useStore(state => state.i18n.locale)
 
   useEffect(() => {
-    const unsubscribe = subscribeToEvents(dispatch)
+    const unsubscribe = subscribeToEvents()
     Promise.all([isInitialized(), isBiometricAvailable().catch(() => false)])
       .then(([initialized, biometric]) =>
-        dispatch(initialized ? flowAuth(biometric) : flowSetup())
+        initialized ? flowAuth(biometric) : flowSetup()
       )
       .catch(() => {})
     return unsubscribe
-  }, [dispatch])
+  }, [])
 
   // `locale` as key remounts the tree on language change so `t()` re-runs.
   return <Shell key={locale} />

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { unlock, unlockBiometric } from '@/lib/commands'
-import { useAppDispatch } from '@/store'
-import { enterMain } from '@/store/thunks'
+import { enterMain } from '@/store'
 import { t } from '@/i18n'
 import Masterpass from '@/components/elements/Masterpass'
 import Controls from '@/components/elements/Controls'
@@ -12,18 +11,17 @@ interface Props {
 }
 
 export function Auth({ touchID }: Props) {
-  const dispatch = useAppDispatch()
   const [error, setError] = useState<string | null>(null)
 
   const handleEnter = (value: string) => {
     unlock(value)
-      .then(result => dispatch(enterMain(result)))
+      .then(result => enterMain(result))
       .catch(() => setError(t('Incorrect Master Password')))
   }
 
   const handleTouchId = () => {
     unlockBiometric()
-      .then(result => dispatch(enterMain(result)))
+      .then(result => enterMain(result))
       .catch(() => setError(t('Incorrect Master Password')))
   }
 

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -1,4 +1,4 @@
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import type { Audit, AuditItem } from '@/lib/commands'
 import { t } from '@/i18n'
 import Score from './Score'
@@ -7,10 +7,8 @@ const count = (audit: Audit, property: keyof AuditItem) =>
   Object.values(audit).filter(item => item[property]).length
 
 export default function Audit() {
-  const { isPristine, audit } = useAppSelector(state => ({
-    audit: state.audit,
-    isPristine: state.entries.items.length === 0
-  }))
+  const audit = useStore(state => state.audit)
+  const isPristine = useStore(state => state.entries.items.length === 0)
 
   if (isPristine || !audit) return null
 

--- a/src/components/Main/Body/Aside/Empty/Actions.tsx
+++ b/src/components/Main/Body/Aside/Empty/Actions.tsx
@@ -1,14 +1,12 @@
 import { useState } from 'react'
 import { cx } from '@/utils/cx'
-import { useAppDispatch, useAppSelector } from '@/store'
-import { newEntry } from '@/store/entriesSlice'
+import { useStore, newEntry } from '@/store'
 import { syncImport } from '@/lib/commands'
 import { SYNC_ENABLED } from '@/config'
 import { t } from '@/i18n'
 
 export default function Actions() {
-  const dispatch = useAppDispatch()
-  const isPristine = useAppSelector(state => state.entries.items.length === 0)
+  const isPristine = useStore(state => state.entries.items.length === 0)
   const [loading, setLoading] = useState(false)
 
   const onImport = () => {
@@ -21,7 +19,7 @@ export default function Actions() {
   return (
     <div className="actions">
       <div>
-        <a href="#" onClick={() => dispatch(newEntry())}>
+        <a href="#" onClick={() => newEntry()}>
           {t('Create First Entry')}
         </a>
       </div>

--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useAppDispatch, useAppSelector } from '@/store'
-import { setCurrentEntry, setNoEntry } from '@/store/entriesSlice'
-import { saveEntry } from '@/store/thunks'
+import { useStore, setCurrentEntry, setNoEntry, saveEntry } from '@/store'
 import { useRevealed } from '@/hooks/useRevealed'
 import { isValid } from '@/services/entries'
 import defaults, { type EntryDraft } from '@/defaults/entries'
@@ -17,8 +15,7 @@ interface Props {
 }
 
 export default function Form({ entry }: Props) {
-  const dispatch = useAppDispatch()
-  const scope = useAppSelector(state => state.filters.scope)
+  const scope = useStore(state => state.filters.scope)
   const type: EntryType = scope === 'audit' ? 'login' : scope
 
   const [validate, setValidate] = useState(false)
@@ -46,12 +43,12 @@ export default function Form({ entry }: Props) {
   const onTagsChange = (tags: string[]) => patch('tags', tags)
 
   const onCancel = () => {
-    if (model.id) dispatch(setCurrentEntry(model.id))
-    else dispatch(setNoEntry())
+    if (model.id) setCurrentEntry(model.id)
+    else setNoEntry()
   }
 
   const onSave = () => {
-    if (isValid(model)) dispatch(saveEntry(model))
+    if (isValid(model)) saveEntry(model)
     else setValidate(true)
   }
 

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -1,6 +1,4 @@
-import { useAppDispatch } from '@/store'
-import { editEntry } from '@/store/entriesSlice'
-import { deleteEntry } from '@/store/thunks'
+import { editEntry, deleteEntry } from '@/store'
 import type { Entry } from '@/lib/commands'
 import { useRevealed } from '@/hooks/useRevealed'
 import { t } from '@/i18n'
@@ -16,12 +14,11 @@ const formatDate = (value?: string) =>
   value ? new Date(value).toLocaleString() : ''
 
 export default function Show({ entry }: Props) {
-  const dispatch = useAppDispatch()
   const revealed = useRevealed(entry)
 
   const onDelete = () => {
     if (window.confirm(t('Are you sure you want to delete this item?'))) {
-      dispatch(deleteEntry(entry.id))
+      deleteEntry(entry.id)
     }
   }
 
@@ -32,7 +29,7 @@ export default function Show({ entry }: Props) {
       </div>
       <div className="entry-title">
         <h1>{entry.title}</h1>
-        <Pencil width="16" height="16" onClick={() => dispatch(editEntry())} className="action" />
+        <Pencil width="16" height="16" onClick={() => editEntry()} className="action" />
         <Delete width="16" height="16" onClick={onDelete} className="action" />
       </div>
       {revealed && <Details entry={revealed} />}

--- a/src/components/Main/Body/Aside/index.tsx
+++ b/src/components/Main/Body/Aside/index.tsx
@@ -1,16 +1,14 @@
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import Form from './Form'
 import Show from './Show'
 import Empty from './Empty'
 import Audit from './Audit'
 
 export default function Aside() {
-  const { isNew, isEditing, entry, scope } = useAppSelector(state => ({
-    scope: state.filters.scope,
-    isNew: state.entries.new,
-    isEditing: state.entries.edit,
-    entry: state.entries.current
-  }))
+  const scope = useStore(state => state.filters.scope)
+  const isNew = useStore(state => state.entries.new)
+  const isEditing = useStore(state => state.entries.edit)
+  const entry = useStore(state => state.entries.current)
 
   if (isNew) return <Form />
   if (isEditing && entry) return <Form entry={entry} />

--- a/src/components/Main/Body/List/Audit/index.tsx
+++ b/src/components/Main/Body/List/Audit/index.tsx
@@ -1,14 +1,12 @@
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import type { Audit, AuditItem, Entry } from '@/lib/commands'
 import { t } from '@/i18n'
 import Empty from '../Empty'
 import Group from './Group'
 
 export default function AuditList() {
-  const { items, audit } = useAppSelector(state => ({
-    audit: state.audit,
-    items: state.entries.items
-  }))
+  const audit = useStore(state => state.audit)
+  const items = useStore(state => state.entries.items)
 
   const byProperty = (property: keyof AuditItem): Entry[] =>
     Object.keys(audit as Audit)

--- a/src/components/Main/Body/List/Item/index.tsx
+++ b/src/components/Main/Body/List/Item/index.tsx
@@ -1,6 +1,5 @@
 import { cx } from '@/utils/cx'
-import { useAppDispatch, useAppSelector } from '@/store'
-import { setCurrentEntry } from '@/store/entriesSlice'
+import { useStore, setCurrentEntry } from '@/store'
 import type { Entry } from '@/lib/commands'
 import Login from './Login'
 import Card from './Card'
@@ -11,8 +10,7 @@ interface Props {
 }
 
 export default function Item({ entry }: Props) {
-  const dispatch = useAppDispatch()
-  const current = useAppSelector(state => state.entries.current)
+  const current = useStore(state => state.entries.current)
 
   const content = () => {
     switch (entry.type) {
@@ -28,7 +26,7 @@ export default function Item({ entry }: Props) {
   return (
     <div
       className={cx('entry', { current: current?.id === entry.id })}
-      onClick={() => dispatch(setCurrentEntry(entry.id))}
+      onClick={() => setCurrentEntry(entry.id)}
     >
       {content()}
     </div>

--- a/src/components/Main/Body/List/Manager.tsx
+++ b/src/components/Main/Body/List/Manager.tsx
@@ -1,15 +1,13 @@
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import { filterEntries } from '@/services/entries'
 import Item from './Item'
 import Empty from './Empty'
 
 export default function Manager() {
-  const { items, query, scope, tags } = useAppSelector(state => ({
-    tags: state.filters.tags,
-    scope: state.filters.scope,
-    query: state.filters.query,
-    items: state.entries.items
-  }))
+  const tags = useStore(state => state.filters.tags)
+  const scope = useStore(state => state.filters.scope)
+  const query = useStore(state => state.filters.query)
+  const items = useStore(state => state.entries.items)
 
   const entries = filterEntries(items, { scope, query, tags })
 

--- a/src/components/Main/Body/List/index.tsx
+++ b/src/components/Main/Body/List/index.tsx
@@ -1,8 +1,8 @@
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import Manager from './Manager'
 import AuditList from './Audit'
 
 export default function List() {
-  const scope = useAppSelector(state => state.filters.scope)
+  const scope = useStore(state => state.filters.scope)
   return scope === 'audit' ? <AuditList /> : <Manager />
 }

--- a/src/components/Main/Header/Search.tsx
+++ b/src/components/Main/Header/Search.tsx
@@ -1,12 +1,10 @@
-import { useAppDispatch, useAppSelector } from '@/store'
-import { setFilterQuery } from '@/store/filtersSlice'
+import { useStore, setFilterQuery } from '@/store'
 import { t } from '@/i18n'
 import SearchIcon from '@/assets/images/search.svg?react'
 import ClearIcon from '@/assets/images/clear.svg?react'
 
 export default function Search() {
-  const dispatch = useAppDispatch()
-  const query = useAppSelector(state => state.filters.query)
+  const query = useStore(state => state.filters.query)
 
   return (
     <div className="search">
@@ -16,11 +14,11 @@ export default function Search() {
         name="search"
         placeholder={t('Search')}
         value={query}
-        onChange={e => dispatch(setFilterQuery(e.target.value))}
+        onChange={e => setFilterQuery(e.target.value)}
       />
       {query !== '' && (
         <ClearIcon
-          onClick={() => dispatch(setFilterQuery(''))}
+          onClick={() => setFilterQuery('')}
           width="10"
           height="10"
           className="clear-icon"

--- a/src/components/Main/Header/SyncIndicator.tsx
+++ b/src/components/Main/Header/SyncIndicator.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@/utils/cx'
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import Tooltip from '@/components/elements/Tooltip'
 import Gdrive from '@/assets/images/google-drive-color.svg?react'
 import HardDrive from '@/assets/images/hard-drive.svg?react'
@@ -7,7 +7,7 @@ import Tick from '@/assets/images/success_tick@2x.png'
 import Exclamation from '@/assets/images/warning_exclamation@2x.png'
 
 export default function SyncIndicator() {
-  const sync = useAppSelector(state => state.sync)
+  const sync = useStore(state => state.sync)
 
   const icon = sync.enabled ? (
     <Gdrive width="18" height="18" />

--- a/src/components/Main/Header/Tags/Dropdown.tsx
+++ b/src/components/Main/Header/Tags/Dropdown.tsx
@@ -1,5 +1,5 @@
-import { useAppDispatch, useAppSelector } from '@/store'
-import { setFilterTag } from '@/store/filtersSlice'
+import { useShallow } from 'zustand/react/shallow'
+import { useStore, setFilterTag } from '@/store'
 import { Dropdown as Menu, DropdownItem } from '@/components/elements/Dropdown'
 import Empty from './Empty'
 
@@ -9,13 +9,14 @@ interface Props {
 }
 
 export default function Dropdown({ visible, setVisible }: Props) {
-  const dispatch = useAppDispatch()
-  const tags = useAppSelector(state =>
-    Array.from(
-      new Set(
-        state.entries.items
-          .filter(item => item.type === state.filters.scope)
-          .flatMap(entry => entry.tags ?? [])
+  const tags = useStore(
+    useShallow(state =>
+      Array.from(
+        new Set(
+          state.entries.items
+            .filter(item => item.type === state.filters.scope)
+            .flatMap(entry => entry.tags ?? [])
+        )
       )
     )
   )
@@ -23,7 +24,7 @@ export default function Dropdown({ visible, setVisible }: Props) {
   if (!visible) return null
 
   const setTag = (tag: string) => {
-    dispatch(setFilterTag(tag))
+    setFilterTag(tag)
     setVisible(false)
   }
 

--- a/src/components/Main/Header/Tags/Selected.tsx
+++ b/src/components/Main/Header/Tags/Selected.tsx
@@ -1,16 +1,14 @@
-import { useAppDispatch, useAppSelector } from '@/store'
-import { unsetFilterTag } from '@/store/filtersSlice'
+import { useStore, unsetFilterTag } from '@/store'
 
 export default function Selected() {
-  const dispatch = useAppDispatch()
-  const tag = useAppSelector(state => state.filters.tags[0])
+  const tag = useStore(state => state.filters.tags[0])
 
   if (!tag) return null
 
   return (
     <span className="tag-selected">
       {tag}
-      <span className="tag-clear" onClick={() => dispatch(unsetFilterTag())}>
+      <span className="tag-clear" onClick={() => unsetFilterTag()}>
         x
       </span>
     </span>

--- a/src/components/Main/Sidebar/Add.tsx
+++ b/src/components/Main/Sidebar/Add.tsx
@@ -1,15 +1,12 @@
-import { useAppDispatch, useAppSelector } from '@/store'
-import { newEntry } from '@/store/entriesSlice'
-import { setFilterScope } from '@/store/filtersSlice'
+import { useStore, newEntry, setFilterScope } from '@/store'
 import Plus from '@/assets/images/plus.svg?react'
 
 export default function Add() {
-  const dispatch = useAppDispatch()
-  const scope = useAppSelector(state => state.filters.scope)
+  const scope = useStore(state => state.filters.scope)
 
   const onAddEntry = () => {
-    if (scope === 'audit') dispatch(setFilterScope('login'))
-    dispatch(newEntry())
+    if (scope === 'audit') setFilterScope('login')
+    newEntry()
   }
 
   return (

--- a/src/components/Main/Sidebar/Settings/Language.tsx
+++ b/src/components/Main/Sidebar/Settings/Language.tsx
@@ -1,5 +1,4 @@
-import { useAppDispatch, useAppSelector } from '@/store'
-import { localeChanged } from '@/store/i18nSlice'
+import { useStore, localeChanged } from '@/store'
 import { LANGUAGES, t } from '@/i18n'
 import type { Section } from './Navigation'
 
@@ -8,8 +7,7 @@ interface Props {
 }
 
 export default function Language({ section }: Props) {
-  const dispatch = useAppDispatch()
-  const locale = useAppSelector(state => state.i18n.locale)
+  const locale = useStore(state => state.i18n.locale)
 
   if (section !== 'language') return null
 
@@ -20,7 +18,7 @@ export default function Language({ section }: Props) {
         <select
           name="locale"
           value={locale}
-          onChange={e => dispatch(localeChanged(e.target.value))}
+          onChange={e => localeChanged(e.target.value)}
         >
           {Object.keys(LANGUAGES).map(key => (
             <option key={key} value={key}>

--- a/src/components/Main/Sidebar/Settings/Vault.tsx
+++ b/src/components/Main/Sidebar/Settings/Vault.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { cx } from '@/utils/cx'
-import { useAppSelector } from '@/store'
+import { useStore } from '@/store'
 import { syncConnect, syncDisconnect, exportVault } from '@/lib/commands'
 import { SYNC_ENABLED } from '@/config'
 import { t } from '@/i18n'
@@ -13,7 +13,7 @@ interface Props {
 
 export default function Vault({ section }: Props) {
   const [connecting, setConnecting] = useState(false)
-  const syncEnabled = useAppSelector(state => state.sync.enabled)
+  const syncEnabled = useStore(state => state.sync.enabled)
 
   useEffect(() => setConnecting(false), [syncEnabled])
 

--- a/src/components/Main/Sidebar/Switcher.tsx
+++ b/src/components/Main/Sidebar/Switcher.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@/utils/cx'
-import { useAppDispatch, useAppSelector } from '@/store'
-import { setFilterScope, type Scope } from '@/store/filtersSlice'
+import { useStore, setFilterScope } from '@/store'
+import { type Scope } from '@/store/filtersSlice'
 import { t } from '@/i18n'
 import Tooltip from '@/components/elements/Tooltip'
 import LoginIcon from '@/assets/images/login.svg?react'
@@ -8,8 +8,7 @@ import CardIcon from '@/assets/images/card.svg?react'
 import NoteIcon from '@/assets/images/note.svg?react'
 
 export default function Switcher() {
-  const dispatch = useAppDispatch()
-  const scope = useAppSelector(state => state.filters.scope)
+  const scope = useStore(state => state.filters.scope)
 
   const itemClass = (current: Scope) =>
     cx('item', { current: scope === current })
@@ -17,17 +16,17 @@ export default function Switcher() {
   return (
     <div className="switcher">
       <Tooltip content={t('Logins')}>
-        <div className={itemClass('login')} onClick={() => dispatch(setFilterScope('login'))}>
+        <div className={itemClass('login')} onClick={() => setFilterScope('login')}>
           <LoginIcon width="28" height="28" />
         </div>
       </Tooltip>
       <Tooltip content={t('Secure Notes')}>
-        <div className={itemClass('note')} onClick={() => dispatch(setFilterScope('note'))}>
+        <div className={itemClass('note')} onClick={() => setFilterScope('note')}>
           <NoteIcon width="28" height="28" />
         </div>
       </Tooltip>
       <Tooltip content={t('Credit Cards')}>
-        <div className={itemClass('card')} onClick={() => dispatch(setFilterScope('card'))}>
+        <div className={itemClass('card')} onClick={() => setFilterScope('card')}>
           <CardIcon width="28" height="28" />
         </div>
       </Tooltip>

--- a/src/components/Start/Restore/Confirm.tsx
+++ b/src/components/Start/Restore/Confirm.tsx
@@ -1,6 +1,5 @@
 import { useState, type ChangeEvent } from 'react'
-import { useAppDispatch } from '@/store'
-import { restoreBackup } from '@/store/thunks'
+import { restoreBackup } from '@/store'
 import { t } from '@/i18n'
 import Masterpass from '@/components/elements/Masterpass'
 
@@ -10,7 +9,6 @@ interface Props {
 }
 
 export default function Confirm({ display, path }: Props) {
-  const dispatch = useAppDispatch()
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
 
@@ -20,7 +18,7 @@ export default function Confirm({ display, path }: Props) {
   }
 
   const onSend = () => {
-    dispatch(restoreBackup(path, password)).catch(() =>
+    restoreBackup(path, password).catch(() =>
       setError(t('Invalid password for backup'))
     )
   }

--- a/src/components/Start/Setup/Confirm.tsx
+++ b/src/components/Start/Setup/Confirm.tsx
@@ -1,6 +1,5 @@
 import { useState, type ChangeEvent } from 'react'
-import { useAppDispatch } from '@/store'
-import { completeSetup } from '@/store/thunks'
+import { completeSetup } from '@/store'
 import { t } from '@/i18n'
 import Masterpass from '@/components/elements/Masterpass'
 
@@ -10,7 +9,6 @@ interface Props {
 }
 
 export default function Confirm({ display, password }: Props) {
-  const dispatch = useAppDispatch()
   const [confirmation, setConfirmation] = useState('')
   const [error, setError] = useState<string | null>(null)
 
@@ -20,7 +18,7 @@ export default function Confirm({ display, password }: Props) {
   }
 
   const onSend = () => {
-    if (password === confirmation) dispatch(completeSetup(password))
+    if (password === confirmation) completeSetup(password)
     else setError(t('Passwords do not match'))
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { Provider } from 'react-redux'
-import { store } from './store'
 import App from './App'
 import { applyPlatform } from './utils/platform'
 import './shortcuts'
@@ -11,8 +9,6 @@ applyPlatform()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
+    <App />
   </React.StrictMode>
 )

--- a/src/store/auditSlice.ts
+++ b/src/store/auditSlice.ts
@@ -1,15 +1,13 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
 import type { Audit } from '@/lib/commands'
+import type { StoreState } from './index'
 
-const auditSlice = createSlice({
-  name: 'audit',
-  initialState: null as Audit | null,
-  reducers: {
-    auditDone(_state, action: PayloadAction<Audit>) {
-      return action.payload
-    }
-  }
+export interface AuditSlice {
+  audit: Audit | null
+  auditDone: (audit: Audit) => void
+}
+
+export const createAuditSlice: StateCreator<StoreState, [], [], AuditSlice> = set => ({
+  audit: null,
+  auditDone: audit => set({ audit })
 })
-
-export const { auditDone } = auditSlice.actions
-export default auditSlice.reducer

--- a/src/store/entriesSlice.ts
+++ b/src/store/entriesSlice.ts
@@ -1,77 +1,35 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
 import type { Entry } from '@/lib/commands'
-import { setFilterScope } from './filtersSlice'
+import type { StoreState } from './index'
 
-interface EntriesState {
-  new: boolean
-  edit: boolean
-  current: Entry | null
-  items: Entry[]
-}
-
-const initialState: EntriesState = {
-  new: false,
-  edit: false,
-  current: null,
-  items: []
+export interface EntriesSlice {
+  entries: { new: boolean; edit: boolean; current: Entry | null; items: Entry[] }
+  newEntry: () => void
+  setNoEntry: () => void
+  editEntry: () => void
+  setEntries: (items: Entry[]) => void
+  setCurrentEntry: (id: string) => void
+  entrySaved: (id: string) => void
+  entryRemoved: (items: Entry[]) => void
 }
 
 const find = (items: Entry[], id?: string) =>
   items.find(item => item.id === id) ?? null
 
-const entriesSlice = createSlice({
-  name: 'entries',
-  initialState,
-  reducers: {
-    newEntry(state) {
-      state.new = true
-      state.edit = false
-      state.current = null
-    },
-    setNoEntry(state) {
-      state.new = false
-      state.edit = false
-      state.current = null
-    },
-    editEntry(state) {
-      state.edit = true
-      state.new = false
-    },
-    setEntries(state, action: PayloadAction<Entry[]>) {
-      state.items = action.payload
-    },
-    setCurrentEntry(state, action: PayloadAction<string>) {
-      state.current = find(state.items, action.payload)
-      state.new = false
-      state.edit = false
-    },
-    entrySaved(state, action: PayloadAction<string>) {
-      state.edit = false
-      state.new = false
-      state.current = find(state.items, action.payload)
-    },
-    entryRemoved(state, action: PayloadAction<Entry[]>) {
-      state.items = action.payload
-      state.new = false
-      state.edit = false
-      state.current = null
-    }
-  },
-  extraReducers: builder => {
-    builder.addCase(setFilterScope, state => {
-      state.new = false
-      state.current = null
-    })
-  }
+export const createEntriesSlice: StateCreator<StoreState, [], [], EntriesSlice> = (set, get) => ({
+  entries: { new: false, edit: false, current: null, items: [] },
+  newEntry: () => set(s => ({ entries: { ...s.entries, new: true, edit: false, current: null } })),
+  setNoEntry: () => set(s => ({ entries: { ...s.entries, new: false, edit: false, current: null } })),
+  editEntry: () => set(s => ({ entries: { ...s.entries, edit: true, new: false } })),
+  setEntries: items => set(s => ({ entries: { ...s.entries, items } })),
+  setCurrentEntry: id =>
+    set(s => ({
+      entries: { ...s.entries, current: find(get().entries.items, id), new: false, edit: false }
+    })),
+  entrySaved: id =>
+    set(s => ({
+      entries: { ...s.entries, edit: false, new: false, current: find(get().entries.items, id) }
+    })),
+  entryRemoved: items =>
+    set(s => ({ entries: { ...s.entries, items, new: false, edit: false, current: null } }))
 })
-
-export const {
-  newEntry,
-  setNoEntry,
-  editEntry,
-  setEntries,
-  setCurrentEntry,
-  entrySaved,
-  entryRemoved
-} = entriesSlice.actions
-export default entriesSlice.reducer

--- a/src/store/events.ts
+++ b/src/store/events.ts
@@ -1,30 +1,29 @@
 import type { UnlistenFn } from '@tauri-apps/api/event'
 import { on, EVENTS } from '@/lib/events'
-import type { AppDispatch } from './index'
-import { setEntries } from './entriesSlice'
-import { auditDone } from './auditSlice'
-import { flowAuth } from './flowSlice'
 import {
+  setEntries,
+  auditDone,
+  flowAuth,
   syncStart,
   syncStop,
   syncConnected,
   syncDisconnected
-} from './syncSlice'
+} from './index'
 
-// Wires backend events to store dispatches. Returns a cleanup function.
-export const subscribeToEvents = (dispatch: AppDispatch): (() => void) => {
+// Wires backend events to store actions. Returns a cleanup function.
+export const subscribeToEvents = (): (() => void) => {
   const pending: Promise<UnlistenFn>[] = [
-    on(EVENTS.syncStarted, () => dispatch(syncStart())),
-    on(EVENTS.syncStopped, payload => dispatch(syncStop(payload))),
-    on(EVENTS.syncConnected, () => dispatch(syncConnected())),
-    on(EVENTS.syncDisconnected, () => dispatch(syncDisconnected())),
-    on(EVENTS.pullStarted, () => dispatch(syncStart())),
+    on(EVENTS.syncStarted, () => syncStart()),
+    on(EVENTS.syncStopped, payload => syncStop(payload)),
+    on(EVENTS.syncConnected, () => syncConnected()),
+    on(EVENTS.syncDisconnected, () => syncDisconnected()),
+    on(EVENTS.pullStarted, () => syncStart()),
     on(EVENTS.pullStopped, payload => {
-      dispatch(syncStop(payload))
-      if (payload.data) dispatch(setEntries(payload.data.entries))
+      syncStop(payload)
+      if (payload.data) setEntries(payload.data.entries)
     }),
-    on(EVENTS.auditDone, payload => dispatch(auditDone(payload.data))),
-    on(EVENTS.vaultLocked, () => dispatch(flowAuth(false)))
+    on(EVENTS.auditDone, payload => auditDone(payload.data)),
+    on(EVENTS.vaultLocked, () => flowAuth(false))
   ]
 
   return () => {

--- a/src/store/filtersSlice.ts
+++ b/src/store/filtersSlice.ts
@@ -1,34 +1,25 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
+import type { StoreState } from './index'
 
 export type Scope = 'login' | 'note' | 'card' | 'audit'
 
-interface FiltersState {
-  scope: Scope
-  query: string
-  tags: string[]
+export interface FiltersSlice {
+  filters: { scope: Scope; query: string; tags: string[] }
+  setFilterQuery: (query: string) => void
+  setFilterScope: (scope: Scope) => void
+  setFilterTag: (tag: string) => void
+  unsetFilterTag: () => void
 }
 
-const initialState: FiltersState = { scope: 'login', query: '', tags: [] }
-
-const filtersSlice = createSlice({
-  name: 'filters',
-  initialState,
-  reducers: {
-    setFilterQuery(state, action: PayloadAction<string>) {
-      state.query = action.payload
-    },
-    setFilterScope(state, action: PayloadAction<Scope>) {
-      state.scope = action.payload
-    },
-    setFilterTag(state, action: PayloadAction<string>) {
-      state.tags = [action.payload]
-    },
-    unsetFilterTag(state) {
-      state.tags = []
-    }
-  }
+export const createFiltersSlice: StateCreator<StoreState, [], [], FiltersSlice> = set => ({
+  filters: { scope: 'login', query: '', tags: [] },
+  setFilterQuery: query => set(s => ({ filters: { ...s.filters, query } })),
+  // Switching scope also drops any in-progress new entry and selection.
+  setFilterScope: scope =>
+    set(s => ({
+      filters: { ...s.filters, scope },
+      entries: { ...s.entries, new: false, current: null }
+    })),
+  setFilterTag: tag => set(s => ({ filters: { ...s.filters, tags: [tag] } })),
+  unsetFilterTag: () => set(s => ({ filters: { ...s.filters, tags: [] } }))
 })
-
-export const { setFilterQuery, setFilterScope, setFilterTag, unsetFilterTag } =
-  filtersSlice.actions
-export default filtersSlice.reducer

--- a/src/store/flowSlice.ts
+++ b/src/store/flowSlice.ts
@@ -1,32 +1,20 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
+import type { StoreState } from './index'
 
 export type FlowName = 'setup' | 'auth' | 'main'
 
-interface FlowState {
-  name: FlowName
-  touchID: boolean
+export interface FlowSlice {
+  flow: { name: FlowName; touchID: boolean }
+  flowSetup: () => void
+  flowAuth: (touchID: boolean) => void
+  flowMain: () => void
 }
 
-// No backend command exists to detect a pristine vault, so we default to the
-// auth screen (see PR report). Setup is reached explicitly via `flowSetup`.
-const initialState: FlowState = { name: 'auth', touchID: false }
-
-const flowSlice = createSlice({
-  name: 'flow',
-  initialState,
-  reducers: {
-    flowSetup(state) {
-      state.name = 'setup'
-    },
-    flowAuth(state, action: PayloadAction<boolean>) {
-      state.name = 'auth'
-      state.touchID = action.payload
-    },
-    flowMain(state) {
-      state.name = 'main'
-    }
-  }
+export const createFlowSlice: StateCreator<StoreState, [], [], FlowSlice> = set => ({
+  // No backend command exists to detect a pristine vault, so we default to the
+  // auth screen (see PR report). Setup is reached explicitly via `flowSetup`.
+  flow: { name: 'auth', touchID: false },
+  flowSetup: () => set(s => ({ flow: { ...s.flow, name: 'setup' } })),
+  flowAuth: touchID => set(() => ({ flow: { name: 'auth', touchID } })),
+  flowMain: () => set(s => ({ flow: { ...s.flow, name: 'main' } }))
 })
-
-export const { flowSetup, flowAuth, flowMain } = flowSlice.actions
-export default flowSlice.reducer

--- a/src/store/i18nSlice.ts
+++ b/src/store/i18nSlice.ts
@@ -1,16 +1,16 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
 import { getLocale, setLocale } from '@/i18n'
+import type { StoreState } from './index'
 
-const i18nSlice = createSlice({
-  name: 'i18n',
-  initialState: { locale: getLocale() },
-  reducers: {
-    localeChanged(state, action: PayloadAction<string>) {
-      setLocale(action.payload)
-      state.locale = action.payload
-    }
+export interface I18nSlice {
+  i18n: { locale: string }
+  localeChanged: (locale: string) => void
+}
+
+export const createI18nSlice: StateCreator<StoreState, [], [], I18nSlice> = set => ({
+  i18n: { locale: getLocale() },
+  localeChanged: locale => {
+    setLocale(locale)
+    set({ i18n: { locale } })
   }
 })
-
-export const { localeChanged } = i18nSlice.actions
-export default i18nSlice.reducer

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,21 +1,75 @@
-import { configureStore } from '@reduxjs/toolkit'
-import { useDispatch, useSelector } from 'react-redux'
-import type { TypedUseSelectorHook } from 'react-redux'
-import flow from './flowSlice'
-import filters from './filtersSlice'
-import entries from './entriesSlice'
-import audit from './auditSlice'
-import sync from './syncSlice'
-import i18n from './i18nSlice'
+import { create } from 'zustand'
+import { getLocale } from '@/i18n'
+import { createFlowSlice, type FlowSlice } from './flowSlice'
+import { createFiltersSlice, type FiltersSlice } from './filtersSlice'
+import { createEntriesSlice, type EntriesSlice } from './entriesSlice'
+import { createAuditSlice, type AuditSlice } from './auditSlice'
+import { createSyncSlice, type SyncSlice } from './syncSlice'
+import { createI18nSlice, type I18nSlice } from './i18nSlice'
+import { createAsyncSlice, type AsyncSlice } from './thunks'
 
-export const makeStore = () =>
-  configureStore({ reducer: { flow, filters, entries, audit, sync, i18n } })
+export type StoreState = FlowSlice &
+  FiltersSlice &
+  EntriesSlice &
+  AuditSlice &
+  SyncSlice &
+  I18nSlice &
+  AsyncSlice
 
-export const store = makeStore()
+export const useStore = create<StoreState>()((...a) => ({
+  ...createFlowSlice(...a),
+  ...createFiltersSlice(...a),
+  ...createEntriesSlice(...a),
+  ...createAuditSlice(...a),
+  ...createSyncSlice(...a),
+  ...createI18nSlice(...a),
+  ...createAsyncSlice(...a)
+}))
 
-export type AppStore = ReturnType<typeof makeStore>
-export type RootState = ReturnType<typeof store.getState>
-export type AppDispatch = typeof store.dispatch
+const pickData = (s: StoreState) => ({
+  flow: s.flow,
+  filters: s.filters,
+  entries: s.entries,
+  audit: s.audit,
+  sync: s.sync,
+  i18n: s.i18n
+})
 
-export const useAppDispatch: () => AppDispatch = useDispatch
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+const initialData = pickData(useStore.getState())
+
+// Resets the (singleton) store to its initial state. Tests call this to isolate
+// state between runs; `false` merges so the action functions are preserved.
+export const makeStore = () => {
+  useStore.setState({ ...structuredClone(initialData), i18n: { locale: getLocale() } }, false)
+  return useStore
+}
+
+// Actions never change reference, so we expose them bound for non-reactive use.
+export const {
+  flowSetup,
+  flowAuth,
+  flowMain,
+  setFilterQuery,
+  setFilterScope,
+  setFilterTag,
+  unsetFilterTag,
+  newEntry,
+  setNoEntry,
+  editEntry,
+  setEntries,
+  setCurrentEntry,
+  entrySaved,
+  entryRemoved,
+  auditDone,
+  syncInit,
+  syncConnected,
+  syncDisconnected,
+  syncStart,
+  syncStop,
+  localeChanged,
+  saveEntry,
+  deleteEntry,
+  enterMain,
+  completeSetup,
+  restoreBackup
+} = useStore.getState()

--- a/src/store/syncSlice.ts
+++ b/src/store/syncSlice.ts
@@ -1,55 +1,23 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { StateCreator } from 'zustand'
+import type { StoreState } from './index'
 
-interface SyncState {
-  enabled: boolean
-  inProgress: boolean
-  success: boolean
-  error: string | null
+export interface SyncSlice {
+  sync: { enabled: boolean; inProgress: boolean; success: boolean; error: string | null }
+  syncInit: (enabled: boolean) => void
+  syncConnected: () => void
+  syncDisconnected: () => void
+  syncStart: () => void
+  syncStop: (payload: { success: boolean; error?: string }) => void
 }
 
-const initialState: SyncState = {
-  enabled: false,
-  inProgress: false,
-  success: true,
-  error: null
-}
-
-const syncSlice = createSlice({
-  name: 'sync',
-  initialState,
-  reducers: {
-    syncInit(state, action: PayloadAction<boolean>) {
-      state.enabled = action.payload
-    },
-    syncConnected(state) {
-      state.enabled = true
-      state.success = true
-      state.error = null
-    },
-    syncDisconnected(state) {
-      state.enabled = false
-    },
-    syncStart(state) {
-      state.inProgress = true
-      state.success = true
-      state.error = null
-    },
-    syncStop(
-      state,
-      action: PayloadAction<{ success: boolean; error?: string }>
-    ) {
-      state.inProgress = false
-      state.success = action.payload.success
-      state.error = action.payload.error ?? null
-    }
-  }
+export const createSyncSlice: StateCreator<StoreState, [], [], SyncSlice> = set => ({
+  sync: { enabled: false, inProgress: false, success: true, error: null },
+  syncInit: enabled => set(s => ({ sync: { ...s.sync, enabled } })),
+  syncConnected: () => set(s => ({ sync: { ...s.sync, enabled: true, success: true, error: null } })),
+  syncDisconnected: () => set(s => ({ sync: { ...s.sync, enabled: false } })),
+  syncStart: () => set(s => ({ sync: { ...s.sync, inProgress: true, success: true, error: null } })),
+  syncStop: payload =>
+    set(s => ({
+      sync: { ...s.sync, inProgress: false, success: payload.success, error: payload.error ?? null }
+    }))
 })
-
-export const {
-  syncInit,
-  syncConnected,
-  syncDisconnected,
-  syncStart,
-  syncStop
-} = syncSlice.actions
-export default syncSlice.reducer

--- a/src/store/thunks.test.ts
+++ b/src/store/thunks.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { makeStore } from './index'
-import { setEntries } from './entriesSlice'
-import { saveEntry, deleteEntry, enterMain } from './thunks'
+import { makeStore, setEntries, saveEntry, deleteEntry, enterMain } from './index'
 import { saveVault, syncNow } from '@/lib/commands'
 import type { Entry } from '@/lib/commands'
 
@@ -10,6 +8,7 @@ const entry = (id: string, title = id): Entry =>
 
 beforeEach(() => {
   vi.clearAllMocks()
+  makeStore()
   // Echo the plaintext entries back, as the real backend does after encrypting.
   vi.mocked(saveVault).mockImplementation(entries => Promise.resolve({ entries }))
 })
@@ -17,7 +16,7 @@ beforeEach(() => {
 describe('saveEntry', () => {
   it('creates a new entry and selects it', async () => {
     const store = makeStore()
-    await store.dispatch(saveEntry({ type: 'login', title: 'New', username: 'u', password: 'p' }))
+    await saveEntry({ type: 'login', title: 'New', username: 'u', password: 'p' })
 
     const { items, current } = store.getState().entries
     expect(items).toHaveLength(1)
@@ -30,8 +29,8 @@ describe('saveEntry', () => {
 
   it('updates an existing entry', async () => {
     const store = makeStore()
-    store.dispatch(setEntries([entry('a', 'Old')]))
-    await store.dispatch(saveEntry({ id: 'a', type: 'login', title: 'Updated', username: 'u', password: 'p' }))
+    setEntries([entry('a', 'Old')])
+    await saveEntry({ id: 'a', type: 'login', title: 'Updated', username: 'u', password: 'p' })
 
     const { items } = store.getState().entries
     expect(items).toHaveLength(1)
@@ -42,8 +41,8 @@ describe('saveEntry', () => {
 describe('deleteEntry', () => {
   it('removes the entry and clears the selection', async () => {
     const store = makeStore()
-    store.dispatch(setEntries([entry('a'), entry('b')]))
-    await store.dispatch(deleteEntry('a'))
+    setEntries([entry('a'), entry('b')])
+    await deleteEntry('a')
 
     const { items, current } = store.getState().entries
     expect(items.map(e => e.id)).toEqual(['b'])
@@ -54,7 +53,7 @@ describe('deleteEntry', () => {
 describe('enterMain', () => {
   it('loads the vault and switches to the main flow', async () => {
     const store = makeStore()
-    await store.dispatch(enterMain({ vault: { entries: [entry('a')] }, syncConfigured: true }))
+    await enterMain({ vault: { entries: [entry('a')] }, syncConfigured: true })
 
     const state = store.getState()
     expect(state.flow.name).toBe('main')

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -1,4 +1,4 @@
-import type { AppDispatch, RootState } from './index'
+import type { StateCreator } from 'zustand'
 import type { Entry, UnlockResult } from '@/lib/commands'
 import {
   saveVault,
@@ -10,24 +10,24 @@ import {
 } from '@/lib/commands'
 import type { EntryDraft } from '@/defaults/entries'
 import { enlarge } from '@/services/window'
-import { setEntries, entrySaved, entryRemoved } from './entriesSlice'
-import { auditDone } from './auditSlice'
-import { flowMain } from './flowSlice'
-import { syncInit } from './syncSlice'
 import { SYNC_ENABLED } from '@/config'
+import type { StoreState } from './index'
+
+export interface AsyncSlice {
+  saveEntry: (draft: EntryDraft) => Promise<void>
+  deleteEntry: (id: string) => Promise<void>
+  enterMain: (result: UnlockResult) => Promise<void>
+  completeSetup: (password: string) => Promise<void>
+  restoreBackup: (path: string, password: string) => Promise<void>
+}
 
 const trySync = () => {
   if (SYNC_ENABLED) syncNow().catch(() => {})
 }
 
-type Thunk = (dispatch: AppDispatch, getState: () => RootState) => Promise<void>
-
 const now = () => new Date().toISOString()
 
-const buildEntries = (
-  draft: EntryDraft,
-  items: Entry[]
-): [Entry[], Entry] => {
+const buildEntries = (draft: EntryDraft, items: Entry[]): [Entry[], Entry] => {
   const entries = items.slice()
   const index = entries.findIndex(e => e.id === draft.id)
   if (draft.id && index !== -1) {
@@ -45,53 +45,43 @@ const buildEntries = (
   return [entries, created]
 }
 
-const refreshAudit = (dispatch: AppDispatch) =>
-  getAudit()
-    .then(data => dispatch(auditDone(data)))
-    .catch(() => {})
+export const createAsyncSlice: StateCreator<StoreState, [], [], AsyncSlice> = (_set, get) => {
+  const refreshAudit = () =>
+    getAudit()
+      .then(data => get().auditDone(data))
+      .catch(() => {})
 
-export const saveEntry =
-  (draft: EntryDraft): Thunk =>
-  async (dispatch, getState) => {
-    const [entries, item] = buildEntries(draft, getState().entries.items)
-    const vault = await saveVault(entries)
-    dispatch(setEntries(vault.entries))
-    dispatch(entrySaved(item.id))
-    trySync()
-    refreshAudit(dispatch)
+  return {
+    saveEntry: async draft => {
+      const [entries, item] = buildEntries(draft, get().entries.items)
+      const vault = await saveVault(entries)
+      get().setEntries(vault.entries)
+      get().entrySaved(item.id)
+      trySync()
+      refreshAudit()
+    },
+    deleteEntry: async id => {
+      const remaining = get().entries.items.filter(e => e.id !== id)
+      const vault = await saveVault(remaining)
+      get().entryRemoved(vault.entries)
+      trySync()
+      refreshAudit()
+    },
+    enterMain: async result => {
+      await enlarge().catch(() => {})
+      get().setEntries(result.vault.entries)
+      get().flowMain()
+      get().syncInit(SYNC_ENABLED && result.syncConfigured)
+      if (SYNC_ENABLED && result.syncConfigured) syncNow().catch(() => {})
+    },
+    completeSetup: async password => {
+      await setup(password)
+      const vault = await readVault()
+      await get().enterMain({ vault, syncConfigured: false })
+    },
+    restoreBackup: async (path, password) => {
+      const result = await importBackup(path, password)
+      await get().enterMain(result)
+    }
   }
-
-export const deleteEntry =
-  (id: string): Thunk =>
-  async (dispatch, getState) => {
-    const remaining = getState().entries.items.filter(e => e.id !== id)
-    const vault = await saveVault(remaining)
-    dispatch(entryRemoved(vault.entries))
-    trySync()
-    refreshAudit(dispatch)
-  }
-
-export const enterMain =
-  (result: UnlockResult): Thunk =>
-  async dispatch => {
-    await enlarge().catch(() => {})
-    dispatch(setEntries(result.vault.entries))
-    dispatch(flowMain())
-    dispatch(syncInit(SYNC_ENABLED && result.syncConfigured))
-    if (SYNC_ENABLED && result.syncConfigured) syncNow().catch(() => {})
-  }
-
-export const completeSetup =
-  (password: string): Thunk =>
-  async dispatch => {
-    await setup(password)
-    const vault = await readVault()
-    await dispatch(enterMain({ vault, syncConfigured: false }))
-  }
-
-export const restoreBackup =
-  (path: string, password: string): Thunk =>
-  async dispatch => {
-    const result = await importBackup(path, password)
-    await dispatch(enterMain(result))
-  }
+}

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,29 +1,25 @@
 import type { ReactElement } from 'react'
 import { render } from '@testing-library/react'
-import { Provider } from 'react-redux'
-import { makeStore, type AppStore, type RootState } from '@/store'
-import { setEntries } from '@/store/entriesSlice'
-import { flowMain } from '@/store/flowSlice'
-import { auditDone } from '@/store/auditSlice'
+import { makeStore, setEntries, flowMain, auditDone } from '@/store'
 import type { Entry, Audit } from '@/lib/commands'
 
+type Store = ReturnType<typeof makeStore>
+
 interface Options {
-  store?: AppStore
+  store?: Store
 }
 
-// Renders a component inside a fresh store so tests never share state.
+// Renders a component against a freshly reset store so tests never share state.
 export const renderWithStore = (ui: ReactElement, { store = makeStore() }: Options = {}) => ({
   store,
-  ...render(<Provider store={store}>{ui}</Provider>)
+  ...render(ui)
 })
 
-export const state = (store: AppStore): RootState => store.getState()
-
 // Puts the store into the unlocked "main" flow with the given entries.
-export const withEntries = (store: AppStore, entries: Entry[], audit?: Audit) => {
-  store.dispatch(setEntries(entries))
-  store.dispatch(flowMain())
-  if (audit) store.dispatch(auditDone(audit))
+export const withEntries = (_store: Store, entries: Entry[], audit?: Audit) => {
+  setEntries(entries)
+  flowMain()
+  if (audit) auditDone(audit)
 }
 
 export const loginEntry = (overrides: Partial<Entry> = {}): Entry => ({


### PR DESCRIPTION
## Summary
Replaces **Redux Toolkit + react-redux** with **Zustand** while preserving behavior exactly.

- Single zustand store composed of six slice creators mirroring the previous slices — `flow`, `filters`, `entries`, `audit`, `sync`, `i18n` — plus an async slice holding the former thunks (`saveEntry`, `deleteEntry`, `enterMain`, `completeSetup`, `restoreBackup`).
- **State keeps the same nested shape** (`state.filters.scope`, `state.entries.items`, etc.) so selectors and tests read identically.
- Actions are exposed as bound module-level functions, so call sites drop the `dispatch(...)` wrapper (`setFilterScope('login')` instead of `dispatch(setFilterScope('login'))`). Reactive reads use `useStore(selector)`.
- Cross-slice effect preserved: `setFilterScope` still clears the in-progress new entry / selection (the old `extraReducers` behavior).
- `main.tsx` no longer needs the react-redux `<Provider>`.
- `makeStore()` now resets the singleton store; `test/utils` seeding helpers and `thunks.test.ts` were ported to the zustand store (component-level assertions unchanged).
- Object-returning selectors were split into atomic selectors; the one derived-array selector (Tags `Dropdown`) uses `useShallow` to avoid v5 re-render loops.
- Dependencies: removed `@reduxjs/toolkit` and `react-redux`, added `zustand@^5`.

**Call sites changed:** 22 consumers + `App.tsx` + `main.tsx` + `test/utils` + `thunks.test.ts`.

## Confirmation — gates pass
- `bun run typecheck` — clean
- `bun run lint` — clean, zero warnings
- `bun run test` — 39/39 specs green
- `grep` confirms no `@reduxjs/toolkit` / `react-redux` / `useAppSelector` / `useAppDispatch` remain in `src/`.

## Notes
- Targets `v1-0-0`. Stays strictly in the state-management lane (no React/Vite/ESLint bumps, no package-manager change).
- May need a rebase after PR-1 lands React 19.