### PR TITLE
ci(codeql): ignore test code for hard-coded-value queries

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "Swifty CodeQL config"
+
+# Test code intentionally embeds hard-coded fixtures (passwords, salts, keys) to
+# exercise the crypto/store code. Exclude tests so the "Hard-coded cryptographic
+# value" query — which we KEEP for production, where a real hard-coded key should
+# fail the build — doesn't flag fixtures on every test change.
+paths-ignore:
+  - '**/tests.rs'
+  - 'src/test'
+  - '**/*.test.ts'
+  - '**/*.test.tsx'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Every test change was adding new CodeQL 'Hard-coded cryptographic value' alerts for unit-test fixtures (test passwords/salts/keys) — e.g. #22-23,44-47 on #246 and #24-43 on #248, all dismissed as test fixtures. This adds a CodeQL config (`paths-ignore` for `**/tests.rs`, `src/test`, `*.test.ts(x)`) so the query stays enforced on **production** code (a genuine hard-coded key still fails the build) without recurring fixture noise. Inline `#[cfg(test)]` modules in production files (rare) still need per-alert dismissal.