### PR TITLE
docs: refresh SECURITY.md + threat model to SQLite/SQLCipher + Argon2id

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@
 - Time-based One Time Passwords support (TOTP)
 - Google Drive Sync (optional)
 - No data is leaving your computer:
-  - Everything is encrypted, stored and decrypted on your local file system
-  - Decryption happens once on entering Master Password
+  - Your vault is a locally stored, encrypted SQLite database (SQLCipher); each
+    entry's secrets are sealed in an extra application-level AEAD layer
+  - Secrets stay encrypted at rest and in memory, decrypted only when you reveal
+    or copy them
   - Ability to migrate from one computer to another using backup file or GDrive sync
 - There's more to come...
 
@@ -130,8 +132,10 @@ is provided to CI via the `TAURI_SIGNING_PRIVATE_KEY` (and
 
 ## Security
 
-Swifty is offline-first: your vault is an encrypted file on your own device and
-there is no backend that holds your secrets. See [`SECURITY.md`](SECURITY.md) for
+Swifty is offline-first: your vault is an encrypted SQLite database (SQLCipher)
+on your own device, with each entry's secrets sealed in an additional
+application-level AEAD layer, and there is no backend that holds your secrets.
+See [`SECURITY.md`](SECURITY.md) for
 how to report a vulnerability, and [`docs/threat-model.md`](docs/threat-model.md)
 for what Swifty does and does not defend against.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security Policy
 
 Swifty is an offline-first password manager. Your vault lives on your own device
-as an encrypted file, and the app has no backend that holds your secrets. We take
-reports about the encryption, key handling, update channel, and platform
-integration seriously.
+as an encrypted SQLite database (SQLCipher), with each entry's secrets sealed in
+an additional application-level AEAD layer, and the app has no backend that holds
+your secrets. We take reports about the encryption, key derivation and handling,
+update channel, and platform integration seriously.
 
 ## Supported Versions
 
@@ -28,10 +29,7 @@ Preferred channel — GitHub private security advisories:
 3. We triage from there and, if needed, invite you into the advisory thread.
 
 If you cannot use GitHub advisories, email the maintainers at
-`<SECURITY_CONTACT_EMAIL>`.
-
-> **Maintainer note:** replace `<SECURITY_CONTACT_EMAIL>` with a monitored
-> security address before publishing this file.
+`security@getswifty.pro`.
 
 What to include:
 
@@ -53,8 +51,9 @@ What to include:
 
 ## Scope
 
-In scope: the desktop app and its Rust core — vault encryption, key derivation
-and lifecycle, the OS keychain / biometric integration, the Tauri command
+In scope: the desktop app and its Rust core — the SQLCipher at-rest encryption
+and the per-entry application AEAD layer, key derivation and lifecycle, the
+`.swftx` import path, the OS keychain / biometric integration, the Tauri command
 surface and capabilities, the webview CSP, and the signed updater.
 
 Out of scope: issues that require an already-compromised operating system,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,65 +1,122 @@
 # Swifty Threat Model
 
 This describes what Swifty protects, what it deliberately does not, and how the
-master key moves through the app. It reflects the code in `v1-0-0`; where the
-current implementation differs from the planned design, that is called out.
+master key moves through the app. It reflects the code merged on `v1-0-0`; where
+the current implementation differs from the planned design, that is called out.
 
 ## Architecture in one paragraph
 
 Swifty is a Tauri 2 desktop app: a trusted Rust core plus a system-webview
 frontend (React/TypeScript). All cryptography and key handling live in Rust. The
 webview never sees the master key; it talks to the core through a fixed,
-enumerated list of commands and receives decrypted data only for display. The
-vault is a single file stored locally under the OS app-data directory. There is
-no account server and no backend that holds user secrets.
+enumerated list of commands (`src-tauri/src/lib.rs`) and receives non-secret
+entry metadata for the list plus one decrypted entry at a time on reveal. The
+vault is a locally stored, encrypted SQLite database under the OS app-data
+directory. There is no account server and no backend that holds user secrets. The
+webview is locked down by a strict CSP (`default-src 'self'`, `connect-src
+'self'`, `object-src 'none'`, `frame-src 'none'`, `base-uri 'none'`; see
+`src-tauri/tauri.conf.json`), and external links are opened through the OS only
+for `http`/`https` URLs (`opener:allow-open-url` scope in
+`capabilities/default.json`).
 
 ## What sits on disk
 
-The whole vault serializes to JSON and is sealed as one AES-256-GCM (AEAD) blob,
-written to `vault.swftx`. So at rest, everything — including metadata like titles
-and tags — is ciphertext. On top of the whole-file encryption, the individually
-sensitive fields (login password, OTP secret, secure-note body, card PIN) are
-each encrypted as their own AEAD value, so they stay ciphertext even inside the
-in-memory vault and are decrypted only when the user reveals or copies one
-(decrypt-on-reveal).
+The vault is a **SQLite database sealed with SQLCipher** (`vault.db`,
+`src-tauri/src/store/`, `rusqlite` with `bundled-sqlcipher`). SQLCipher encrypts
+the **entire database file at rest** — page contents, the schema, free pages, and
+the write-ahead log — with AES-256 and per-page authentication. On disk, nothing
+is readable without the database key.
 
-The vault key is derived from the master passphrase with **PBKDF2-HMAC-SHA512
-(100,000 iterations)** via `ring`. A per-value 64-byte salt and 16-byte nonce are
-used per field. See `src-tauri/src/crypto/mod.rs`.
+Inside the decrypted database:
 
-> **Planned, not yet shipped (honest gaps):**
-> - **KDF.** PBKDF2 at 100k iterations is below current OWASP guidance
->   (~210k for PBKDF2-HMAC-SHA512), and the passphrase is pre-hashed with SHA-512
->   for legacy byte-compatibility, which adds no strength. Argon2id with stored
->   params is planned (remediation Phase 2) but is not in `v1-0-0`.
-> - **Storage engine.** A SQLite + **SQLCipher** backend
->   (`src-tauri/src/store/`, `rusqlite` with `bundled-sqlcipher`) is implemented
->   and tested in-tree but is **not yet wired into the live vault path**. When it
->   ships, metadata columns become queryable and are encrypted at rest by
->   SQLCipher while secret fields stay app-AEAD; writes become per-row and atomic
->   (WAL). Today `v1-0-0` still uses the single JSON blob above, written with a
->   non-atomic `fs::write`.
-> - **Attempt throttling.** There is no failed-unlock backoff yet, so offline
->   guessing against a stolen vault is bounded only by the KDF cost.
-> - **Windows file ACLs.** The on-disk file/dir modes are tightened on Unix
->   (`0600`/`0700`); the Windows ACL equivalent is still a TODO.
+- An `entries` table keeps **non-secret metadata in plaintext columns** — `id`,
+  `kind`, `title`, `tags`, `url_host`, `created_at`, `updated_at`, `deleted_at` —
+  so the list and search work without unsealing anything. These columns are
+  protected at rest by SQLCipher, but they are *not* additionally app-encrypted:
+  anyone holding the database key sees them in the clear.
+- Each row also carries an opaque `payload` BLOB. The storage layer never
+  inspects or encrypts it (`src-tauri/src/store/sqlite.rs` documents the payload
+  as caller-owned); the application applies its **own AEAD** on top. The whole
+  entry is serialized to JSON and sealed as AES-256-GCM (base64-wrapped), and
+  each individually sensitive field (login password, OTP secret, secure-note
+  body, card PIN) is **also** sealed as its own AES-256-GCM value nested inside.
+  So a secret stays ciphertext even inside the *decrypted* database and is
+  unsealed only when the user reveals or copies it (**decrypt-on-reveal**,
+  `reveal_entry` in `src-tauri/src/commands/vault.rs`).
+- A small `meta` key/value table holds app data — the KDF descriptor and similar
+  settings — not schema versioning (that rides SQLite's `user_version`).
+
+The practical shape of this two-layer design: an attacker who never obtains the
+key sees only SQLCipher ciphertext for everything. Metadata confidentiality rests
+on SQLCipher alone; secret fields get a second, app-level AEAD layer whose purpose
+is defense-in-depth and decrypt-on-reveal, not hiding metadata from someone who
+already has the database key.
+
+Writes are **per-row and atomic** (WAL mode), not a whole-file rewrite: saving one
+edited entry re-seals only that row's payload. Deletes are **tombstones**
+(`deleted_at` is stamped and the row is retained so a later sync can propagate the
+deletion), not hard deletes. On-disk file and directory modes are tightened on
+Unix (`0600` file / `0700` dir); the Windows ACL equivalent is still a TODO
+(`set_mode` no-ops off Unix in `sqlite.rs`).
+
+### Key derivation (KDF)
+
+From the master password the core derives two keys:
+
+- **The SQLCipher database key** — `HKDF-SHA256` over the session secret with a
+  fixed context salt (`crypto::sqlcipher_key`). SQLCipher opens the file with this
+  raw key; a wrong password derives a wrong key and the open fails verification,
+  which the app surfaces as an invalid password.
+- **The payload key** — `PBKDF2-HMAC-SHA512`, 100,000 iterations, with a per-value
+  random 64-byte salt (the legacy `Cryptor`, `ring`-backed, in
+  `crypto/mod.rs`). This is the key that seals each entry payload and each nested
+  secret field.
+
+Both are derived from the same `secret` = `base64(SHA512(master password))`, a
+pre-hash kept for byte-compatibility with the legacy `.swftx` vault format. The
+KDF descriptor recorded in the `meta` table is currently the placeholder string
+`pbkdf2-sha512-100000`.
+
+> **Shipped vs. in progress (honest KDF status):**
+> - **Argon2id is landed as a primitive, not yet as the live derivation.**
+>   `crypto/kdf.rs` ships a memory-hard **Argon2id** implementation
+>   (`m=64 MiB, t=3, p=4`), a versioned, self-describing `KdfParams` descriptor
+>   (Argon2id or PBKDF2-SHA512, each carrying its salt), a fresh 32-byte random
+>   salt for new params, and a `derive()` dispatcher — all unit-tested, including
+>   a known-answer vector. But `setup`, `unlock`, `change_master_password`, and
+>   the import paths still derive keys through the PBKDF2/HKDF path above; the
+>   `meta` descriptor is a placeholder for the upgrade. Wiring Argon2id into the
+>   live path — and persisting its salt/params where they can be read *before* the
+>   database is opened (a plaintext sidecar, since Argon2 parameters must be known
+>   to derive the key that opens the encrypted DB) — is **in progress**. Once
+>   wired, new vaults derive with Argon2id and PBKDF2 remains only to **read
+>   legacy `.swftx` backups**.
+> - **PBKDF2 strength.** 100,000 iterations of PBKDF2-HMAC-SHA512 is below current
+>   OWASP guidance (~210k), and the `SHA-512` pre-hash adds no strength. This is
+>   precisely why Argon2id is the target primitive.
+> - **Attempt throttling.** There is no failed-unlock backoff, so offline guessing
+>   against a stolen database is bounded only by the KDF cost.
 
 ## Key lifecycle across the process split
 
-1. **Derive on unlock.** The user enters the master passphrase in the webview. It
-   is passed once to the Rust core, which derives the key material. The passphrase
-   is not stored.
-2. **Hold in Rust only.** The derived key lives in the Rust session
-   (`state.rs`, `Session.master_key`) wrapped in a zeroizing buffer. It never
-   crosses back to the webview. On unlock the webview receives vault metadata plus
-   the ciphertext of secret fields; a secret is decrypted and returned to the
-   webview only on an explicit `reveal_entry` (view/copy).
+1. **Derive off the UI thread on unlock.** The user enters the master passphrase
+   in the webview. It is passed once to the Rust core, which derives the key
+   material and opens SQLCipher (which runs its own internal KDF) on a blocking
+   thread (`spawn_blocking` in `commands/auth.rs`), so the UI never stalls. The
+   passphrase itself is not stored.
+2. **Hold in Rust only.** The derived secret lives in the Rust session
+   (`state.rs`, `Session.master_key`) wrapped in a zeroizing buffer, alongside the
+   open encrypted store handle — never a fully decrypted vault. It never crosses
+   back to the webview. The webview receives entry metadata plus, on an explicit
+   `reveal_entry`, one decrypted entry.
 3. **Zeroize on lock.** The key buffer is scrubbed from the heap (`zeroize`) when
-   it is dropped or replaced, and on lock. Locking happens three ways: an explicit
-   Lock action, a **60-second inactivity auto-lock** (armed when the window loses
-   focus, cancelled when it regains focus — `autolock.rs`), and on app exit.
-4. **Optional biometric unlock (opt-in).** Instead of the in-session key, the key
-   material can be stored in the OS keychain behind a biometric gate:
+   it is dropped or replaced, and the store connection is closed. Locking happens
+   several ways: an explicit Lock action, a **60-second inactivity auto-lock**
+   (armed when the window loses focus, cancelled when it regains focus —
+   `autolock.rs`), and on app exit (the session is dropped).
+4. **Optional biometric unlock (opt-in).** Instead of re-entering the passphrase,
+   the same key material can be stored in the OS keychain behind a biometric gate
+   (`secure_store.rs`):
    - **macOS:** a data-protection Keychain item with a `SecAccessControl` of
      `kSecAccessControlBiometryCurrentSet`. Touch ID is enforced by the OS on
      *read*, and the item auto-invalidates if the enrolled fingerprints change.
@@ -68,27 +125,53 @@ used per field. See `src-tauri/src/crypto/mod.rs`.
    - **Linux and others:** unsupported; the app reports biometrics unavailable
      rather than store an ungated key.
 
+## Fresh start and explicit import
+
+`v1-0-0` starts with an **empty SQLite vault**. `is_initialized` is true only when
+the encrypted database exists; a legacy `vault.swftx` file alone does **not**
+count. Nothing is migrated automatically on unlock.
+
+Bringing an old vault forward is an **explicit** action, and there are two paths
+(`commands/vault.rs`):
+
+- **Restore a backup as a new vault** (`import_backup`): decrypt a chosen `.swftx`
+  with its password and create the database from it.
+- **Import into the currently-unlocked vault** (`import_swftx`): the `.swftx` is
+  independently encrypted and carries its own master password. Each entry is
+  decrypted under the backup's key and re-sealed under the current session key,
+  then merged by id. This CPU-bound re-encrypt loop runs **off the UI thread** and
+  emits `import:progress` events so the UI can show progress.
+
+(The one automatic step, `ensure_migrated`, only *relocates* a legacy
+Electron-era `vault.swftx` file into the new Tauri app-data directory; it does not
+convert it into the encrypted database.)
+
 ## What Swifty defends against
 
-- **Device theft / a lost or stolen laptop.** The vault is a local encrypted
-  file. Without the master passphrase (or a biometric unlock on that specific
-  enrolled device) the contents are unreadable. The key is never persisted in
-  plaintext, and auto-lock limits how long an unlocked session stays open.
+- **Device theft / a lost or stolen laptop.** The vault is a local, SQLCipher-
+  encrypted database; each entry's secrets carry an additional app-AEAD layer.
+  Without the master passphrase (or a biometric unlock on that specific enrolled
+  device) the contents are unreadable. The key is never persisted in plaintext,
+  and auto-lock limits how long an unlocked session stays open.
 - **Cloud-provider or sync compromise.** Sync is optional and, in `v1-0-0`,
-  disabled. When enabled it uploads only the already-encrypted vault blob to the
-  user's own Google Drive; the master passphrase and derived key never leave the
-  device. A compromised Drive account or a tapped sync channel yields ciphertext,
-  not secrets.
+  disabled (`sync::ENABLED = false`). When enabled it uploads only the already-
+  encrypted vault blob to the user's own Google Drive; the master passphrase and
+  derived keys never leave the device. A compromised Drive account or a tapped
+  sync channel yields ciphertext, not secrets.
 - **Remote server breach.** There is nothing central to breach. Swifty is
   offline-first with no account server, no telemetry, and no phone-home. The only
-  outbound request at launch is the signed updater check to GitHub Releases.
-- **Passive at-rest access and backups.** Because the on-disk vault is an AEAD
-  blob, file-level backups (Time Machine, disk images, cloud file backups) carry
-  only ciphertext.
-- **A tampered update.** Updater artifacts are minisign-signed; an unsigned or
-  modified artifact is rejected. (Caveat: installation is currently silent on
-  launch, without a consent prompt — a UX/trust gap that is tracked. The
-  signature check is still enforced.)
+  outbound request at launch is the signed updater check to GitHub Releases; Drive
+  sync (when enabled) runs from the Rust core over HTTPS, not from the webview.
+- **Passive at-rest access and backups.** Because the database is SQLCipher-
+  encrypted whole-file, file-level backups (Time Machine, disk images, cloud file
+  backups) carry only ciphertext.
+- **A tampered update.** Updater artifacts are minisign-signed and verified
+  against the public key baked into `src-tauri/tauri.conf.json`; an unsigned or
+  modified artifact is rejected. A signed update is downloaded and **staged** in
+  the background and applied on the next launch — but the app does **not** relaunch
+  silently. It surfaces a restart toast, and the update is applied only when the
+  user consents to restart (or the next time they quit and reopen). This replaces
+  the earlier silent-on-launch install.
 
 ## What Swifty explicitly does NOT defend against
 
@@ -105,6 +188,10 @@ used per field. See `src-tauri/src/crypto/mod.rs`.
 - **A known master passphrase.** The passphrase is the single root of trust.
   Whoever knows it can decrypt the vault; there is no second factor on the
   encryption itself.
+- **Offline brute force at scale.** There is no failed-unlock throttling yet, so a
+  stolen database can be attacked offline, bounded only by the KDF cost. That cost
+  is the PBKDF2 parameters described above until Argon2id is wired into the live
+  path.
 - **The clipboard window.** Copied secrets go to the system clipboard. Swifty
   marks them as concealed and auto-clears after a timeout, but other apps can read
   the clipboard during that window.
@@ -113,8 +200,11 @@ used per field. See `src-tauri/src/crypto/mod.rs`.
 
 ## Summary
 
-Swifty's security rests on a locally encrypted vault, a key that is derived on
+Swifty's security rests on a SQLCipher-encrypted database, a second app-AEAD layer
+that keeps each entry's secrets sealed until reveal, keys that are derived on
 unlock, held only in the Rust process, and zeroized on lock, and the absence of
 any server that could be breached. It assumes the user's device and operating
 system are trustworthy while the vault is unlocked. It does not try to defend a
-device that is already compromised.
+device that is already compromised. The move to Argon2id for live key derivation
+is landing incrementally: the primitive and its versioned descriptor are merged,
+and the live derivation path is being wired over from PBKDF2.


### PR DESCRIPTION
Refreshes the T-DOC-1/2 deliverables to match the merged `v1-0-0` architecture. Docs only — no code, workflows, or config touched.

## What changed

### SECURITY.md
- On-disk description updated to the SQLCipher-encrypted SQLite DB + per-entry application AEAD layer.
- **Security contact restored to `security@getswifty.pro`** (the placeholder `<SECURITY_CONTACT_EMAIL>` + maintainer note are removed).
- Scope section updated to name SQLCipher, the app-AEAD layer, the `.swftx` import path. Supported-versions, disclosure policy, and GitHub private advisories as the primary channel are kept.

### docs/threat-model.md
- **On disk:** SQLCipher whole-file encryption; non-secret metadata in plaintext columns; opaque `payload` BLOB carrying a second app-AEAD layer (whole entry sealed + each sensitive field nested), decrypt-on-reveal; tombstone deletes; per-row atomic WAL writes; Unix `0600/0700` modes with Windows ACL still a TODO.
- **Fresh start + explicit import:** `v1-0-0` starts empty; `.swftx` is never auto-migrated on unlock — `import_backup` (restore as new vault) and `import_swftx` (off-thread, `import:progress`) are the two explicit paths.
- **KDF + key lifecycle:** derived off the UI thread, held only in the Rust session (zeroized on lock), never in the webview; biometric via OS keychain (macOS `SecAccessControl` biometry-on-read / Windows Hello verify-then-read).
- **Updater consent:** staged download + user-consented restart toast (no silent relaunch), minisign-signed.
- Defends-against / explicitly-not sections and honest gap callouts kept.

### README.md
- Security section and the stale "Decryption happens once" feature bullet updated to the SQLCipher + app-AEAD, decrypt-on-reveal model.

## Shipped-vs-in-flight honesty notes
The task brief assumed a `feat/kdf-wiring` PR had made **Argon2id the live derivation**. On `v1-0-0` that is **not** the case, and the docs say so:
- `crypto/kdf.rs` ships the **Argon2id primitive** (`m=64MiB, t=3, p=4`), a versioned self-describing `KdfParams` descriptor, a fresh 32-byte salt, and a `derive()` dispatcher — all unit-tested (incl. a known-answer vector).
- But `setup`/`unlock`/`change_master_password`/import still derive keys via the **PBKDF2-HMAC-SHA512 (100k) + HKDF** path from `base64(SHA512(pw))`; the `meta` KDF descriptor is the placeholder `pbkdf2-sha512-100000` (see the comment in `commands/mod.rs`).
- The docs describe Argon2id as the **target with the primitive landed and live wiring in progress**, and note PBKDF2 will remain only for reading legacy `.swftx`. The "plaintext salt/params sidecar" is likewise described as the planned Argon2id design (needed because Argon2 params must be read before the DB key can be derived), not as shipped.

Also corrected vs. the pre-integration docs: metadata (title/tags/url_host/etc.) is now **plaintext columns protected by SQLCipher only**, not app-AEAD ciphertext — so metadata confidentiality rests on SQLCipher while secret fields get the extra layer. Sync remains disabled (`sync::ENABLED = false`).