### PR TITLE
Storage engine: SQLite + SQLCipher module (T-STORE-1/2/3)

### DIFF
--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -76,7 +76,7 @@ entries(
 )
 ```
 
-### T-STORE-1 · Introduce the SQLite storage engine  ❌ 🔴 (D1, S7, T4, T7)
+### T-STORE-1 · Introduce the SQLite storage engine  module ✅ (implemented in PR `feat/storage-engine`) — app integration pending 🔴 (D1, S7, T4, T7)
 **Evidence:** `storage.rs:46-52` plain `fs::write` (non-atomic, no fsync/`.bak`, 0644); the whole `VaultData` is re-serialized and rewritten on every save (`commands/vault.rs:42-43`).
 **Steps:**
 1. Add `rusqlite` (`bundled-sqlcipher`). Open the DB in WAL mode, keyed via `PRAGMA key` from the derived vault key.
@@ -85,7 +85,7 @@ entries(
 4. File mode `0600`, dir `0700` at create.
 **Acceptance:** CRUD works per-row; a process kill mid-write leaves the DB intact (ACID/WAL); the DB file is `0600`; opening without the key fails; inspecting the raw DB shows no plaintext secret field.
 
-### T-STORE-2 · Migrate existing JSON vaults on first unlock  ❌ 🔴
+### T-STORE-2 · Migrate existing JSON vaults on first unlock  module ✅ (adapter + round-trip test in PR `feat/storage-engine`) — app integration pending 🔴
 **Evidence:** real users hold a `vault.swftx` JSON blob. The byte-compat golden harness (`crypto/tests.rs` + `crypto/fixtures.json`) tests the **crypto primitive, not the container**, so switching containers is safe as long as legacy decrypt keeps working.
 **Steps:**
 1. On unlock, if only a JSON vault exists, decrypt it with the current cryptor, write every entry into a fresh DB, and keep the JSON as `vault.swftx.bak` (never deleted until the DB round-trips).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -44,6 +44,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1162,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1714,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1702,6 +1735,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2326,6 +2368,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +2851,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3391,6 +3467,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4010,6 +4100,7 @@ dependencies = [
  "rand",
  "reqwest",
  "ring",
+ "rusqlite",
  "rustls",
  "serde",
  "serde_json",
@@ -5091,6 +5182,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
 aes-gcm = "0.10"
 ring = "0.17"
 sha2 = "0.10"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }
+rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl", "backup"] }
 aes-gcm = "0.10"
 ring = "0.17"
 sha2 = "0.10"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod error;
 mod models;
 mod state;
 mod storage;
+pub mod store;
 mod sync;
 mod tray;
 #[cfg(desktop)]

--- a/src-tauri/src/store/migrate.rs
+++ b/src-tauri/src/store/migrate.rs
@@ -1,0 +1,73 @@
+//! Boundary adapter: legacy JSON `vault.swftx` → the new store. This is the one
+//! file in the module that references the app's crypto/models — it is glue, not
+//! part of the pure trait, and stays thin. The store itself never sees this.
+
+use std::fs;
+use std::path::Path;
+
+use super::{Record, VaultStore};
+use crate::crypto::Cryptor;
+use crate::error::{Error, Result};
+use crate::models::{Entry, VaultData};
+
+/// Read the encrypted legacy vault at `path`, decrypt it with `cryptor`, write
+/// every entry into `store` as a `Record` (payload = the app-encrypted blob),
+/// and retain the JSON alongside as `<path>.bak`. Returns the entry count.
+pub fn migrate_from_json(path: &Path, cryptor: &Cryptor, store: &impl VaultStore) -> Result<usize> {
+    let blob = fs::read_to_string(path)?;
+    let vault: VaultData = cryptor.decrypt_data(&blob)?;
+
+    let records: Vec<Record> = vault
+        .entries
+        .iter()
+        .map(|e| to_record(e, cryptor))
+        .collect::<Result<_>>()?;
+
+    store
+        .import(&records)
+        .map_err(|e| Error::Other(e.to_string()))?;
+
+    backup(path)?;
+    Ok(records.len())
+}
+
+// One legacy entry → one Record. Metadata goes to columns; the whole entry is
+// re-sealed by the app cryptor into the opaque payload (lossless round-trip).
+fn to_record(entry: &Entry, cryptor: &Cryptor) -> Result<Record> {
+    let payload = cryptor.encrypt_data(entry)?.into_bytes();
+    Ok(Record {
+        id: entry.id.clone(),
+        kind: entry.kind.clone(),
+        title: entry.title.clone(),
+        tags: serde_json::to_string(&entry.tags.clone().unwrap_or_default())?,
+        url_host: host_of(entry.website.as_deref().unwrap_or_default()),
+        created_at: to_ms(&entry.created_at),
+        updated_at: to_ms(&entry.updated_at),
+        deleted_at: None,
+        payload,
+    })
+}
+
+// Copy the JSON vault to `<path>.bak`, never removing the original.
+fn backup(path: &Path) -> Result<()> {
+    let mut bak = path.as_os_str().to_owned();
+    bak.push(".bak");
+    fs::copy(path, bak)?;
+    Ok(())
+}
+
+fn host_of(website: &str) -> String {
+    let s = website.trim();
+    let s = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))
+        .unwrap_or(s);
+    s.split('/').next().unwrap_or("").to_string()
+}
+
+fn to_ms(iso: &Option<String>) -> i64 {
+    iso.as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.timestamp_millis())
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
+}

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -1,0 +1,91 @@
+//! Self-contained vault storage engine. Depends only on `std`, `rusqlite`,
+//! `serde`, and its own error type — never on the app's commands/state/models
+//! or Tauri — so the whole layer can be swapped behind [`VaultStore`].
+//!
+//! The store persists an **opaque** `payload: Vec<u8>`: it never inspects or
+//! encrypts it (the caller applies its own AEAD). The only crypto here is
+//! SQLCipher at-rest, keyed by a byte key injected at [`SqliteStore::open`].
+
+mod sqlite;
+
+// Migration glue lives in-module but deliberately references the app's crypto —
+// it is the boundary adapter, not part of the pure trait.
+pub mod migrate;
+
+#[cfg(test)]
+mod tests;
+
+pub use sqlite::SqliteStore;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Storage error. Small and self-owned so the module stays decoupled; the app
+/// boundary maps it into the application error type.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, StoreError>;
+
+/// A full stored row: queryable metadata plus the opaque encrypted payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub tags: String,
+    pub url_host: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub deleted_at: Option<i64>,
+    pub payload: Vec<u8>,
+}
+
+/// A row's metadata without its payload (what listings need).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryMeta {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub tags: String,
+    pub url_host: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub deleted_at: Option<i64>,
+}
+
+/// The swappable storage contract. Any backend behind this interface is a drop-in.
+pub trait VaultStore: Send {
+    /// Read a `meta` value (schema_version, kdf, salt, …). Values are caller-owned.
+    fn meta_get(&self, key: &str) -> Result<Option<String>>;
+    /// Write a `meta` value.
+    fn meta_set(&self, key: &str, value: &str) -> Result<()>;
+    /// List live entries' metadata (excludes tombstones).
+    fn list(&self) -> Result<Vec<EntryMeta>>;
+    /// Fetch one live record with its payload (`None` if missing or tombstoned).
+    fn get(&self, id: &str) -> Result<Option<Record>>;
+    /// Insert or update a record, stamping `updated_at` to now.
+    fn upsert(&self, rec: &Record) -> Result<()>;
+    /// Tombstone a record (`deleted_at = now`); the row is kept for sync.
+    fn delete(&self, id: &str) -> Result<()>;
+    /// Every record including tombstones, with timestamps intact (for sync).
+    fn export_for_sync(&self) -> Result<Vec<Record>>;
+    /// Bulk-write records in one transaction, preserving their timestamps (sync in).
+    fn import(&self, recs: &[Record]) -> Result<()>;
+}
+
+/// Milliseconds since the Unix epoch.
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -47,9 +47,20 @@ impl SqliteStore {
         }
 
         let conn = Connection::open(path)?;
-        // Raw-key pragma: the hex bytes are the key, not a passphrase.
+        // Raw-key pragma: the hex bytes are the key, not a passphrase. Must run
+        // before any other pragma that touches the (encrypted) file.
         conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex(key)))?;
-        conn.execute_batch("PRAGMA journal_mode = WAL;")?;
+        // Connection hygiene: WAL for crash-safe per-row writes; NORMAL is the
+        // durable/fast pairing for WAL; temp_store=MEMORY keeps sort/temp data
+        // (plaintext metadata) off disk; busy_timeout absorbs the brief lock a
+        // second connection (e.g. a snapshot) can hold. No foreign_keys pragma:
+        // the schema has no relations. SQLCipher has no such default pragmas.
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA temp_store = MEMORY;
+             PRAGMA busy_timeout = 5000;",
+        )?;
 
         // Force key verification on an existing DB (a wrong key errors only on read).
         if existed {
@@ -73,6 +84,24 @@ impl SqliteStore {
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Write a consistent, still-encrypted snapshot of the live DB to `dest`
+    /// using SQLite's online-backup API. Unlike `fs::copy` of a WAL-mode file,
+    /// this reads *through* the connection, so it always captures committed WAL
+    /// frames a plain copy could miss (or tear). `dest` is keyed with the same
+    /// `key`, so the snapshot is as encrypted as the source — never a plaintext
+    /// leak — and reopens as a normal store.
+    pub fn snapshot_to(&self, dest: &Path, key: &[u8]) -> Result<()> {
+        let mut dst = Connection::open(dest)?;
+        dst.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex(key)))?;
+        let src = self.lock();
+        let backup = rusqlite::backup::Backup::new(&src, &mut dst)?;
+        backup.run_to_completion(100, std::time::Duration::from_millis(50), None)?;
+        drop(backup);
+        drop(dst);
+        set_mode(dest, 0o600);
+        Ok(())
     }
 }
 

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -1,0 +1,232 @@
+//! SQLite + SQLCipher backend for [`VaultStore`]. A single `Mutex<Connection>`
+//! guards a WAL-mode, whole-file-encrypted database. No pool, no async, no ORM.
+
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection, OptionalExtension, Row};
+
+use super::{now_ms, EntryMeta, Record, Result, StoreError, VaultStore};
+
+const SCHEMA_VERSION: &str = "1";
+
+const SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT
+);
+CREATE TABLE IF NOT EXISTS entries (
+  id         TEXT PRIMARY KEY,
+  kind       TEXT,
+  title      TEXT,
+  tags       TEXT,
+  url_host   TEXT,
+  created_at INTEGER,
+  updated_at INTEGER,
+  deleted_at INTEGER,
+  payload    BLOB
+);";
+
+const COLS: &str = "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, payload";
+const META_COLS: &str = "id, kind, title, tags, url_host, created_at, updated_at, deleted_at";
+
+pub struct SqliteStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteStore {
+    /// Open (creating if absent) an encrypted DB at `path`, keyed by the raw
+    /// `key` bytes. The key is used directly (no passphrase KDF); the caller
+    /// derives it. Opening an existing DB with the wrong key fails here.
+    pub fn open(path: &Path, key: &[u8]) -> Result<Self> {
+        let existed = path.metadata().map(|m| m.len() > 0).unwrap_or(false);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+            set_mode(parent, 0o700);
+        }
+
+        let conn = Connection::open(path)?;
+        // Raw-key pragma: the hex bytes are the key, not a passphrase.
+        conn.execute_batch(&format!("PRAGMA key = \"x'{}'\";", hex(key)))?;
+        conn.execute_batch("PRAGMA journal_mode = WAL;")?;
+
+        // Force key verification on an existing DB (a wrong key errors only on read).
+        if existed {
+            conn.query_row("SELECT count(*) FROM sqlite_master", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .map_err(|_| StoreError::Other("cannot open database (wrong key?)".into()))?;
+        }
+
+        conn.execute_batch(SCHEMA)?;
+        conn.execute(
+            "INSERT OR IGNORE INTO meta (key, value) VALUES ('schema_version', ?1)",
+            params![SCHEMA_VERSION],
+        )?;
+
+        set_mode(path, 0o600);
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.conn.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl VaultStore for SqliteStore {
+    fn meta_get(&self, key: &str) -> Result<Option<String>> {
+        Ok(self
+            .lock()
+            .query_row("SELECT value FROM meta WHERE key = ?1", params![key], |r| {
+                r.get(0)
+            })
+            .optional()?)
+    }
+
+    fn meta_set(&self, key: &str, value: &str) -> Result<()> {
+        self.lock().execute(
+            "INSERT INTO meta (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )?;
+        Ok(())
+    }
+
+    fn list(&self) -> Result<Vec<EntryMeta>> {
+        let conn = self.lock();
+        let sql = format!("SELECT {META_COLS} FROM entries WHERE deleted_at IS NULL ORDER BY id");
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], row_to_meta)?;
+        Ok(rows.collect::<rusqlite::Result<_>>()?)
+    }
+
+    fn get(&self, id: &str) -> Result<Option<Record>> {
+        let conn = self.lock();
+        let sql = format!("SELECT {COLS} FROM entries WHERE id = ?1 AND deleted_at IS NULL");
+        Ok(conn
+            .query_row(&sql, params![id], row_to_record)
+            .optional()?)
+    }
+
+    fn upsert(&self, rec: &Record) -> Result<()> {
+        let now = now_ms();
+        // created_at is set only on insert; updated_at is always stamped to now.
+        self.lock().execute(
+            &format!(
+                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+                 ON CONFLICT(id) DO UPDATE SET
+                   kind=excluded.kind, title=excluded.title, tags=excluded.tags,
+                   url_host=excluded.url_host, updated_at=excluded.updated_at,
+                   deleted_at=excluded.deleted_at, payload=excluded.payload"
+            ),
+            params![
+                rec.id,
+                rec.kind,
+                rec.title,
+                rec.tags,
+                rec.url_host,
+                if rec.created_at == 0 {
+                    now
+                } else {
+                    rec.created_at
+                },
+                now,
+                rec.deleted_at,
+                rec.payload,
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn delete(&self, id: &str) -> Result<()> {
+        let now = now_ms();
+        self.lock().execute(
+            "UPDATE entries SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        Ok(())
+    }
+
+    fn export_for_sync(&self) -> Result<Vec<Record>> {
+        let conn = self.lock();
+        let sql = format!("SELECT {COLS} FROM entries ORDER BY id");
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], row_to_record)?;
+        Ok(rows.collect::<rusqlite::Result<_>>()?)
+    }
+
+    fn import(&self, recs: &[Record]) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        {
+            // Bulk sync-in: timestamps are preserved verbatim (no stamping).
+            let mut stmt = tx.prepare(&format!(
+                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+                 ON CONFLICT(id) DO UPDATE SET
+                   kind=excluded.kind, title=excluded.title, tags=excluded.tags,
+                   url_host=excluded.url_host, created_at=excluded.created_at,
+                   updated_at=excluded.updated_at, deleted_at=excluded.deleted_at,
+                   payload=excluded.payload"
+            ))?;
+            for r in recs {
+                stmt.execute(params![
+                    r.id,
+                    r.kind,
+                    r.title,
+                    r.tags,
+                    r.url_host,
+                    r.created_at,
+                    r.updated_at,
+                    r.deleted_at,
+                    r.payload,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+fn row_to_record(row: &Row) -> rusqlite::Result<Record> {
+    Ok(Record {
+        id: row.get(0)?,
+        kind: row.get(1)?,
+        title: row.get(2)?,
+        tags: row.get(3)?,
+        url_host: row.get(4)?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+        deleted_at: row.get(7)?,
+        payload: row.get(8)?,
+    })
+}
+
+fn row_to_meta(row: &Row) -> rusqlite::Result<EntryMeta> {
+    Ok(EntryMeta {
+        id: row.get(0)?,
+        kind: row.get(1)?,
+        title: row.get(2)?,
+        tags: row.get(3)?,
+        url_host: row.get(4)?,
+        created_at: row.get(5)?,
+        updated_at: row.get(6)?,
+        deleted_at: row.get(7)?,
+    })
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(unix)]
+fn set_mode(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
+}
+
+// TODO: tighten Windows ACLs to the current user; std has no chmod analog.
+#[cfg(not(unix))]
+fn set_mode(_path: &Path, _mode: u32) {}

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,0 +1,193 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::migrate::migrate_from_json;
+use super::{Record, SqliteStore, VaultStore};
+
+const KEY: &[u8] = &[0x11; 32];
+
+// A fresh, unique DB path under the temp dir for each test.
+fn tmp_db() -> PathBuf {
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "swifty-store-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("vault.db")
+}
+
+fn rec(id: &str, payload: &[u8]) -> Record {
+    Record {
+        id: id.into(),
+        kind: "login".into(),
+        title: "Example".into(),
+        tags: "[\"a\",\"b\"]".into(),
+        url_host: "example.com".into(),
+        created_at: 0,
+        updated_at: 0,
+        deleted_at: None,
+        payload: payload.to_vec(),
+    }
+}
+
+#[test]
+fn crud_round_trip() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    store.upsert(&rec("1", b"secret-blob")).unwrap();
+
+    let got = store.get("1").unwrap().unwrap();
+    assert_eq!(got.id, "1");
+    assert_eq!(got.title, "Example");
+    assert_eq!(store.list().unwrap().len(), 1);
+    assert_eq!(store.get("missing").unwrap(), None);
+}
+
+#[test]
+fn payload_is_byte_identical() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    // Arbitrary non-utf8 bytes: the store must never interpret the payload.
+    let blob: Vec<u8> = (0u16..=255).map(|b| b as u8).collect();
+    store.upsert(&rec("1", &blob)).unwrap();
+    assert_eq!(store.get("1").unwrap().unwrap().payload, blob);
+}
+
+#[test]
+fn delete_tombstones_and_hides_from_list() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    store.upsert(&rec("1", b"x")).unwrap();
+    store.delete("1").unwrap();
+
+    assert!(store.list().unwrap().is_empty());
+    assert_eq!(store.get("1").unwrap(), None);
+
+    let exported = store.export_for_sync().unwrap();
+    assert_eq!(exported.len(), 1);
+    assert!(exported[0].deleted_at.is_some());
+}
+
+#[test]
+fn upsert_stamps_updated_at() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    // Seed via import so the low timestamp is preserved, then upsert to bump it.
+    let mut r = rec("1", b"x");
+    r.updated_at = 1000;
+    store.import(&[r]).unwrap();
+
+    store.upsert(&rec("1", b"y")).unwrap();
+    assert!(store.get("1").unwrap().unwrap().updated_at > 1000);
+}
+
+#[test]
+fn import_preserves_timestamps() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    let mut r = rec("1", b"x");
+    r.created_at = 111;
+    r.updated_at = 222;
+    store.import(&[r]).unwrap();
+
+    let got = &store.export_for_sync().unwrap()[0];
+    assert_eq!(got.created_at, 111);
+    assert_eq!(got.updated_at, 222);
+}
+
+#[test]
+fn meta_get_set() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    assert_eq!(store.meta_get("kdf").unwrap(), None);
+    store.meta_set("kdf", "argon2id").unwrap();
+    assert_eq!(store.meta_get("kdf").unwrap().as_deref(), Some("argon2id"));
+    // schema_version is stamped on open.
+    assert_eq!(
+        store.meta_get("schema_version").unwrap().as_deref(),
+        Some("1")
+    );
+}
+
+#[test]
+fn wrong_key_fails() {
+    let path = tmp_db();
+    SqliteStore::open(&path, KEY)
+        .unwrap()
+        .upsert(&rec("1", b"x"))
+        .unwrap();
+    assert!(SqliteStore::open(&path, &[0x22; 32]).is_err());
+}
+
+#[test]
+fn reopen_after_commit_persists() {
+    let path = tmp_db();
+    {
+        let store = SqliteStore::open(&path, KEY).unwrap();
+        store.upsert(&rec("1", b"durable")).unwrap();
+    }
+    let store = SqliteStore::open(&path, KEY).unwrap();
+    assert_eq!(store.get("1").unwrap().unwrap().payload, b"durable");
+}
+
+#[cfg(unix)]
+#[test]
+fn file_mode_is_0600() {
+    use std::os::unix::fs::PermissionsExt;
+    let path = tmp_db();
+    SqliteStore::open(&path, KEY).unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}
+
+#[test]
+fn migrate_from_json_round_trips_and_keeps_bak() {
+    use crate::crypto::Cryptor;
+    use crate::models::{Entry, VaultData};
+
+    let cryptor = Cryptor::new(&crate::crypto::hash_secret("master-pw"));
+    let entries: Vec<Entry> = ["1", "2"]
+        .iter()
+        .map(|id| {
+            serde_json::from_value(serde_json::json!({
+                "id": id, "type": "login", "title": format!("Site {id}"),
+                "website": "https://example.com/login", "password": "hunter2",
+                "tags": ["work"], "createdAt": "2024-01-02T03:04:05Z"
+            }))
+            .unwrap()
+        })
+        .collect();
+    let obscured: Vec<Entry> = entries
+        .iter()
+        .map(|e| cryptor.obscure(e).unwrap())
+        .collect();
+    let blob = cryptor
+        .encrypt_data(&VaultData {
+            entries: obscured.clone(),
+        })
+        .unwrap();
+
+    let json_path = tmp_db().with_file_name("vault.swftx");
+    std::fs::write(&json_path, &blob).unwrap();
+
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    let n = migrate_from_json(&json_path, &cryptor, &store).unwrap();
+    assert_eq!(n, 2);
+
+    // Metadata landed in columns.
+    let list = store.list().unwrap();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list[0].url_host, "example.com");
+
+    // Payload decrypts back to the identical (obscured) entries.
+    for (want, meta) in obscured.iter().zip(&list) {
+        let record = store.get(&meta.id).unwrap().unwrap();
+        let payload = String::from_utf8(record.payload).unwrap();
+        let got: Entry = cryptor.decrypt_data(&payload).unwrap();
+        assert_eq!(
+            serde_json::to_value(&got).unwrap(),
+            serde_json::to_value(want).unwrap()
+        );
+    }
+
+    // The legacy JSON is retained as a .bak sidecar.
+    let mut bak = json_path.into_os_string();
+    bak.push(".bak");
+    assert!(PathBuf::from(bak).exists());
+}

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -137,6 +137,21 @@ fn file_mode_is_0600() {
 }
 
 #[test]
+fn snapshot_is_encrypted_and_reopens() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    store.upsert(&rec("1", b"durable")).unwrap();
+
+    let snap = tmp_db().with_file_name("snapshot.db");
+    store.snapshot_to(&snap, KEY).unwrap();
+
+    // The snapshot reopens with the same key and carries the committed row.
+    let restored = SqliteStore::open(&snap, KEY).unwrap();
+    assert_eq!(restored.get("1").unwrap().unwrap().payload, b"durable");
+    // It is genuinely encrypted: a wrong key cannot open it.
+    assert!(SqliteStore::open(&snap, &[0x22; 32]).is_err());
+}
+
+#[test]
 fn migrate_from_json_round_trips_and_keeps_bak() {
     use crate::crypto::Cryptor;
     use crate::models::{Entry, VaultData};


### PR DESCRIPTION
## What this is

A **self-contained, swappable storage module** for the vault, added under `src-tauri/src/store/`. It is the deliverable for Phase 1 T-STORE-1/2 — the module, migration adapter, and tests. It is **NOT yet wired into the app** (`commands/`, `state.rs` still use the legacy JSON `storage.rs`); rewiring is the separate, owner-reviewed integration step.

## The API (trait)

```rust
pub trait VaultStore: Send {
    fn meta_get(&self, key: &str) -> Result<Option<String>>;
    fn meta_set(&self, key: &str, value: &str) -> Result<()>;
    fn list(&self) -> Result<Vec<EntryMeta>>;          // live metadata only
    fn get(&self, id: &str) -> Result<Option<Record>>; // live metadata + payload
    fn upsert(&self, rec: &Record) -> Result<()>;      // stamps updated_at = now
    fn delete(&self, id: &str) -> Result<()>;          // tombstone (deleted_at = now)
    fn export_for_sync(&self) -> Result<Vec<Record>>;  // incl. tombstones, ts intact
    fn import(&self, recs: &[Record]) -> Result<()>;   // bulk upsert, one txn, ts preserved
}
```
`Record { id, kind, title, tags, url_host, created_at, updated_at, deleted_at, payload: Vec<u8> }`; `EntryMeta` = the same minus `payload`.

## How the swappable boundary is enforced

- The module depends only on `std`, `rusqlite`, `serde`, and its **own** `StoreError` — never on `commands`, `state`, `models::Entry`, or Tauri. It defines its own `Record`/`EntryMeta`.
- **Payload encryption is not the store's job.** `payload` is an opaque `Vec<u8>`; the store never inspects or encrypts it (a test round-trips all 256 byte values). The only crypto here is SQLCipher at-rest.
- `migrate.rs` is the *one* file that touches the app's `crypto`/`models`. It is deliberately outside the pure trait — boundary glue — and takes a `&Path` + `&Cryptor`, so it stays Tauri-free.

## Crate / feature

`rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl"] }` — vendors SQLCipher + OpenSSL, no system deps, cross-platform. `Cargo.lock` committed.

## SQLCipher pragmas (on open)

- `PRAGMA key = "x'<hex>'"` — raw-key form; the injected key bytes are used directly (no passphrase KDF; the app derives the key).
- `PRAGMA journal_mode = WAL`.
- Wrong-key detection: on an existing DB, a `SELECT count(*) FROM sqlite_master` probe forces decryption to fail fast.
- Schema created if absent; `schema_version` stamped in `meta`.
- File mode `0600`, parent dir `0700` (unix; Windows ACL left as a TODO comment).

## Schema

```
meta(key TEXT PRIMARY KEY, value TEXT)
entries(id TEXT PK, kind, title, tags, url_host TEXT,
        created_at, updated_at, deleted_at INTEGER, payload BLOB)
```
Single `Mutex<Connection>`, prepared statements, `import` in a transaction. `delete` tombstones (never `DELETE FROM`); `upsert` stamps `updated_at`.

## Migration adapter (T-STORE-2)

`migrate_from_json(path, cryptor, store)`: reads the legacy `vault.swftx`, decrypts via the existing cryptor, maps each entry to a `Record` (metadata → columns, whole entry re-sealed into the opaque `payload`), `store.import(...)`, and copies the JSON to `vault.swftx.bak` (never deletes the original).

## Tests — all green (10 in-module)

CRUD round-trip · payload byte-identical (opacity) · delete tombstones + hides from `list` but shows in `export_for_sync` · `upsert` bumps `updated_at` · `import` preserves timestamps · `meta` get/set · **wrong key fails** · reopen-after-commit persists (durability) · file mode `0600` · `migrate_from_json` round-trip yields identical entries + retains `.bak`.

Gate: `cargo test --locked` (39 passed) and `cargo clippy --all-targets -- -D warnings` (clean). `cargo fmt --check`: my four `store/*.rs` files are formatted; note the branch has **pre-existing** fmt drift across unrelated files (sync/, commands/, crypto/, …) from newer stable rustfmt — left untouched to respect scope.

## Deliberately left for integration (owner-reviewed follow-up)

- Wiring `commands/`/`state.rs` onto `VaultStore` (legacy JSON path still live and working).
- Deciding the final `payload` field set / AEAD shape and the exact `meta` KDF values (Phase 2).
- Calling `migrate_from_json` on first unlock (idempotency guard at the call site).