### PR TITLE
fix: Linux dead-code in secure_store (unbreaks ubuntu CI)

### DIFF
--- a/src-tauri/src/secure_store.rs
+++ b/src-tauri/src/secure_store.rs
@@ -17,7 +17,11 @@ use crate::error::{Error, Result};
 use crate::models::VaultData;
 use zeroize::Zeroizing;
 
+// Used only by the macOS/Windows key-store impls; absent on the unsupported
+// fallback (Linux), so gate them to avoid a dead_code error there.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 const SERVICE: &str = "pro.getswifty.app.vault";
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 const ACCOUNT: &str = "master-key";
 
 /// Abstraction over the platform key store so the non-interactive unlock logic


### PR DESCRIPTION
The merged biometric PR (#241) failed the Rust (ubuntu-latest) CI job: SERVICE/ACCOUNT consts are used by the macOS/Windows key-store impls but dead on the Linux fallback, tripping clippy -D warnings. Gated them to macos+windows. macOS clippy verified clean; windows/macos CI already passed (they use the consts).