### PR TITLE
crypto: Argon2id KDF primitive + versioned descriptor (T-KDF-1, primitive)

### DIFF
--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -112,6 +112,7 @@ change, not an on-disk-format break. **Never break legacy-vault decrypt** (golde
 2. Feed the password directly to the KDF for new DBs — drop `hash_secret` (legacy JSON decrypt keeps it during T-STORE-2 migration only).
 3. Derive the app payload key and the SQLCipher key as separate subkeys of the Argon2id output (HKDF), so one KDF pass yields both.
 **Acceptance:** new DBs use Argon2id per `meta`; migrated legacy vaults still open; cross-impl/golden suites green; a KDF-params round-trip test exists.
+> **Progress (primitive done):** The self-contained KDF primitive lands in the `crypto: Argon2id KDF primitive` PR — `crypto/kdf.rs` with the versioned `KdfParams` descriptor (`argo`/`m_cost`/`t_cost`/`p_cost`/`iterations`/`salt`, JSON string for `meta`), `derive()` dispatch (Argon2id default `m=64MiB, t=3, p=4` / PBKDF2-SHA512 fallback), a fresh-salt generator, and in-module tests (determinism, serde round-trip, dispatch, Argon2id KAT). Legacy PBKDF2 `Cryptor` + golden/crosscheck harness untouched. **Wiring is pending** and is a follow-up after the storage rework (#246) lands: persist `KdfParams` in `meta` at setup, read it at unlock, feed the master password directly to `derive()`, and HKDF-split the output into the SQLCipher + payload subkeys. This task stays ❌ until that wiring ships.
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -142,6 +142,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3102,6 +3129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4259,7 @@ name = "swifty"
 version = "1.0.0"
 dependencies = [
  "aes-gcm",
+ "argon2",
  "base64 0.22.1",
  "block2",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "for
 rustls = { version = "0.23", default-features = false, features = ["ring", "tls12"] }
 url = "2"
 zeroize = "1.8.2"
+argon2 = "0.5.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/crypto/kdf.rs
+++ b/src-tauri/src/crypto/kdf.rs
@@ -1,0 +1,314 @@
+//! Versioned key-derivation primitive.
+//!
+//! A [`KdfParams`] descriptor names the algorithm and its parameters and is
+//! meant to be stored (as a JSON string) alongside a vault — e.g. in the
+//! store's `meta` table — so a derivation can be reproduced from what was
+//! persisted. [`derive`] dispatches on that descriptor.
+//!
+//! Two algorithms are supported:
+//! - **Argon2id** — the default for new vaults (memory-hard, OWASP-reasonable).
+//! - **PBKDF2-HMAC-SHA512** — a configurable fallback and the shape the legacy
+//!   `.swftx` vaults derive with. The byte-compatible *legacy* read path lives
+//!   in [`super::Cryptor`] and is untouched by this module.
+//!
+//! This is a self-contained primitive: it turns password bytes into ≥32 bytes
+//! of key material suitable as HKDF input. Splitting that output into the
+//! SQLCipher and payload subkeys (HKDF) is done by the store integration, not
+//! here. Callers own the choice of what `password` bytes to feed: for Argon2id,
+//! feed the master password **directly** (no `hash_secret` pre-hash); the
+//! `base64(SHA512(pw))` pre-hash survives only on the legacy `Cryptor` path.
+
+use argon2::{Algorithm, Argon2, Params as Argon2Params, Version};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU32;
+use zeroize::Zeroizing;
+
+use crate::error::{Error, Result};
+
+/// Derived key length in bytes. 32 bytes is a valid HKDF input keying material
+/// length; the store's HKDF step expands it into the SQLCipher + payload subkeys.
+pub const KEY_LEN: usize = 32;
+
+/// Salt length in bytes for freshly generated params. 16 bytes is the Argon2
+/// minimum/recommended salt size; we use 32 for headroom.
+pub const SALT_LEN: usize = 32;
+
+// Default Argon2id cost parameters (OWASP-reasonable, 2024). Tunable: raise as
+// hardware improves. `m_cost` is in KiB, so 65536 KiB = 64 MiB.
+pub const DEFAULT_M_COST: u32 = 65_536; // 64 MiB
+pub const DEFAULT_T_COST: u32 = 3; // iterations (time cost)
+pub const DEFAULT_P_COST: u32 = 4; // parallelism (lanes)
+
+fn err<E: std::fmt::Display>(e: E) -> Error {
+    Error::Crypto(e.to_string())
+}
+
+/// A self-describing KDF descriptor. Serializes to a compact JSON object tagged
+/// by `algo`, e.g.
+/// `{"algo":"argon2id","m_cost":65536,"t_cost":3,"p_cost":4,"salt":"<base64>"}`
+/// or `{"algo":"pbkdf2-sha512","iterations":100000,"salt":"<base64>"}`.
+///
+/// The `salt` is stored as standard base64. Store the whole thing as a string
+/// in the vault's metadata; [`derive`] reproduces the key from it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "algo")]
+pub enum KdfParams {
+    /// Memory-hard Argon2id. Costs: `m_cost` in KiB, `t_cost` passes,
+    /// `p_cost` lanes.
+    #[serde(rename = "argon2id")]
+    Argon2id {
+        m_cost: u32,
+        t_cost: u32,
+        p_cost: u32,
+        /// base64(salt).
+        salt: String,
+    },
+    /// PBKDF2-HMAC-SHA512 fallback / legacy shape.
+    #[serde(rename = "pbkdf2-sha512")]
+    Pbkdf2Sha512 {
+        iterations: u32,
+        /// base64(salt).
+        salt: String,
+    },
+}
+
+impl KdfParams {
+    /// Default Argon2id params (`m=64MiB, t=3, p=4`) with a **fresh random
+    /// salt** — the descriptor to persist for a brand-new vault.
+    pub fn default_argon2id() -> Self {
+        Self::argon2id(
+            &random_salt(),
+            DEFAULT_M_COST,
+            DEFAULT_T_COST,
+            DEFAULT_P_COST,
+        )
+    }
+
+    /// Build Argon2id params from an explicit salt and costs (used by tests and
+    /// callers that must reproduce a specific derivation).
+    pub fn argon2id(salt: &[u8], m_cost: u32, t_cost: u32, p_cost: u32) -> Self {
+        Self::Argon2id {
+            m_cost,
+            t_cost,
+            p_cost,
+            salt: STANDARD.encode(salt),
+        }
+    }
+
+    /// Build PBKDF2-HMAC-SHA512 params from an explicit salt and iteration count.
+    pub fn pbkdf2_sha512(salt: &[u8], iterations: u32) -> Self {
+        Self::Pbkdf2Sha512 {
+            iterations,
+            salt: STANDARD.encode(salt),
+        }
+    }
+
+    /// The `algo` tag as stored (`"argon2id"` / `"pbkdf2-sha512"`).
+    pub fn algo(&self) -> &'static str {
+        match self {
+            Self::Argon2id { .. } => "argon2id",
+            Self::Pbkdf2Sha512 { .. } => "pbkdf2-sha512",
+        }
+    }
+
+    /// Serialize to a compact JSON string suitable for the `meta` table.
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    /// Parse from the JSON string produced by [`to_json`](Self::to_json).
+    pub fn from_json(s: &str) -> Result<Self> {
+        Ok(serde_json::from_str(s)?)
+    }
+
+    fn decoded_salt(salt: &str) -> Result<Vec<u8>> {
+        STANDARD.decode(salt).map_err(err)
+    }
+}
+
+/// Generate `SALT_LEN` cryptographically-random bytes.
+pub fn random_salt() -> Vec<u8> {
+    let mut salt = vec![0u8; SALT_LEN];
+    rand::thread_rng().fill_bytes(&mut salt);
+    salt
+}
+
+/// Derive `KEY_LEN` bytes of key material from `password` per `params`.
+///
+/// The output is zeroized on drop. `password` is treated as opaque input bytes:
+/// callers feed the master password directly for Argon2id.
+pub fn derive(password: &[u8], params: &KdfParams) -> Result<Zeroizing<Vec<u8>>> {
+    let mut out = Zeroizing::new(vec![0u8; KEY_LEN]);
+    match params {
+        KdfParams::Argon2id {
+            m_cost,
+            t_cost,
+            p_cost,
+            salt,
+        } => {
+            let salt = KdfParams::decoded_salt(salt)?;
+            let params =
+                Argon2Params::new(*m_cost, *t_cost, *p_cost, Some(KEY_LEN)).map_err(err)?;
+            let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+            argon
+                .hash_password_into(password, &salt, &mut out)
+                .map_err(err)?;
+        }
+        KdfParams::Pbkdf2Sha512 { iterations, salt } => {
+            let salt = KdfParams::decoded_salt(salt)?;
+            let iters = NonZeroU32::new(*iterations)
+                .ok_or_else(|| Error::Crypto("pbkdf2 iterations must be > 0".into()))?;
+            // Matches the legacy Cryptor's PBKDF2-HMAC-SHA512, so a fallback
+            // descriptor reproduces the same key path (minus the pre-hash,
+            // which is the caller's choice of `password` bytes).
+            ring::pbkdf2::derive(
+                ring::pbkdf2::PBKDF2_HMAC_SHA512,
+                iters,
+                &salt,
+                password,
+                &mut out,
+            );
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SALT_A: &[u8] = b"0123456789abcdef0123456789abcdef";
+    const SALT_B: &[u8] = b"fedcba9876543210fedcba9876543210";
+
+    fn argon(salt: &[u8]) -> KdfParams {
+        // Low cost so the test suite stays fast; production uses the defaults.
+        KdfParams::argon2id(salt, 256, 1, 1)
+    }
+
+    #[test]
+    fn argon2id_is_deterministic() {
+        let p = argon(SALT_A);
+        let a = derive(b"correct horse", &p).unwrap();
+        let b = derive(b"correct horse", &p).unwrap();
+        assert_eq!(&*a, &*b);
+        assert_eq!(a.len(), KEY_LEN);
+    }
+
+    #[test]
+    fn argon2id_salt_changes_key() {
+        let a = derive(b"pw", &argon(SALT_A)).unwrap();
+        let b = derive(b"pw", &argon(SALT_B)).unwrap();
+        assert_ne!(&*a, &*b);
+    }
+
+    #[test]
+    fn argon2id_password_changes_key() {
+        let p = argon(SALT_A);
+        let a = derive(b"pw-one", &p).unwrap();
+        let b = derive(b"pw-two", &p).unwrap();
+        assert_ne!(&*a, &*b);
+    }
+
+    #[test]
+    fn argon2id_cost_change_changes_key() {
+        let a = derive(b"pw", &KdfParams::argon2id(SALT_A, 256, 1, 1)).unwrap();
+        let b = derive(b"pw", &KdfParams::argon2id(SALT_A, 256, 2, 1)).unwrap();
+        assert_ne!(&*a, &*b, "changing t_cost must change the derived key");
+    }
+
+    #[test]
+    fn pbkdf2_is_deterministic() {
+        let p = KdfParams::pbkdf2_sha512(SALT_A, 1000);
+        let a = derive(b"pw", &p).unwrap();
+        let b = derive(b"pw", &p).unwrap();
+        assert_eq!(&*a, &*b);
+        assert_eq!(a.len(), KEY_LEN);
+    }
+
+    #[test]
+    fn pbkdf2_iterations_change_key() {
+        let a = derive(b"pw", &KdfParams::pbkdf2_sha512(SALT_A, 1000)).unwrap();
+        let b = derive(b"pw", &KdfParams::pbkdf2_sha512(SALT_A, 2000)).unwrap();
+        assert_ne!(&*a, &*b);
+    }
+
+    #[test]
+    fn dispatch_distinguishes_algos() {
+        // Same password + same salt, different algorithm → different key.
+        let argon = derive(b"pw", &KdfParams::argon2id(SALT_A, 256, 1, 1)).unwrap();
+        let pbkdf2 = derive(b"pw", &KdfParams::pbkdf2_sha512(SALT_A, 1000)).unwrap();
+        assert_ne!(&*argon, &*pbkdf2);
+    }
+
+    #[test]
+    fn serde_round_trip_argon2id() {
+        let p = KdfParams::argon2id(SALT_A, DEFAULT_M_COST, DEFAULT_T_COST, DEFAULT_P_COST);
+        let json = p.to_json().unwrap();
+        assert!(json.contains("\"algo\":\"argon2id\""));
+        let back = KdfParams::from_json(&json).unwrap();
+        assert_eq!(p, back);
+        // The reconstructed descriptor derives the same key.
+        assert_eq!(
+            &*derive(b"pw", &p).unwrap(),
+            &*derive(b"pw", &back).unwrap()
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_pbkdf2() {
+        let p = KdfParams::pbkdf2_sha512(SALT_A, 100_000);
+        let json = p.to_json().unwrap();
+        assert!(json.contains("\"algo\":\"pbkdf2-sha512\""));
+        let back = KdfParams::from_json(&json).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn default_argon2id_uses_owasp_params_and_fresh_salt() {
+        let a = KdfParams::default_argon2id();
+        let b = KdfParams::default_argon2id();
+        match (&a, &b) {
+            (
+                KdfParams::Argon2id {
+                    m_cost,
+                    t_cost,
+                    p_cost,
+                    salt: salt_a,
+                },
+                KdfParams::Argon2id { salt: salt_b, .. },
+            ) => {
+                assert_eq!((*m_cost, *t_cost, *p_cost), (65_536, 3, 4));
+                assert_ne!(salt_a, salt_b, "each call must generate a fresh salt");
+            }
+            _ => panic!("default_argon2id must be Argon2id"),
+        }
+    }
+
+    #[test]
+    fn random_salt_has_expected_len_and_varies() {
+        let a = random_salt();
+        let b = random_salt();
+        assert_eq!(a.len(), SALT_LEN);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn algo_tag() {
+        assert_eq!(KdfParams::default_argon2id().algo(), "argon2id");
+        assert_eq!(KdfParams::pbkdf2_sha512(SALT_A, 1).algo(), "pbkdf2-sha512");
+    }
+
+    // Known-answer vector for Argon2id (RustCrypto `argon2` v0.5, Version::V0x13).
+    // Pins output length 32 with the low-cost params above so a crate/param/
+    // version regression is caught. Salt = SALT_A ("0123...").
+    #[test]
+    fn argon2id_known_answer() {
+        let key = derive(b"password", &KdfParams::argon2id(SALT_A, 256, 1, 1)).unwrap();
+        assert_eq!(hex::encode(&*key), KNOWN_ARGON2ID_HEX);
+    }
+
+    const KNOWN_ARGON2ID_HEX: &str =
+        "5e08debc30c12c81d0d281980d6e5b29afead8f827714dd1d239f45996d415cb";
+}

--- a/src-tauri/src/crypto/mod.rs
+++ b/src-tauri/src/crypto/mod.rs
@@ -16,6 +16,9 @@ use zeroize::Zeroizing;
 use crate::error::{Error, Result};
 use crate::models::Entry;
 
+pub mod kdf;
+pub use kdf::{derive, KdfParams};
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
## What

The **self-contained primitive half of T-KDF-1** (Phase 2, `docs/v1-remediation.md`): a versioned Argon2id key-derivation primitive, built as a standalone tested module. **No wiring** into `setup`/`unlock`/`open_and_load`/the store — that is a small follow-up after the storage rework (#246) lands (mirrors how the storage module was built first as a clean primitive).

## Descriptor format (`KdfParams`)

A serde enum tagged by `algo`, serialized to a compact JSON string suitable for the store's `meta` table:

```json
{"algo":"argon2id","m_cost":65536,"t_cost":3,"p_cost":4,"salt":"<base64>"}
{"algo":"pbkdf2-sha512","iterations":100000,"salt":"<base64>"}
```

`m_cost` is in KiB (65536 = 64 MiB); `salt` is standard base64. `KdfParams::to_json()` / `from_json()` round-trip it. `derive(password: &[u8], params) -> Zeroizing<Vec<u8>>` dispatches on `algo` and returns 32 bytes of key material (valid HKDF input; the HKDF split into SQLCipher + payload subkeys stays in the store integration, not here).

## Default Argon2id params

`KdfParams::default_argon2id()` → **Argon2id, m=64 MiB, t=3, p=4** (OWASP-reasonable, commented as tunable) with a fresh random 32-byte salt. `random_salt()` is the salt generator. The Argon2id path feeds the master password **directly** — the pointless `hash_secret` = `base64(SHA512(pw))` pre-hash is dropped here.

## Why legacy PBKDF2 stays

The existing `Cryptor` (PBKDF2-HMAC-SHA512 @ 100k + `hash_secret` pre-hash) and the byte-compat golden/crosscheck harness are **untouched** — legacy `.swftx` vaults must keep decrypting. Argon2id is **additive**, for new vaults. The `pbkdf2-sha512` descriptor variant exists as a configurable fallback / to reproduce the legacy key shape from a stored descriptor.

## Tests

In-module (`crypto/kdf.rs`): Argon2id determinism, salt/password/cost sensitivity (t_cost change flips the key), PBKDF2 determinism + iteration sensitivity, algo dispatch (argon2id vs pbkdf2 differ on same input), `KdfParams` serde round-trips for both algos, `default_argon2id` param + fresh-salt checks, and an Argon2id known-answer vector pinning the RustCrypto `argon2` v0.5 / V0x13 output.

Gate (in `src-tauri`, toolchain pinned 1.90.0): `cargo fmt --check` clean, `cargo clippy --all-targets` 0 warnings, `cargo test --locked` **65 passed**. Node crosscheck: **13 checks passed**. Legacy golden suite untouched and green.

## Follow-up wiring (after #246)

Not in this PR: at setup, generate `KdfParams::default_argon2id()`, persist its JSON in `meta`; at unlock, read the descriptor, call `derive(master_password, &params)`, then HKDF-split the output into the SQLCipher key + payload key. Only then does T-KDF-1 flip to ✅ (this PR leaves it ❌ with a progress sub-note).