### PR TITLE
Webview & shell hardening (T-SEC-1/2/3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,4 +54,8 @@ dependencies, and tools contained in the `swiftyapp/swifty` repository.
 
   * Once your commits are ready to go (with passing tests and linting) begin the process of opening a pull request by pushing your working branch to your fork on GitHub.
   * From within GitHub, opening a new pull request will present you with a template that should be filled out
+
+## Security
+
+* **Never log secret-bearing values.** `log::*!` / `console.*` calls must not interpolate an `Entry`, its secret fields (password, notes, card, OTP), the master password, or any derived key. Log opaque errors and identifiers only.
   * Discuss changes and update pull request

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2.7.2",
-        "@tauri-apps/plugin-log": "^2.9.0",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "react": "^19.2.8",
@@ -330,8 +329,6 @@
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg=="],
-
-    "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.9.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 

--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -157,13 +157,13 @@ on Phase 1.
 
 ## Phase 5 — Webview & shell hardening (parallelizable)
 
-### T-SEC-1 · Set a strict CSP  ❌ (S15, T14) — high priority
+### T-SEC-1 · Set a strict CSP  ✅ (PR) (S15, T14) — high priority
 **Evidence:** `tauri.conf.json:29` `security.csp: null` — **no CSP at all** (worse than legacy's late meta CSP). **Steps:** set an explicit main-process CSP, e.g. `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; object-src 'none'; frame-src 'none'` (add Google sync origins to `connect-src` **only** if/when sync is enabled). **Acceptance:** CSP present; app runs; no console CSP violations.
 
-### T-SEC-2 · Scope external-link opening to http/https  ❌ (S2, T8)
+### T-SEC-2 · Scope external-link opening to http/https  ✅ (PR) (S2, T8)
 **Evidence:** `Show/.../Item/index.tsx:26-29` calls `openUrl(raw)` on the raw vault `website` field; `capabilities/default.json:17` grants **unscoped** `opener:allow-open-url`. **Steps:** validate scheme (`http:`/`https:` only) before `openUrl`, and replace the unscoped permission with `opener:allow-default-urls` or a scoped custom permission. **Acceptance:** a `file://`/custom-scheme website value is refused; http/https still opens.
 
-### T-SEC-3 · Log-redaction discipline  🟡 (S17)
+### T-SEC-3 · Log-redaction discipline  ✅ (PR) (S17)
 **Evidence:** only 2 benign `log::` sites today; no structural redaction; unused frontend `plugin-log`. **Steps:** add a lint/review rule forbidding `log::*!` interpolating `Entry`/secret fields; drop the unused frontend log plugin or wire redaction. **Acceptance:** rule in place; no secret-bearing log call exists.
 
 ### T-SEC-4 · Prompt before auto-installing updates  🟡 (updater UX)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
-    "@tauri-apps/plugin-log": "^2.9.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "react": "^19.2.8",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,7 +14,10 @@
     "clipboard-manager:allow-clear",
     "dialog:allow-open",
     "dialog:allow-save",
-    "opener:allow-open-url",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [{ "url": "http://*" }, { "url": "https://*" }]
+    },
     "log:default",
     "updater:default"
   ]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -18,6 +18,8 @@ const FILE_NAME: &str = "vault.swftx";
 
 // Temporarily disabled: Drive sync blocks the UI thread and needs an async
 // rework before it ships. Flip to true to re-enable. See commands/sync.rs.
+// When enabling: add the Google Drive/OAuth origins to `connect-src` in the
+// `security.csp` string in tauri.conf.json (currently `'self'` only).
 pub const ENABLED: bool = false;
 
 // Build an HTTPS client, installing the ring rustls provider once per process

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'none'"
     }
   },
   "bundle": {

--- a/src/components/Main/Body/Aside/Show/Details/Item/index.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/index.tsx
@@ -1,7 +1,7 @@
-import { openUrl } from '@tauri-apps/plugin-opener'
 import type { Entry } from '@/lib/commands'
 import { t } from '@/i18n'
 import { copy } from '@/services/copy'
+import { openLink } from '@/services/openLink'
 import Copy from '@/assets/images/copy.svg?react'
 
 interface Props {
@@ -25,7 +25,7 @@ export default function Item({ entry, name, link, cc, secure }: Props) {
           href={raw}
           onClick={e => {
             e.preventDefault()
-            openUrl(raw)
+            openLink(raw)
           }}
         >
           {raw}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -90,5 +90,7 @@
   "Are you sure you want to delete this item?": "Are you sure you want to delete this item?",
   "Confirm your identity": "Confirm your identity",
   "or": "or",
-  "Language": "Language"
+  "Language": "Language",
+  "Invalid link": "Invalid link",
+  "Only http and https links can be opened": "Only http and https links can be opened"
 }

--- a/src/services/openLink.ts
+++ b/src/services/openLink.ts
@@ -1,0 +1,20 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { t } from '@/i18n'
+
+// Only http/https are handed to the OS opener; anything else (file:, custom
+// schemes, javascript:) is refused. Defense in depth with the scoped
+// `opener:allow-open-url` capability.
+export const openLink = (raw: string) => {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    window.alert(t('Invalid link'))
+    return
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    window.alert(t('Only http and https links can be opened'))
+    return
+  }
+  openUrl(url.href)
+}


### PR DESCRIPTION
Implements Phase 5 items **T-SEC-1**, **T-SEC-2**, **T-SEC-3** from `docs/v1-remediation.md`. Least-privilege webview + shell hardening; no IPC re-architecture (Isolation Pattern out of scope).

## T-SEC-1 — Strict CSP
`security.csp` was `null` (no CSP at all). Set an explicit main-process policy:

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'none'
```

Sync is flag-disabled, so no Google origins are pre-added. `tauri.conf.json` is strict JSON (no comments), so the reminder to add Drive/OAuth origins to `connect-src` when enabling sync lives at the `sync::ENABLED` flag site (`src-tauri/src/sync/mod.rs`), where the switch actually gets flipped.

Verified against the production bundle: the only `<script>` is an external `src` from `'self'`, styles are a linked stylesheet + inline React styles (`'unsafe-inline'`), no `connect`/`img` beyond `'self'`/`data:`. GUI could not be launched headlessly here, so runtime-console verification is left to the reviewer, but the build is statically CSP-compatible.

## T-SEC-2 — Opener scope (defense in depth)
- **Frontend:** new `src/services/openLink.ts` parses the raw `website` value and opens it only when the protocol is `http:`/`https:`; anything else (file:, custom schemes, javascript:, unparseable) is refused with a clear localized message. `Item` now calls `openLink` instead of `openUrl(raw)`.
- **ACL:** replaced the unscoped `opener:allow-open-url` with an inline-scoped permission allowing only `http://*` and `https://*` — tighter than `allow-default-urls` (which also permits `mailto:`/`tel:`) and exactly matching the frontend check. Validated by `tauri_build` at compile time.

## T-SEC-3 — Log hygiene
- Confirmed the only two `log::*!` sites (`updater.rs`, `storage.rs`) interpolate error values, not `Entry`/secret fields.
- Dropped the unused frontend `@tauri-apps/plugin-log` dependency (no JS import anywhere; lockfile updated). Rust `tauri_plugin_log` is unaffected.
- Added a Security section to `CONTRIBUTING.md` forbidding logging secret-bearing values.

Also flips the T-SEC-1/2/3 status markers to ✅ (PR) in `docs/v1-remediation.md`.

## Gate results
- `bun run typecheck` ✅
- `bun run lint` (0 warnings) ✅
- `bun run test` ✅ (39)
- `bun run build` ✅
- `cargo clippy --all-targets` ✅ (no issues)
- `cargo test --locked` ✅ (29)
- `cargo fmt --check`: pre-existing violations in files **not touched by this PR** (`sync/merge.rs`, `sync/mod.rs:52`, `autolock.rs`) exist on the base `v1-0-0` branch; my changes are fmt-clean. Left unformatted to avoid unrelated churn (scope guard).