### PR TITLE
CI: migrate workflow from npm to bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run build
-      - run: npm test
+          bun-version: 1.3.3
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run build
+      - run: bun run test
 
   rust:
     name: Rust (${{ matrix.os }})
@@ -44,14 +43,13 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
+          bun-version: 1.3.3
 
       # generate_context! needs the built frontend (../dist) to exist.
-      - run: npm ci
-      - run: npm run build
+      - run: bun install --frozen-lockfile
+      - run: bun run build
 
       - name: Format check
         working-directory: src-tauri
@@ -82,14 +80,13 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
+          bun-version: 1.3.3
 
       # generate_context! needs the built frontend (../dist) to exist.
-      - run: npm ci
-      - run: npm run build
+      - run: bun install --frozen-lockfile
+      - run: bun run build
 
       # Rust decrypts the Node-generated golden fixtures and asserts plaintext.
       - name: Fixture + round-trip tests
@@ -98,4 +95,4 @@ jobs:
 
       # Rust encrypts -> Node decrypts, and vice versa.
       - name: Cross-implementation round-trip
-        run: node scripts/crypto-crosscheck.mjs
+        run: bun scripts/crypto-crosscheck.mjs


### PR DESCRIPTION
## Problem
PR #234 modernized the toolchain to **bun** (removed `package-lock.json`, added `bun.lock`) but did not update `.github/workflows/ci.yml`, which still runs `cache: npm` + `npm ci` in all three jobs. Result: **every CI job on `v1-0-0` and every PR fails immediately** at `setup-node` with `Dependencies lock file is not found ... package-lock.json`. (Confirmed on PR #234's own run and reproduced from git objects.)

## Fix
Migrate all jobs to bun:
- `actions/setup-node@v4` (+ `cache: npm`) → `oven-sh/setup-bun@v2` pinned to `1.3.3`
- `npm ci` → `bun install --frozen-lockfile`
- `npm run lint/build`, `npm test` → `bun run lint/build`, **`bun run test`** (keeps vitest; not `bun test`)
- `node scripts/crypto-crosscheck.mjs` → `bun scripts/...` (verified locally: drives the Rust build, 13/13 cross-impl round-trips pass)

Unblocks CI for #235 (zustand) and all future PRs.