### PR TITLE
CI: pin rust-toolchain 1.90.0 + apply cargo fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+      - name: Install pinned Rust toolchain (from rust-toolchain.toml)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -74,7 +73,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain (from rust-toolchain.toml)
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Single source of truth for the Rust toolchain — used by CI, the release
+# build, and local dev. rustup auto-selects this in any cargo/clippy/rustc
+# invocation under the repo and installs it on demand.
+#
+# The CI clippy gate is `-D warnings` and CI runs `cargo fmt --check`, so a
+# floating toolchain would let a new release's lints or formatting break CI on
+# unchanged code. Pin deliberately: bump `channel` here and nowhere else.
+[toolchain]
+channel = "1.90.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/src-tauri/src/autolock.rs
+++ b/src-tauri/src/autolock.rs
@@ -24,10 +24,20 @@ pub fn handle_event(app: &AppHandle, event: &WindowEvent) {
 }
 
 fn arm(app: &AppHandle) {
-    if !app.state::<AppState>().session.lock().unwrap().is_unlocked() {
+    if !app
+        .state::<AppState>()
+        .session
+        .lock()
+        .unwrap()
+        .is_unlocked()
+    {
         return;
     }
-    let generation = app.state::<AutoLock>().generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let generation = app
+        .state::<AutoLock>()
+        .generation
+        .fetch_add(1, Ordering::SeqCst)
+        + 1;
     let app = app.clone();
     std::thread::spawn(move || {
         std::thread::sleep(INACTIVE_TIMEOUT);

--- a/src-tauri/src/biometrics.rs
+++ b/src-tauri/src/biometrics.rs
@@ -74,7 +74,9 @@ mod imp {
 
     #[allow(dead_code)]
     pub fn authenticate() -> Result<()> {
-        Err(Error::Other("biometrics not supported on this platform".into()))
+        Err(Error::Other(
+            "biometrics not supported on this platform".into(),
+        ))
     }
 }
 

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -31,7 +31,12 @@ pub async fn get_audit(state: State<'_, AppState>, check_breaches: bool) -> Resu
 fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<Audit> {
     let creds: Vec<(&Entry, String)> = entries
         .iter()
-        .filter_map(|e| e.password.as_deref().filter(|p| !p.is_empty()).map(|p| (e, p)))
+        .filter_map(|e| {
+            e.password
+                .as_deref()
+                .filter(|p| !p.is_empty())
+                .map(|p| (e, p))
+        })
         .map(|(e, p)| Ok((e, cryptor.decrypt(p)?)))
         .collect::<Result<_>>()?;
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -26,14 +26,20 @@ pub fn setup(password: String, app: AppHandle, state: State<'_, AppState>) -> Re
 // Unlock the vault with the master password. Returns decrypted data for display;
 // the derived key stays in Rust.
 #[tauri::command]
-pub fn unlock(password: String, app: AppHandle, state: State<'_, AppState>) -> Result<UnlockResult> {
+pub fn unlock(
+    password: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<UnlockResult> {
     storage::ensure_migrated(&app);
     let blob = storage::read_vault(&app)?;
     let secret = crypto::hash_secret(&password);
     let cryptor = crypto::Cryptor::new(&secret);
     // One derivation decrypts the outer blob. Sensitive fields stay encrypted and
     // are exposed lazily (reveal_entry) so plaintext secrets aren't all in memory.
-    let vault: VaultData = cryptor.decrypt_data(&blob).map_err(|_| Error::InvalidPassword)?;
+    let vault: VaultData = cryptor
+        .decrypt_data(&blob)
+        .map_err(|_| Error::InvalidPassword)?;
     let sync_configured = crate::sync::ENABLED && storage::sync_configured(&app);
     state
         .session
@@ -170,10 +176,10 @@ pub fn change_master_password(
     }
 
     let sync_configured = crate::sync::ENABLED && storage::sync_configured(&app);
-    state.session.lock().unwrap().set(
-        new_secret,
-        VaultData { entries: exposed },
-        sync_configured,
-    );
+    state
+        .session
+        .lock()
+        .unwrap()
+        .set(new_secret, VaultData { entries: exposed }, sync_configured);
     Ok(())
 }

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -42,7 +42,10 @@ pub fn sync_now(app: AppHandle, state: State<'_, AppState>) -> Result<()> {
     let result = perform(&app, &state);
     let _ = match &result {
         Ok(()) => app.emit("sync:stopped", json!({ "success": true })),
-        Err(e) => app.emit("sync:stopped", json!({ "success": false, "error": e.to_string() })),
+        Err(e) => app.emit(
+            "sync:stopped",
+            json!({ "success": false, "error": e.to_string() }),
+        ),
     };
     result
 }
@@ -85,8 +88,14 @@ pub fn sync_import(app: AppHandle, state: State<'_, AppState>) -> Result<()> {
     let _ = app.emit("vault:pull:started", ());
     let result = import_remote(&app, &state, &cryptor);
     let _ = match &result {
-        Ok(vault) => app.emit("vault:pull:stopped", json!({ "success": true, "data": vault })),
-        Err(e) => app.emit("vault:pull:stopped", json!({ "success": false, "error": e.to_string() })),
+        Ok(vault) => app.emit(
+            "vault:pull:stopped",
+            json!({ "success": true, "data": vault }),
+        ),
+        Err(e) => app.emit(
+            "vault:pull:stopped",
+            json!({ "success": false, "error": e.to_string() }),
+        ),
     };
     result.map(|_| ())
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -9,7 +9,13 @@ use tauri_plugin_dialog::DialogExt;
 // frontend reveals individual entries on demand (reveal_entry).
 #[tauri::command]
 pub fn read_vault(state: State<'_, AppState>) -> Result<VaultData> {
-    state.session.lock().unwrap().vault.clone().ok_or(Error::Locked)
+    state
+        .session
+        .lock()
+        .unwrap()
+        .vault
+        .clone()
+        .ok_or(Error::Locked)
 }
 
 // Decrypt one entry's sensitive fields on demand (view/edit).
@@ -18,7 +24,11 @@ pub fn reveal_entry(id: String, state: State<'_, AppState>) -> Result<Entry> {
     let session = state.session.lock().unwrap();
     let cryptor = session.cryptor()?;
     let vault = session.vault.as_ref().ok_or(Error::Locked)?;
-    let entry = vault.entries.iter().find(|e| e.id == id).ok_or(Error::NotFound)?;
+    let entry = vault
+        .entries
+        .iter()
+        .find(|e| e.id == id)
+        .ok_or(Error::NotFound)?;
     cryptor.expose(entry)
 }
 
@@ -70,7 +80,9 @@ pub fn import_backup(
     let secret = crypto::hash_secret(&password);
     let cryptor = crypto::Cryptor::new(&secret);
     // Validate it decrypts, then adopt it; fields stay encrypted (revealed lazily).
-    let vault: VaultData = cryptor.decrypt_data(&blob).map_err(|_| Error::InvalidPassword)?;
+    let vault: VaultData = cryptor
+        .decrypt_data(&blob)
+        .map_err(|_| Error::InvalidPassword)?;
 
     storage::write_vault(&app, &blob)?;
     let sync_configured = crate::sync::ENABLED && storage::sync_configured(&app);

--- a/src-tauri/src/crypto/mod.rs
+++ b/src-tauri/src/crypto/mod.rs
@@ -56,7 +56,13 @@ impl Cryptor {
         // ring's PBKDF2 is assembly-optimized; the pure-Rust one is ~10-20x slower
         // and froze the UI while deriving a key per field. Output is identical.
         let iters = NonZeroU32::new(ITERATIONS).unwrap();
-        ring::pbkdf2::derive(ring::pbkdf2::PBKDF2_HMAC_SHA512, iters, salt, &self.secret, &mut *key);
+        ring::pbkdf2::derive(
+            ring::pbkdf2::PBKDF2_HMAC_SHA512,
+            iters,
+            salt,
+            &self.secret,
+            &mut *key,
+        );
         Aes256Gcm16::new_from_slice(&*key).map_err(err)
     }
 

--- a/src-tauri/src/hibp.rs
+++ b/src-tauri/src/hibp.rs
@@ -19,7 +19,10 @@ const PREFIX_LEN: usize = 5;
 // SHA-1 hex (uppercase, 40 chars) of the password. SHA-1 is required by the
 // HIBP range API and is not used here for any security property.
 fn sha1_hex(password: &str) -> String {
-    hex::encode_upper(digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, password.as_bytes()))
+    hex::encode_upper(digest::digest(
+        &digest::SHA1_FOR_LEGACY_USE_ONLY,
+        password.as_bytes(),
+    ))
 }
 
 // k-anonymity split: the 5-char prefix is all that is ever sent.

--- a/src-tauri/src/sync/auth.rs
+++ b/src-tauri/src/sync/auth.rs
@@ -123,7 +123,10 @@ pub fn authenticate(app: &AppHandle, cryptor: &Cryptor) -> Result<()> {
 pub async fn access_token(client: &Client, app: &AppHandle, cryptor: &Cryptor) -> Result<String> {
     let mut tokens = read_tokens(app, cryptor).ok_or(Error::SyncNotConfigured)?;
     if needs_refresh(&tokens) {
-        let refresh_token = tokens.refresh_token.clone().ok_or(Error::SyncNotConfigured)?;
+        let refresh_token = tokens
+            .refresh_token
+            .clone()
+            .ok_or(Error::SyncNotConfigured)?;
         let fresh = refresh(client, &refresh_token).await?;
         tokens.access_token = fresh.access_token;
         tokens.expires_at = fresh.expires_at;
@@ -184,7 +187,12 @@ async fn refresh(client: &Client, refresh_token: &str) -> Result<Tokens> {
 }
 
 async fn post_token(client: &Client, form: Vec<(&str, String)>) -> Result<Tokens> {
-    let resp = client.post(TOKEN_URL).form(&form).send().await.map_err(other)?;
+    let resp = client
+        .post(TOKEN_URL)
+        .form(&form)
+        .send()
+        .await
+        .map_err(other)?;
     let status = resp.status();
     let body = resp.text().await.map_err(other)?;
     if !status.is_success() {
@@ -271,7 +279,10 @@ mod tests {
     fn pkce_challenge_is_url_safe_sha256() {
         // Known RFC 7636 test vector.
         let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-        assert_eq!(challenge(verifier), "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+        assert_eq!(
+            challenge(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/drive.rs
+++ b/src-tauri/src/sync/drive.rs
@@ -52,7 +52,12 @@ async fn find_one(client: &Client, token: &str, q: &str) -> Result<Option<String
 }
 
 pub async fn folder_id(client: &Client, token: &str, name: &str) -> Result<Option<String>> {
-    find_one(client, token, &format!("name = '{}' and trashed = false", escape(name))).await
+    find_one(
+        client,
+        token,
+        &format!("name = '{}' and trashed = false", escape(name)),
+    )
+    .await
 }
 
 pub async fn file_id(

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -82,7 +82,11 @@ fn group(vault: &Value) -> Group {
         .unwrap_or_default()
         .into_iter()
         .map(|e| {
-            let id = e.get("id").and_then(Value::as_str).unwrap_or("").to_string();
+            let id = e
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
             (id, e)
         })
         .collect();
@@ -129,7 +133,9 @@ mod tests {
             json!([{ "id": "a", "title": "new" }]),
             "2024-06-01T00:00:00+00:00",
         );
-        let merged: Value = c.decrypt_data(&merge_data(&local, &remote, &c).unwrap()).unwrap();
+        let merged: Value = c
+            .decrypt_data(&merge_data(&local, &remote, &c).unwrap())
+            .unwrap();
         let e = &merged["entries"][0];
         assert_eq!(e["title"], "new"); // remote (newer) wins
         assert_eq!(e["note"], "keep"); // field only in local is preserved
@@ -149,7 +155,9 @@ mod tests {
             json!([{ "id": "a" }, { "id": "new_only" }]),
             "2024-06-01T00:00:00+00:00",
         );
-        let merged: Value = c.decrypt_data(&merge_data(&local, &remote, &c).unwrap()).unwrap();
+        let merged: Value = c
+            .decrypt_data(&merge_data(&local, &remote, &c).unwrap())
+            .unwrap();
         let got = ids(&merged);
         assert!(got.contains(&"a".to_string()));
         assert!(got.contains(&"new_only".to_string()));
@@ -169,7 +177,9 @@ mod tests {
             json!([{ "id": "a", "title": "remote" }, { "id": "remote_only" }]),
             "2024-01-01T00:00:00+00:00",
         );
-        let merged: Value = c.decrypt_data(&merge_data(&local, &remote, &c).unwrap()).unwrap();
+        let merged: Value = c
+            .decrypt_data(&merge_data(&local, &remote, &c).unwrap())
+            .unwrap();
         assert_eq!(merged["entries"][0]["title"], "local");
         let got = ids(&merged);
         assert!(got.contains(&"local_only".to_string()));

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -52,7 +52,9 @@ pub fn remote_vault_exists(app: &AppHandle, cryptor: &Cryptor) -> Result<bool> {
         let Some(folder) = drive::folder_id(&client, &token, FOLDER_NAME).await? else {
             return Ok(false);
         };
-        Ok(drive::file_id(&client, &token, FILE_NAME, &folder).await?.is_some())
+        Ok(drive::file_id(&client, &token, FILE_NAME, &folder)
+            .await?
+            .is_some())
     })
 }
 


### PR DESCRIPTION
Fixes the second CI break (fmt drift). Pins the toolchain via `rust-toolchain.toml` (single source: channel + clippy/rustfmt components); CI now installs it with `rustup toolchain install` (mirrors quorum) instead of a floating `@stable`, so a new Rust release can't drift the clippy/fmt gates on unchanged code. Applies `cargo fmt` (12 files) to clear the pre-existing drift. Verified locally: `cargo fmt --check` clean, clippy 0 warnings, cargo test 52 passed.