### PR TITLE
docs: SECURITY.md + threat model (T-DOC-1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ is provided to CI via the `TAURI_SIGNING_PRIVATE_KEY` (and
 `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) secrets. Generate a keypair with
 `npm run tauri signer generate -- -w ~/.swifty/updater.key`.
 
+## Security
+
+Swifty is offline-first: your vault is an encrypted file on your own device and
+there is no backend that holds your secrets. See [`SECURITY.md`](SECURITY.md) for
+how to report a vulnerability, and [`docs/threat-model.md`](docs/threat-model.md)
+for what Swifty does and does not defend against.
+
 ## Contributors
 
 ### Code Contributors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,14 @@
 # Security Policy
 
+Swifty is an offline-first password manager. Your vault lives on your own device
+as an encrypted file, and the app has no backend that holds your secrets. We take
+reports about the encryption, key handling, update channel, and platform
+integration seriously.
+
 ## Supported Versions
 
-Security updates are provided for the latest released version.
+Security fixes land in the latest released version. Older versions are not
+patched; please update before reporting.
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -11,11 +17,48 @@ Security updates are provided for the latest released version.
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities privately via GitHub Security Advisories
-(<https://github.com/swiftyapp/swifty/security/advisories/new>) or by email to
-**security@getswifty.pro**.
+**Please report privately. Do not open a public issue, PR, or discussion for a
+security problem.**
 
-Do not open a public issue for security reports. We aim to acknowledge reports
-within 72 hours and to provide a remediation timeline after triage. Please
-include steps to reproduce and, where possible, the affected version and
-platform.
+Preferred channel — GitHub private security advisories:
+
+1. Go to <https://github.com/swiftyapp/swifty/security/advisories/new>.
+2. Describe the issue, the affected version and platform (macOS / Windows /
+   Linux), and steps to reproduce. A proof of concept helps.
+3. We triage from there and, if needed, invite you into the advisory thread.
+
+If you cannot use GitHub advisories, email the maintainers at
+`<SECURITY_CONTACT_EMAIL>`.
+
+> **Maintainer note:** replace `<SECURITY_CONTACT_EMAIL>` with a monitored
+> security address before publishing this file.
+
+What to include:
+
+- The affected version (see the About screen) and OS.
+- A clear description of the impact and how to reproduce it.
+- Any relevant logs, but redact your own vault contents and secrets.
+
+## Response and Disclosure
+
+- **Acknowledgement:** within 72 hours of a report.
+- **Triage and initial assessment:** within 7 days, including a severity call and
+  a rough remediation timeline.
+- **Fix and release:** as fast as the severity warrants; critical issues are
+  prioritized over other work.
+- **Coordinated disclosure:** we ask that you give us a reasonable window
+  (up to 90 days) to ship a fix before any public write-up. We are happy to
+  coordinate timing and to credit you in the advisory unless you prefer to stay
+  anonymous.
+
+## Scope
+
+In scope: the desktop app and its Rust core — vault encryption, key derivation
+and lifecycle, the OS keychain / biometric integration, the Tauri command
+surface and capabilities, the webview CSP, and the signed updater.
+
+Out of scope: issues that require an already-compromised operating system,
+physical access to an unlocked device, malware running with the user's
+privileges, or social-engineering of the device owner. These are covered in
+[`docs/threat-model.md`](docs/threat-model.md), which describes what Swifty does
+and does not defend against.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,120 @@
+# Swifty Threat Model
+
+This describes what Swifty protects, what it deliberately does not, and how the
+master key moves through the app. It reflects the code in `v1-0-0`; where the
+current implementation differs from the planned design, that is called out.
+
+## Architecture in one paragraph
+
+Swifty is a Tauri 2 desktop app: a trusted Rust core plus a system-webview
+frontend (React/TypeScript). All cryptography and key handling live in Rust. The
+webview never sees the master key; it talks to the core through a fixed,
+enumerated list of commands and receives decrypted data only for display. The
+vault is a single file stored locally under the OS app-data directory. There is
+no account server and no backend that holds user secrets.
+
+## What sits on disk
+
+The whole vault serializes to JSON and is sealed as one AES-256-GCM (AEAD) blob,
+written to `vault.swftx`. So at rest, everything — including metadata like titles
+and tags — is ciphertext. On top of the whole-file encryption, the individually
+sensitive fields (login password, OTP secret, secure-note body, card PIN) are
+each encrypted as their own AEAD value, so they stay ciphertext even inside the
+in-memory vault and are decrypted only when the user reveals or copies one
+(decrypt-on-reveal).
+
+The vault key is derived from the master passphrase with **PBKDF2-HMAC-SHA512
+(100,000 iterations)** via `ring`. A per-value 64-byte salt and 16-byte nonce are
+used per field. See `src-tauri/src/crypto/mod.rs`.
+
+> **Planned, not yet shipped (honest gaps):**
+> - **KDF.** PBKDF2 at 100k iterations is below current OWASP guidance
+>   (~210k for PBKDF2-HMAC-SHA512), and the passphrase is pre-hashed with SHA-512
+>   for legacy byte-compatibility, which adds no strength. Argon2id with stored
+>   params is planned (remediation Phase 2) but is not in `v1-0-0`.
+> - **Storage engine.** A SQLite + **SQLCipher** backend
+>   (`src-tauri/src/store/`, `rusqlite` with `bundled-sqlcipher`) is implemented
+>   and tested in-tree but is **not yet wired into the live vault path**. When it
+>   ships, metadata columns become queryable and are encrypted at rest by
+>   SQLCipher while secret fields stay app-AEAD; writes become per-row and atomic
+>   (WAL). Today `v1-0-0` still uses the single JSON blob above, written with a
+>   non-atomic `fs::write`.
+> - **Attempt throttling.** There is no failed-unlock backoff yet, so offline
+>   guessing against a stolen vault is bounded only by the KDF cost.
+> - **Windows file ACLs.** The on-disk file/dir modes are tightened on Unix
+>   (`0600`/`0700`); the Windows ACL equivalent is still a TODO.
+
+## Key lifecycle across the process split
+
+1. **Derive on unlock.** The user enters the master passphrase in the webview. It
+   is passed once to the Rust core, which derives the key material. The passphrase
+   is not stored.
+2. **Hold in Rust only.** The derived key lives in the Rust session
+   (`state.rs`, `Session.master_key`) wrapped in a zeroizing buffer. It never
+   crosses back to the webview. On unlock the webview receives vault metadata plus
+   the ciphertext of secret fields; a secret is decrypted and returned to the
+   webview only on an explicit `reveal_entry` (view/copy).
+3. **Zeroize on lock.** The key buffer is scrubbed from the heap (`zeroize`) when
+   it is dropped or replaced, and on lock. Locking happens three ways: an explicit
+   Lock action, a **60-second inactivity auto-lock** (armed when the window loses
+   focus, cancelled when it regains focus — `autolock.rs`), and on app exit.
+4. **Optional biometric unlock (opt-in).** Instead of the in-session key, the key
+   material can be stored in the OS keychain behind a biometric gate:
+   - **macOS:** a data-protection Keychain item with a `SecAccessControl` of
+     `kSecAccessControlBiometryCurrentSet`. Touch ID is enforced by the OS on
+     *read*, and the item auto-invalidates if the enrolled fingerprints change.
+   - **Windows:** Credential Manager, with a Windows Hello prompt required before
+     the read (verify-then-read).
+   - **Linux and others:** unsupported; the app reports biometrics unavailable
+     rather than store an ungated key.
+
+## What Swifty defends against
+
+- **Device theft / a lost or stolen laptop.** The vault is a local encrypted
+  file. Without the master passphrase (or a biometric unlock on that specific
+  enrolled device) the contents are unreadable. The key is never persisted in
+  plaintext, and auto-lock limits how long an unlocked session stays open.
+- **Cloud-provider or sync compromise.** Sync is optional and, in `v1-0-0`,
+  disabled. When enabled it uploads only the already-encrypted vault blob to the
+  user's own Google Drive; the master passphrase and derived key never leave the
+  device. A compromised Drive account or a tapped sync channel yields ciphertext,
+  not secrets.
+- **Remote server breach.** There is nothing central to breach. Swifty is
+  offline-first with no account server, no telemetry, and no phone-home. The only
+  outbound request at launch is the signed updater check to GitHub Releases.
+- **Passive at-rest access and backups.** Because the on-disk vault is an AEAD
+  blob, file-level backups (Time Machine, disk images, cloud file backups) carry
+  only ciphertext.
+- **A tampered update.** Updater artifacts are minisign-signed; an unsigned or
+  modified artifact is rejected. (Caveat: installation is currently silent on
+  launch, without a consent prompt — a UX/trust gap that is tracked. The
+  signature check is still enforced.)
+
+## What Swifty explicitly does NOT defend against
+
+- **A compromised operating system.** Code running as the user — malware, a
+  malicious app with the same privileges, an attacker at local root — can read
+  process memory while the vault is unlocked, tamper with the binary, or inject
+  into the webview. Swifty cannot protect secrets from the platform it runs on.
+- **Keyloggers and screen capture.** The master passphrase (as typed) and any
+  revealed secret (as displayed) can be captured by such tools.
+- **A coerced or observed unlock.** If the user is compelled to unlock, or a
+  biometric is used under duress, the vault opens. Biometric unlock trades some
+  resistance here for convenience: anyone who can pass the OS biometric gate on
+  that device can unlock.
+- **A known master passphrase.** The passphrase is the single root of trust.
+  Whoever knows it can decrypt the vault; there is no second factor on the
+  encryption itself.
+- **The clipboard window.** Copied secrets go to the system clipboard. Swifty
+  marks them as concealed and auto-clears after a timeout, but other apps can read
+  the clipboard during that window.
+- **Physical memory attacks.** Cold-boot or DMA attacks against an unlocked
+  session are out of scope.
+
+## Summary
+
+Swifty's security rests on a locally encrypted vault, a key that is derived on
+unlock, held only in the Rust process, and zeroized on lock, and the absence of
+any server that could be breached. It assumes the user's device and operating
+system are trustworthy while the vault is unlocked. It does not try to defend a
+device that is already compromised.

--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -207,10 +207,10 @@ on Phase 1.
 ### T-CI-4 · Build attestation & reproducibility  🟡 (C6, T22)
 **Evidence:** signing exists (notarization + Windows cert + minisign updater) but no provenance. **Steps:** add `actions/attest-build-provenance` (OIDC/SLSA) to `release.yml`; add CycloneDX SBOM to release assets; pin `rust-toolchain.toml` + the bun version; document verification in the README. **Acceptance:** releases carry provenance + SBOM; a documented verify procedure exists.
 
-### T-DOC-1 · SECURITY.md  ❌ (T23)
+### T-DOC-1 · SECURITY.md  ✅ (PR) (T23)
 Supported versions, contact, response-time SLA, disclosure policy. **Acceptance:** file present, non-template.
 
-### T-DOC-2 · Threat model  ❌ (T24)
+### T-DOC-2 · Threat model  ✅ (PR) (T24)
 One page: defends against device theft / cloud-provider compromise / remote breach; explicitly **not** compromised OS / keylogger / local root; key lifecycle across the Tauri process split. **Acceptance:** published under `docs/`.
 
 ---


### PR DESCRIPTION
Implements **T-DOC-1** and **T-DOC-2** from `docs/v1-remediation.md` Phase 8. Docs only — no code, no workflow changes.

## What's here
- **`SECURITY.md`** (rewritten, non-template): supported versions, private reporting via **GitHub Security Advisories** as the primary channel, response/disclosure SLA (72h ack, 7-day triage, up-to-90-day coordinated disclosure), and a scope section pointing at the threat model.
- **`docs/threat-model.md`** (new, ~one page): architecture across the Tauri Rust/webview split; on-disk model; the key lifecycle (derived on unlock, held only in Rust, never crosses to the webview, zeroized on lock / 60s auto-lock / exit; opt-in biometric via OS keychain); what Swifty defends against (device theft, cloud/sync compromise, remote breach, at-rest backups, tampered updates) and what it explicitly does not (compromised OS, keylogger, local root, coerced/observed unlock, known passphrase, clipboard window, cold-boot).
- **`README.md`**: short Security section linking both docs.
- **`docs/v1-remediation.md`**: flipped only the T-DOC-1 and T-DOC-2 status lines to ✅ (PR).

## ⚠️ Owner must fill: `<SECURITY_CONTACT_EMAIL>`
SECURITY.md uses GitHub advisories as the primary channel and a clearly-marked `<SECURITY_CONTACT_EMAIL>` placeholder for the email fallback (with an inline maintainer note). I did not invent an address. Note: the previous SECURITY.md on `v1-0-0` used `security@getswifty.pro` — restore that (or another monitored address) if it is correct.

## Honesty / current-gap callouts documented in the threat model
Written to match the code actually on `v1-0-0`, not the checklist's target state:
- **Storage engine:** the SQLite + **SQLCipher** engine (`src-tauri/src/store/`, `rusqlite bundled-sqlcipher`) is compiled and unit-tested but **not yet wired into the live vault path** (`pub mod store;` is declared but never referenced by any command). `v1-0-0` still ships the **single encrypted JSON blob** (`vault.swftx`) written via a non-atomic `fs::write` (`storage.rs`). The whole vault is one AES-256-GCM blob, so metadata is encrypted at rest today — but it is not the SQLCipher/queryable-column model the checklist described. The doc states both the shipped reality and the planned design.
- **KDF:** PBKDF2-HMAC-SHA512 @ 100k (below OWASP ~210k) plus a non-strengthening SHA-512 pre-hash; Argon2id planned, not shipped (no `argon2` dep in `Cargo.toml`).
- **Updater:** minisign-signed but installs **silently on launch**, no consent prompt (T-SEC-4 still 🟡).
- **No failed-unlock backoff** (T-AUTH-3 open); **Windows file ACLs** not yet tightened (`set_mode` is a Unix-only no-op elsewhere).

Verified as accurate: strict CSP present in `tauri.conf.json` (not `null`); opener capability scoped to http/https; key zeroization via `zeroize::Zeroizing` on `master_key`/`Cryptor::secret`; 60s inactivity auto-lock; biometric keychain gating (macOS `BIOMETRY_CURRENT_SET` OS-enforced-on-read, Windows Hello verify-then-read, Linux unsupported); sync `ENABLED = false`; no telemetry.
