### PR TITLE
Password audit redesign: zxcvbn + HIBP k-anonymity (T-AUDIT-1)

### DIFF
--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -173,7 +173,7 @@ on Phase 1.
 
 ## Phase 6 — Audit quality & product correctness
 
-### T-AUDIT-1 · Modern password audit  ❌ (B8, T13)
+### T-AUDIT-1 · Modern password audit  ✅ (PR) (B8, T13)
 **Evidence:** `commands/audit.rs:8-9,47-53` uses composition rules (upper+lower+digit+symbol — NIST-discredited) + `FRESHNESS_DAYS = 90` rotation; no breach check. **Steps:** replace composition rules with a zxcvbn score; drop the rotation check; add **opt-in** HIBP Pwned-Passwords via k-anonymity (first 5 SHA-1 chars only, clearly explained in UI). Keep the boolean/score-only IPC contract. **Acceptance:** a strong passphrase is not "weak"; HIBP lookup is opt-in and never sends a full hash.
 
 ### T-PROD-1 · Small correctness batch  ✅ (PR) (B2, B5, B9)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -566,8 +566,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -765,12 +767,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -788,11 +814,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -856,6 +893,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.119",
 ]
 
@@ -1052,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1246,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2110,6 +2195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2402,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libappindicator"
@@ -3878,7 +3978,7 @@ version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4139,6 +4239,7 @@ dependencies = [
  "totp-rs",
  "url",
  "windows",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -6439,4 +6540,21 @@ dependencies = [
  "serde",
  "syn 3.0.4",
  "winnow 1.0.4",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eaee90f4a795d1eb4ba6c51e1c1721d4784d550e8efa7b2600f29c867365e0"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ rand = "0.8"
 hex = "0.4"
 base64 = "0.22"
 totp-rs = { version = "5", default-features = false }
+zxcvbn = "3"
 dirs = "5"
 log = "0.4.34"
 chrono = { version = "0.4.45", default-features = false, features = ["clock"] }

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -1,28 +1,34 @@
+use std::collections::HashMap;
+
 use crate::crypto::Cryptor;
 use crate::error::{Error, Result};
+use crate::hibp;
 use crate::models::{Audit, AuditItem, Entry};
 use crate::state::AppState;
-use chrono::{DateTime, Utc};
 use tauri::State;
+use zxcvbn::zxcvbn;
 
-const MIN_LENGTH: usize = 8;
-const FRESHNESS_DAYS: i64 = 90;
+// zxcvbn scores 0-4; below 3 ("safely unguessable") is treated as weak. This
+// replaces NIST-discredited composition rules and already accounts for length,
+// dictionary words, keyboard walks and l33t substitutions.
+const WEAK_SCORE: u8 = 3;
 
-// Audit every password in the unlocked vault (weak / short / old / repeating).
-// Passwords are stored encrypted, so decryption runs off the UI thread.
+// Audit every password in the unlocked vault: strength (zxcvbn), reuse, and —
+// when the user opts in — breach exposure (HIBP k-anonymity). Passwords are
+// stored encrypted, so decryption and the network call run off the UI thread.
 #[tauri::command]
-pub async fn get_audit(state: State<'_, AppState>) -> Result<Audit> {
+pub async fn get_audit(state: State<'_, AppState>, check_breaches: bool) -> Result<Audit> {
     let (cryptor, vault) = {
         let s = state.session.lock().unwrap();
         (s.cryptor()?, s.vault.clone().ok_or(Error::Locked)?)
     };
-    tauri::async_runtime::spawn_blocking(move || audit(&cryptor, &vault.entries))
+    tauri::async_runtime::spawn_blocking(move || audit(&cryptor, &vault.entries, check_breaches))
         .await
         .map_err(|e| Error::Crypto(e.to_string()))?
 }
 
-// Decrypt each non-empty password once, then flag weak / short / old / repeating.
-fn audit(cryptor: &Cryptor, entries: &[Entry]) -> Result<Audit> {
+// Decrypt each non-empty password once, then flag weak / reused / breached.
+fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<Audit> {
     let creds: Vec<(&Entry, String)> = entries
         .iter()
         .filter_map(|e| e.password.as_deref().filter(|p| !p.is_empty()).map(|p| (e, p)))
@@ -30,44 +36,28 @@ fn audit(cryptor: &Cryptor, entries: &[Entry]) -> Result<Audit> {
         .collect::<Result<_>>()?;
 
     let passwords: Vec<&str> = creds.iter().map(|(_, p)| p.as_str()).collect();
+    let breaches: HashMap<String, bool> = if check_breaches {
+        hibp::check_all(&passwords)
+    } else {
+        HashMap::new()
+    };
+
     Ok(creds
         .iter()
         .map(|(e, p)| {
             let repeating = passwords.iter().filter(|&&x| x == p).count() > 1;
+            let score = u8::from(zxcvbn(p, &[]).score());
             (
                 e.id.clone(),
                 AuditItem {
-                    is_short: p.chars().count() < MIN_LENGTH,
-                    is_weak: is_weak(p),
-                    is_old: is_old(e),
+                    score,
+                    is_weak: score < WEAK_SCORE,
                     is_repeating: repeating,
+                    breached: breaches.get(p).copied().unwrap_or(false),
                 },
             )
         })
         .collect())
-}
-
-// Weak if it lacks any of: uppercase, lowercase, digit, symbol.
-fn is_weak(pw: &str) -> bool {
-    let has_upper = pw.chars().any(|c| c.is_uppercase());
-    let has_lower = pw.chars().any(|c| c.is_lowercase());
-    let has_digit = pw.chars().any(|c| c.is_ascii_digit());
-    let has_symbol = pw.chars().any(|c| !c.is_alphanumeric() && !c.is_whitespace());
-    !(has_upper && has_lower && has_digit && has_symbol)
-}
-
-// Old if the last password update was over FRESHNESS_DAYS ago. Missing or
-// unparseable timestamps are treated as not old (legacy luxon NaN behavior).
-fn is_old(entry: &Entry) -> bool {
-    let ts = entry
-        .password_updated_at
-        .as_deref()
-        .or(entry.updated_at.as_deref());
-    let Some(ts) = ts else { return false };
-    match DateTime::parse_from_rfc3339(ts) {
-        Ok(dt) => (Utc::now() - dt.with_timezone(&Utc)).num_days().abs() > FRESHNESS_DAYS,
-        Err(_) => false,
-    }
 }
 
 #[cfg(test)]
@@ -84,11 +74,10 @@ mod tests {
     }
 
     // Build a login with its password encrypted, as it is on disk.
-    fn login(c: &Cryptor, id: &str, password: &str, updated: Option<&str>) -> Entry {
+    fn login(c: &Cryptor, id: &str, password: &str) -> Entry {
         c.obscure(&entry(json!({
             "id": id, "type": "login", "title": "t",
             "password": password,
-            "password_updated_at": updated,
         })))
         .unwrap()
     }
@@ -98,27 +87,27 @@ mod tests {
         let c = cryptor();
         let entries = vec![
             entry(json!({ "id": "n", "type": "note", "title": "t", "note": "x" })),
-            login(&c, "empty", "", None),
+            login(&c, "empty", ""),
         ];
-        assert!(audit(&c, &entries).unwrap().is_empty());
+        assert!(audit(&c, &entries, false).unwrap().is_empty());
     }
 
     #[test]
-    fn flags_short_and_weak() {
+    fn flags_weak_by_score() {
         let c = cryptor();
-        let a = audit(&c, &[login(&c, "1", "abc", None)]).unwrap();
-        let item = &a["1"];
-        assert!(item.is_short);
-        assert!(item.is_weak);
-        assert!(!item.is_repeating);
+        let a = audit(&c, &[login(&c, "1", "abc")], false).unwrap();
+        assert!(a["1"].is_weak);
+        assert!(a["1"].score < WEAK_SCORE);
+        assert!(!a["1"].is_repeating);
+        assert!(!a["1"].breached);
     }
 
     #[test]
-    fn strong_password_is_not_weak_or_short() {
+    fn strong_passphrase_is_not_weak() {
         let c = cryptor();
-        let a = audit(&c, &[login(&c, "1", "Abcdef1!ghij", None)]).unwrap();
-        assert!(!a["1"].is_short);
+        let a = audit(&c, &[login(&c, "1", "correct horse battery staple")], false).unwrap();
         assert!(!a["1"].is_weak);
+        assert!(a["1"].score >= WEAK_SCORE);
     }
 
     #[test]
@@ -127,10 +116,11 @@ mod tests {
         let a = audit(
             &c,
             &[
-                login(&c, "1", "Repeated1!", None),
-                login(&c, "2", "Repeated1!", None),
-                login(&c, "3", "Unique2@ab", None),
+                login(&c, "1", "Repeated1!"),
+                login(&c, "2", "Repeated1!"),
+                login(&c, "3", "Unique2@ab"),
             ],
+            false,
         )
         .unwrap();
         assert!(a["1"].is_repeating);
@@ -138,22 +128,11 @@ mod tests {
         assert!(!a["3"].is_repeating);
     }
 
+    // Opt-out (check_breaches = false) makes no network call and leaves breached false.
     #[test]
-    fn detects_old_passwords() {
+    fn breach_check_is_skipped_when_opted_out() {
         let c = cryptor();
-        let old = (Utc::now() - chrono::Duration::days(120)).to_rfc3339();
-        let fresh = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
-        let a = audit(
-            &c,
-            &[
-                login(&c, "old", "Str0ng!pass", Some(&old)),
-                login(&c, "fresh", "Str0ng!pass", Some(&fresh)),
-                login(&c, "missing", "Str0ng!pass", None),
-            ],
-        )
-        .unwrap();
-        assert!(a["old"].is_old);
-        assert!(!a["fresh"].is_old);
-        assert!(!a["missing"].is_old);
+        let a = audit(&c, &[login(&c, "1", "password")], false).unwrap();
+        assert!(!a["1"].breached);
     }
 }

--- a/src-tauri/src/hibp.rs
+++ b/src-tauri/src/hibp.rs
@@ -1,0 +1,122 @@
+//! HaveIBeenPwned "Pwned Passwords" breach check via k-anonymity.
+//!
+//! We SHA-1 the password locally, then send **only the first 5 hex chars** of
+//! that hash to the range API. The endpoint returns every suffix sharing that
+//! prefix; we match our 35-char suffix locally. The full hash and the password
+//! itself never leave the device. Only booleans cross the IPC boundary.
+
+use std::collections::{HashMap, HashSet};
+
+use reqwest::Client;
+use ring::digest;
+use tauri::async_runtime::block_on;
+
+use crate::error::{Error, Result};
+
+const RANGE_URL: &str = "https://api.pwnedpasswords.com/range/";
+const PREFIX_LEN: usize = 5;
+
+// SHA-1 hex (uppercase, 40 chars) of the password. SHA-1 is required by the
+// HIBP range API and is not used here for any security property.
+fn sha1_hex(password: &str) -> String {
+    hex::encode_upper(digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, password.as_bytes()))
+}
+
+// k-anonymity split: the 5-char prefix is all that is ever sent.
+fn split(hash: &str) -> (&str, &str) {
+    hash.split_at(PREFIX_LEN)
+}
+
+fn range_url(prefix: &str) -> String {
+    format!("{RANGE_URL}{prefix}")
+}
+
+// Range responses are `SUFFIX:count` lines; breached if our suffix has count > 0.
+fn is_breached(suffix: &str, body: &str) -> bool {
+    body.lines().any(|line| {
+        let (hash_suffix, count) = line.split_once(':').unwrap_or((line, "0"));
+        hash_suffix.eq_ignore_ascii_case(suffix) && count.trim().parse::<u64>().unwrap_or(0) > 0
+    })
+}
+
+async fn fetch_range(client: &Client, prefix: &str) -> Result<String> {
+    let resp = client
+        .get(range_url(prefix))
+        .header("User-Agent", "Swifty-Password-Manager")
+        .send()
+        .await
+        .map_err(|e| Error::Other(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(Error::Other(format!("HIBP {}", resp.status())));
+    }
+    resp.text().await.map_err(|e| Error::Other(e.to_string()))
+}
+
+async fn is_pwned(client: &Client, password: &str) -> Result<bool> {
+    let hash = sha1_hex(password);
+    let (prefix, suffix) = split(&hash);
+    let body = fetch_range(client, prefix).await?;
+    Ok(is_breached(suffix, &body))
+}
+
+// Check each unique password once. A network/API failure maps to `false`
+// (not breached) so the rest of the audit still works offline.
+pub fn check_all(passwords: &[&str]) -> HashMap<String, bool> {
+    let client = crate::sync::http_client();
+    let unique: HashSet<&str> = passwords.iter().copied().collect();
+    block_on(async {
+        let mut out = HashMap::with_capacity(unique.len());
+        for pw in unique {
+            let breached = is_pwned(&client, pw).await.unwrap_or(false);
+            out.insert(pw.to_string(), breached);
+        }
+        out
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Known SHA-1 of "password".
+    const PW_HASH: &str = "5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8";
+
+    #[test]
+    fn hashes_uppercase_sha1() {
+        assert_eq!(sha1_hex("password"), PW_HASH);
+    }
+
+    #[test]
+    fn splits_into_5_char_prefix_and_35_char_suffix() {
+        let (prefix, suffix) = split(PW_HASH);
+        assert_eq!(prefix.len(), 5);
+        assert_eq!(suffix.len(), 35);
+        assert_eq!(format!("{prefix}{suffix}"), PW_HASH);
+    }
+
+    // The guarantee: the outbound URL carries only the 5-char prefix — never the
+    // suffix, the full hash, or the password.
+    #[test]
+    fn request_url_leaks_only_the_prefix() {
+        let (prefix, suffix) = split(PW_HASH);
+        let url = range_url(prefix);
+        assert_eq!(url, "https://api.pwnedpasswords.com/range/5BAA6");
+        assert!(url.contains(prefix));
+        assert!(!url.contains(suffix));
+        assert!(!url.contains(PW_HASH));
+    }
+
+    #[test]
+    fn matches_suffix_case_insensitively_with_count() {
+        let (_, suffix) = split(PW_HASH);
+        let body = format!("00000A:1\r\n{}:9999\r\n", suffix.to_lowercase());
+        assert!(is_breached(suffix, &body));
+    }
+
+    #[test]
+    fn absent_or_zero_count_is_not_breached() {
+        let (_, suffix) = split(PW_HASH);
+        assert!(!is_breached(suffix, "00000A:5"));
+        assert!(!is_breached(suffix, &format!("{suffix}:0")));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod biometrics;
 mod commands;
 pub mod crypto;
 mod error;
+mod hibp;
 mod models;
 mod state;
 mod storage;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -88,10 +88,10 @@ pub struct OtpResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuditItem {
-    pub is_short: bool,
+    pub score: u8,
     pub is_weak: bool,
-    pub is_old: bool,
     pub is_repeating: bool,
+    pub breached: bool,
 }
 
 // Audit results keyed by entry id.

--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -5,17 +5,19 @@ interface Props {
   audit: Audit
 }
 
-const scoreOf = (record: AuditItem) =>
-  (record.isWeak ? 0.5 : 0) +
-  (record.isShort ? 0.5 : 0) +
-  (record.isRepeating ? 0.25 : 0) +
-  (record.isOld ? 0.25 : 0)
+// Per-password health from the zxcvbn score (0-4 → 0-1), penalised for reuse
+// and known breaches. Averaged and scaled to a 0-10 overall score.
+const healthOf = (record: AuditItem) => {
+  let value = record.score / 4
+  if (record.isRepeating) value -= 0.25
+  if (record.breached) value -= 0.5
+  return Math.max(0, value)
+}
 
 export default function Score({ audit }: Props) {
   const records = Object.values(audit)
-  const penalty = records.reduce((total, record) => total + scoreOf(record), 0)
-  const score =
-    Math.round(((records.length - penalty) / records.length) * 100) / 10
+  const health = records.reduce((total, record) => total + healthOf(record), 0)
+  const score = Math.round((health / records.length) * 100) / 10
 
   return (
     <div className="score">

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -8,6 +8,7 @@ const count = (audit: Audit, property: keyof AuditItem) =>
 
 export default function Audit() {
   const audit = useStore(state => state.audit)
+  const breachCheck = useStore(state => state.breachCheck)
   const isPristine = useStore(state => state.entries.items.length === 0)
 
   if (isPristine || !audit) return null
@@ -24,19 +25,16 @@ export default function Audit() {
           </li>
           <li>
             <span className="marker level-two"></span>
-            {t('Too Short')}{' '}
-            <span className="count">{count(audit, 'isShort')}</span>
-          </li>
-          <li>
-            <span className="marker level-three"></span>
-            {t('Duplicates')}{' '}
+            {t('Reused')}{' '}
             <span className="count">{count(audit, 'isRepeating')}</span>
           </li>
-          <li>
-            <span className="marker level-four"></span>
-            {t('More than 6 month old')}{' '}
-            <span className="count">{count(audit, 'isOld')}</span>
-          </li>
+          {breachCheck && (
+            <li>
+              <span className="marker level-three"></span>
+              {t('Breached')}{' '}
+              <span className="count">{count(audit, 'breached')}</span>
+            </li>
+          )}
         </ul>
       </div>
     </div>

--- a/src/components/Main/Body/List/Audit/index.tsx
+++ b/src/components/Main/Body/List/Audit/index.tsx
@@ -6,6 +6,7 @@ import Group from './Group'
 
 export default function AuditList() {
   const audit = useStore(state => state.audit)
+  const breachCheck = useStore(state => state.breachCheck)
   const items = useStore(state => state.entries.items)
 
   const byProperty = (property: keyof AuditItem): Entry[] =>
@@ -20,13 +21,18 @@ export default function AuditList() {
   return (
     <div className="list">
       <Group title="Weak" level="level-one" entries={byProperty('isWeak')} />
-      <Group title="Short" level="level-two" entries={byProperty('isShort')} />
       <Group
-        title="Duplicates"
-        level="level-three"
+        title="Reused"
+        level="level-two"
         entries={byProperty('isRepeating')}
       />
-      <Group title="Old" level="level-four" entries={byProperty('isOld')} />
+      {breachCheck && (
+        <Group
+          title="Breached"
+          level="level-three"
+          entries={byProperty('breached')}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/Main/Sidebar/Settings/Audit.tsx
+++ b/src/components/Main/Sidebar/Settings/Audit.tsx
@@ -1,0 +1,49 @@
+import type { ChangeEvent } from 'react'
+import { useStore, setBreachCheck, runAudit } from '@/store'
+import { t } from '@/i18n'
+import type { Section } from './Navigation'
+
+interface Props {
+  section: Section
+}
+
+export default function Audit({ section }: Props) {
+  const breachCheck = useStore(state => state.breachCheck)
+
+  const onToggle = (e: ChangeEvent<HTMLInputElement>) => {
+    setBreachCheck(e.target.checked)
+    runAudit()
+  }
+
+  if (section !== 'audit') return null
+
+  return (
+    <>
+      <h1>{t('Password Audit')}</h1>
+      <div className="section">
+        <strong>{t('Check for breaches')}</strong>
+        <div>
+          {t(
+            'Compares your passwords against the Have I Been Pwned database of leaked passwords.'
+          )}
+        </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              name="breachCheck"
+              checked={breachCheck}
+              onChange={onToggle}
+            />
+            {t('Enable breach check (sends network requests)')}
+          </label>
+        </div>
+        <div className="muted">
+          {t(
+            'Privacy: only the first 5 characters of each password’s SHA-1 hash are sent (k-anonymity). Your password and its full hash never leave this device. Off by default.'
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/Main/Sidebar/Settings/Navigation.tsx
+++ b/src/components/Main/Sidebar/Settings/Navigation.tsx
@@ -1,7 +1,12 @@
 import { cx } from '@/utils/cx'
 import { t } from '@/i18n'
 
-export type Section = 'vault' | 'masterpassword' | 'password' | 'language'
+export type Section =
+  | 'vault'
+  | 'masterpassword'
+  | 'password'
+  | 'audit'
+  | 'language'
 
 interface Props {
   section: Section
@@ -12,6 +17,7 @@ const items: { key: Section; label: string }[] = [
   { key: 'vault', label: 'Vault Settings' },
   { key: 'masterpassword', label: 'Master Password' },
   { key: 'password', label: 'Password Generation' },
+  { key: 'audit', label: 'Password Audit' },
   { key: 'language', label: 'Language' }
 ]
 

--- a/src/components/Main/Sidebar/Settings/index.tsx
+++ b/src/components/Main/Sidebar/Settings/index.tsx
@@ -6,6 +6,7 @@ import Navigation, { type Section } from './Navigation'
 import Vault from './Vault'
 import MasterPassword from './MasterPassword'
 import Password from './Password'
+import Audit from './Audit'
 import Language from './Language'
 import SettingsIcon from '@/assets/images/settings.svg?react'
 
@@ -28,6 +29,7 @@ export default function Settings() {
               <Vault section={section} />
               <MasterPassword section={section} />
               <Password section={section} />
+              <Audit section={section} />
               <Language section={section} />
             </div>
           </div>

--- a/src/defaults/audit.ts
+++ b/src/defaults/audit.ts
@@ -1,0 +1,9 @@
+const KEY = 'swifty:breachCheck'
+
+// Off by default: the HIBP breach check makes an outbound request, so it stays
+// opt-in until the user explicitly enables it.
+export const getBreachCheck = (): boolean =>
+  localStorage.getItem(KEY) === 'true'
+
+export const setBreachCheck = (on: boolean) =>
+  localStorage.setItem(KEY, String(on))

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -79,10 +79,10 @@ export interface OtpResult {
 }
 
 export interface AuditItem {
-  isShort: boolean
+  score: number // zxcvbn strength, 0 (weakest) to 4 (strongest)
   isWeak: boolean
-  isOld: boolean
   isRepeating: boolean
+  breached: boolean // exposed in a known breach (only when the breach check is enabled)
 }
 
 // Keyed by entry id; only entries that have a password are included.
@@ -156,7 +156,8 @@ export const verifyOtp = (secret: string, token: string): Promise<boolean> =>
 // Audit
 // ---------------------------------------------------------------------------
 
-export const getAudit = (): Promise<Audit> => invoke('get_audit')
+export const getAudit = (checkBreaches: boolean): Promise<Audit> =>
+  invoke('get_audit', { checkBreaches })
 
 // ---------------------------------------------------------------------------
 // Clipboard

--- a/src/store/auditSlice.ts
+++ b/src/store/auditSlice.ts
@@ -1,13 +1,21 @@
 import type { StateCreator } from 'zustand'
 import type { Audit } from '@/lib/commands'
+import { getBreachCheck, setBreachCheck } from '@/defaults/audit'
 import type { StoreState } from './index'
 
 export interface AuditSlice {
   audit: Audit | null
+  breachCheck: boolean
   auditDone: (audit: Audit) => void
+  setBreachCheck: (on: boolean) => void
 }
 
 export const createAuditSlice: StateCreator<StoreState, [], [], AuditSlice> = set => ({
   audit: null,
-  auditDone: audit => set({ audit })
+  breachCheck: getBreachCheck(),
+  auditDone: audit => set({ audit }),
+  setBreachCheck: on => {
+    setBreachCheck(on)
+    set({ breachCheck: on })
+  }
 })

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -31,6 +31,7 @@ const pickData = (s: StoreState) => ({
   filters: s.filters,
   entries: s.entries,
   audit: s.audit,
+  breachCheck: s.breachCheck,
   sync: s.sync,
   i18n: s.i18n
 })
@@ -61,6 +62,8 @@ export const {
   entrySaved,
   entryRemoved,
   auditDone,
+  setBreachCheck,
+  runAudit,
   syncInit,
   syncConnected,
   syncDisconnected,

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -19,6 +19,7 @@ export interface AsyncSlice {
   enterMain: (result: UnlockResult) => Promise<void>
   completeSetup: (password: string) => Promise<void>
   restoreBackup: (path: string, password: string) => Promise<void>
+  runAudit: () => Promise<void>
 }
 
 const trySync = () => {
@@ -47,11 +48,12 @@ const buildEntries = (draft: EntryDraft, items: Entry[]): [Entry[], Entry] => {
 
 export const createAsyncSlice: StateCreator<StoreState, [], [], AsyncSlice> = (_set, get) => {
   const refreshAudit = () =>
-    getAudit()
+    getAudit(get().breachCheck)
       .then(data => get().auditDone(data))
       .catch(() => {})
 
   return {
+    runAudit: refreshAudit,
     saveEntry: async draft => {
       const [entries, item] = buildEntries(draft, get().entries.items)
       const vault = await saveVault(entries)
@@ -73,6 +75,7 @@ export const createAsyncSlice: StateCreator<StoreState, [], [], AsyncSlice> = (_
       get().flowMain()
       get().syncInit(SYNC_ENABLED && result.syncConfigured)
       if (SYNC_ENABLED && result.syncConfigured) syncNow().catch(() => {})
+      refreshAudit()
     },
     completeSetup: async password => {
       await setup(password)

--- a/src/test/audit.test.tsx
+++ b/src/test/audit.test.tsx
@@ -3,31 +3,44 @@ import { screen } from '@testing-library/react'
 import AuditList from '@/components/Main/Body/List/Audit'
 import AuditAside from '@/components/Main/Body/Aside/Audit'
 import type { Audit } from '@/lib/commands'
-import { makeStore } from '@/store'
+import { makeStore, setBreachCheck } from '@/store'
 import { renderWithStore, withEntries, loginEntry } from './utils'
 
 const audit: Audit = {
-  l1: { isWeak: true, isShort: false, isOld: false, isRepeating: false },
-  l2: { isWeak: false, isShort: true, isOld: false, isRepeating: false }
+  l1: { score: 0, isWeak: true, isRepeating: false, breached: false },
+  l2: { score: 2, isWeak: false, isRepeating: true, breached: true }
 }
 
 const seed = () => {
   const store = makeStore()
   withEntries(
     store,
-    [loginEntry({ id: 'l1', title: 'Weakling' }), loginEntry({ id: 'l2', title: 'Shorty' })],
+    [loginEntry({ id: 'l1', title: 'Weakling' }), loginEntry({ id: 'l2', title: 'Reuser' })],
     audit
   )
   return store
 }
 
 describe('Audit list', () => {
-  it('groups entries by weakness', () => {
+  it('groups entries by weakness and reuse', () => {
     renderWithStore(<AuditList />, { store: seed() })
     expect(screen.getByText('Weak')).toBeInTheDocument()
     expect(screen.getByText('Weakling')).toBeInTheDocument()
-    expect(screen.getByText('Short')).toBeInTheDocument()
-    expect(screen.getByText('Shorty')).toBeInTheDocument()
+    expect(screen.getByText('Reused')).toBeInTheDocument()
+    expect(screen.getByText('Reuser')).toBeInTheDocument()
+  })
+
+  it('hides breached results until the breach check is enabled', () => {
+    renderWithStore(<AuditList />, { store: seed() })
+    expect(screen.queryByText('Breached')).not.toBeInTheDocument()
+  })
+
+  it('shows breached results when the breach check is enabled', () => {
+    const store = seed()
+    setBreachCheck(true)
+    renderWithStore(<AuditList />, { store })
+    expect(screen.getByText('Breached')).toBeInTheDocument()
+    setBreachCheck(false)
   })
 
   it('shows a loading state before results arrive', () => {


### PR DESCRIPTION
## T-AUDIT-1 — Modern password audit

Redesigns the password-health feature around the two signals that actually matter (a real strength model + breach exposure), dropping the NIST-discredited composition rules and forced-rotation heuristic. Boolean/score-only IPC contract preserved; decrypt + network stay off the UI thread.

### Approach

**Strength (zxcvbn).** `is_weak` now comes from the Rust `zxcvbn` crate's score (0-4), computed inside the audit command. `weak = score < 3` ("safely unguessable"). zxcvbn already accounts for length, dictionary words, keyboard walks and l33t substitutions, so the old composition rules **and** the separate "Too Short" bucket are gone. The per-item `score` is exposed over IPC; the password never is.

**Rotation dropped.** The 90-day `FRESHNESS_DAYS` / `is_old` check is removed entirely (rotation-on-a-timer is an anti-pattern).

**Breach check (HIBP, opt-in).** New `src-tauri/src/hibp.rs`:
- SHA-1 the password locally, split into a **5-char prefix** + 35-char suffix.
- Send **only the prefix** to `https://api.pwnedpasswords.com/range/{prefix}`.
- Match the suffix against the response locally; `breached = count > 0`.

**k-anonymity guarantee:** the full SHA-1 hash and the password itself never leave the device — only the 5-hex-char prefix is transmitted, so the server cannot know which password was checked. A unit test asserts the outbound URL carries only the prefix and never the suffix or full hash. Network failures degrade to `breached = false` so the rest of the audit still works offline. The call originates in the Rust backend (unaffected by the webview CSP work).

**Opt-in flow.** Off by default. A new **Password Audit** settings section carries the toggle and explains the k-anonymity privacy model in the UI. The preference persists in `localStorage` (mirrors the existing generator-defaults pattern) and is threaded to `get_audit(check_breaches)`; toggling it re-runs the audit. When disabled, no network call is made.

**Duplicate detection** kept (already boolean-only).

### Frontend
- Audit list + aside show **Weak / Reused / Breached** (breached rows only when the check is enabled); "old"/"short" categories removed.
- Overall score derived from the zxcvbn score with reuse/breach penalties.
- Audit now populates on unlock (previously only after the first save).

### Gate results
- `bun run typecheck` clean · `bun run lint` 0 warnings · `bun run test` 41 passed
- `src-tauri`: `cargo clippy --all-targets -- -D warnings` clean (exit 0) · `cargo test --locked` 34 passed
- New tests: hibp asserts only-the-prefix-is-sent + never-the-full-hash; audit covers weak-by-score, reuse, and the opted-out breach path.

> Note on `cargo fmt`: this branch's diff is confined to audit files and each touched line stays ≤100 cols, matching the repo's canonical style. The base `v1-0-0` is not clean under local rustfmt 1.8.0 (a chain-width behavior change in newer rustfmt reformats many pre-existing files); those unrelated reformats were deliberately reverted to keep the PR focused and avoid conflicts with the parallel storage/webview branches.

Flips the T-AUDIT-1 status line in `docs/v1-remediation.md` to ✅ (PR).