### PR TITLE
crypto: wire Argon2id into setup/unlock (finish T-KDF-1)

### DIFF
--- a/docs/v1-remediation.md
+++ b/docs/v1-remediation.md
@@ -105,7 +105,7 @@ entries(
 KDF descriptor + params live in the `meta` table (from T-STORE-1), so upgrading the KDF is a metadata
 change, not an on-disk-format break. **Never break legacy-vault decrypt** (golden harness).
 
-### T-KDF-1 · Argon2id with params in `meta`, drop the pre-hash  ❌ 🔴 (depends on T-STORE-1)
+### T-KDF-1 · Argon2id with params in `meta`, drop the pre-hash  ✅ 🔴 (wired — setup/unlock derive the master via Argon2id from a plaintext `vault.kdf.json` sidecar (salt+params, read before opening), HKDF-split into the SQLCipher key + a per-entry AES-256-GCM payload key; password fed directly to Argon2id (no `hash_secret`); descriptor mirrored into `meta`; sidecar-less dev DBs fall back to the legacy deterministic key; change-password rewrites the sidecar + re-seals + rekeys; `.swftx` reads keep the legacy PBKDF2 `Cryptor` + golden/crosscheck harness)
 **Evidence:** `crypto/mod.rs:28` PBKDF2-SHA512 @ 100k (below OWASP ~210k); `crypto/mod.rs:31-34` `hash_secret` = `base64(SHA512(pw))` adds no entropy and feeds the KDF at every call site.
 **Steps:**
 1. Add Argon2id (`argon2`, ~`m=64MiB, t=3, p=4`) as the default for new/migrated DBs; store `{ kdf, params, salt }` in `meta`. Keep PBKDF2-SHA512 as a configurable fallback.

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use crate::commands::live_records;
-use crate::crypto::Cryptor;
 use crate::error::{Error, Result};
 use crate::hibp;
 use crate::models::{Audit, AuditItem, Entry};
@@ -15,37 +14,35 @@ use zxcvbn::zxcvbn;
 const WEAK_SCORE: u8 = 3;
 
 // Audit every password in the unlocked vault: strength (zxcvbn), reuse, and —
-// when the user opts in — breach exposure (HIBP k-anonymity). Passwords are
-// stored encrypted, so decryption and the network call run off the UI thread.
+// when the user opts in — breach exposure (HIBP k-anonymity). Payloads are
+// encrypted, so unsealing and the network call run off the UI thread.
 #[tauri::command]
 pub async fn get_audit(state: State<'_, AppState>, check_breaches: bool) -> Result<Audit> {
-    // Collect the encrypted payloads under the lock, then unseal + score off the
-    // UI thread (payload unseal and each password decrypt run PBKDF2).
-    let (cryptor, payloads) = {
+    // Collect the sealed payloads under the lock, then unseal + score off the UI
+    // thread with the session payload cipher.
+    let (cipher, payloads) = {
         let s = state.session.lock().unwrap();
         let payloads: Vec<Vec<u8>> = live_records(s.store()?)?
             .into_iter()
             .map(|r| r.payload)
             .collect();
-        (s.cryptor()?, payloads)
+        (s.payload_cipher()?, payloads)
     };
     tauri::async_runtime::spawn_blocking(move || {
         let entries: Vec<Entry> = payloads
             .iter()
-            .map(|p| {
-                let blob = std::str::from_utf8(p).map_err(|e| Error::Crypto(e.to_string()))?;
-                cryptor.decrypt_data(blob)
-            })
+            .map(|p| cipher.unseal(p))
             .collect::<Result<_>>()?;
-        audit(&cryptor, &entries, check_breaches)
+        audit(&entries, check_breaches)
     })
     .await
     .map_err(|e| Error::Crypto(e.to_string()))?
 }
 
-// Decrypt each non-empty password once, then flag weak / reused / breached.
-fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<Audit> {
-    let creds: Vec<(&Entry, String)> = entries
+// Flag each non-empty password as weak / reused / breached. Entries arrive
+// already decrypted (the payload cipher unseals to plaintext).
+fn audit(entries: &[Entry], check_breaches: bool) -> Result<Audit> {
+    let creds: Vec<(&Entry, &str)> = entries
         .iter()
         .filter_map(|e| {
             e.password
@@ -53,10 +50,9 @@ fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<A
                 .filter(|p| !p.is_empty())
                 .map(|p| (e, p))
         })
-        .map(|(e, p)| Ok((e, cryptor.decrypt(p)?)))
-        .collect::<Result<_>>()?;
+        .collect();
 
-    let passwords: Vec<&str> = creds.iter().map(|(_, p)| p.as_str()).collect();
+    let passwords: Vec<&str> = creds.iter().map(|(_, p)| *p).collect();
     let breaches: HashMap<String, bool> = if check_breaches {
         hibp::check_all(&passwords)
     } else {
@@ -66,7 +62,7 @@ fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<A
     Ok(creds
         .iter()
         .map(|(e, p)| {
-            let repeating = passwords.iter().filter(|&&x| x == p).count() > 1;
+            let repeating = passwords.iter().filter(|&&x| x == *p).count() > 1;
             let score = u8::from(zxcvbn(p, &[]).score());
             (
                 e.id.clone(),
@@ -74,7 +70,7 @@ fn audit(cryptor: &Cryptor, entries: &[Entry], check_breaches: bool) -> Result<A
                     score,
                     is_weak: score < WEAK_SCORE,
                     is_repeating: repeating,
-                    breached: breaches.get(p).copied().unwrap_or(false),
+                    breached: breaches.get(*p).copied().unwrap_or(false),
                 },
             )
         })
@@ -90,33 +86,23 @@ mod tests {
         serde_json::from_value(v).unwrap()
     }
 
-    fn cryptor() -> Cryptor {
-        Cryptor::new("audit-test-secret")
-    }
-
-    // Build a login with its password encrypted, as it is on disk.
-    fn login(c: &Cryptor, id: &str, password: &str) -> Entry {
-        c.obscure(&entry(json!({
-            "id": id, "type": "login", "title": "t",
-            "password": password,
-        })))
-        .unwrap()
+    // A plaintext login (payloads unseal to plaintext before audit runs).
+    fn login(id: &str, password: &str) -> Entry {
+        entry(json!({ "id": id, "type": "login", "title": "t", "password": password }))
     }
 
     #[test]
     fn skips_entries_without_password() {
-        let c = cryptor();
         let entries = vec![
             entry(json!({ "id": "n", "type": "note", "title": "t", "note": "x" })),
-            login(&c, "empty", ""),
+            login("empty", ""),
         ];
-        assert!(audit(&c, &entries, false).unwrap().is_empty());
+        assert!(audit(&entries, false).unwrap().is_empty());
     }
 
     #[test]
     fn flags_weak_by_score() {
-        let c = cryptor();
-        let a = audit(&c, &[login(&c, "1", "abc")], false).unwrap();
+        let a = audit(&[login("1", "abc")], false).unwrap();
         assert!(a["1"].is_weak);
         assert!(a["1"].score < WEAK_SCORE);
         assert!(!a["1"].is_repeating);
@@ -125,21 +111,18 @@ mod tests {
 
     #[test]
     fn strong_passphrase_is_not_weak() {
-        let c = cryptor();
-        let a = audit(&c, &[login(&c, "1", "correct horse battery staple")], false).unwrap();
+        let a = audit(&[login("1", "correct horse battery staple")], false).unwrap();
         assert!(!a["1"].is_weak);
         assert!(a["1"].score >= WEAK_SCORE);
     }
 
     #[test]
     fn detects_repeating_passwords() {
-        let c = cryptor();
         let a = audit(
-            &c,
             &[
-                login(&c, "1", "Repeated1!"),
-                login(&c, "2", "Repeated1!"),
-                login(&c, "3", "Unique2@ab"),
+                login("1", "Repeated1!"),
+                login("2", "Repeated1!"),
+                login("3", "Unique2@ab"),
             ],
             false,
         )
@@ -152,8 +135,7 @@ mod tests {
     // Opt-out (check_breaches = false) makes no network call and leaves breached false.
     #[test]
     fn breach_check_is_skipped_when_opted_out() {
-        let c = cryptor();
-        let a = audit(&c, &[login(&c, "1", "password")], false).unwrap();
+        let a = audit(&[login("1", "password")], false).unwrap();
         assert!(!a["1"].breached);
     }
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -8,6 +8,8 @@ use crate::secure_store::{self, KeyStore};
 use crate::state::AppState;
 use crate::store::{Record, SqliteStore, VaultStore};
 use crate::{biometrics, storage};
+use std::fs;
+use std::path::Path;
 use tauri::{AppHandle, State};
 
 // True only when a SQLite vault DB exists. A legacy `vault.swftx` alone does NOT
@@ -156,8 +158,15 @@ pub fn disable_biometric(app: AppHandle) -> Result<()> {
 }
 
 // Re-derive a fresh Argon2id key (new salt), re-seal every payload under the new
-// payload key, then re-key the encrypted DB and rewrite the sidecar. Correct even
-// if slow: touches every row once. Requires an unlocked session.
+// payload key, re-key the encrypted DB and rewrite the sidecar. Correct even if
+// slow: touches every row once. Requires an unlocked session.
+//
+// Crash-consistency: the three destructive on-disk steps (import → rekey →
+// sidecar) are guarded by a recovery snapshot taken first. The sidecar (the
+// single source of truth for opening) is written last and atomically, so it only
+// ever names a DB already re-keyed to match. On any failure the pre-change,
+// old-keyed DB is restored from the snapshot and the OLD sidecar is left in place,
+// so the vault still opens under the unchanged current password.
 #[tauri::command]
 pub fn change_master_password(
     current: String,
@@ -165,51 +174,66 @@ pub fn change_master_password(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<()> {
+    // Hold the session lock throughout: no other command sees the half-open state
+    // while the store is out of the session.
     let mut session = state.session.lock().unwrap();
 
     // Verify the current password reproduces the unlocked session key.
-    let current_key = derive_key(&app, &current)?;
-    if current_key.sqlcipher_key() != session.key()?.sqlcipher_key() {
+    if derive_key(&app, &current)?.sqlcipher_key() != session.key()?.sqlcipher_key() {
         return Err(Error::InvalidPassword);
     }
 
-    // Old ciphers from the session; fresh Argon2id key (new salt) for the new one.
-    let old_cipher = session.key()?.payload_cipher();
-    let old_cryptor = session.key()?.cryptor();
-    let params = KdfParams::default_argon2id();
-    let new_key = VaultKey::Argon2 {
-        master: crypto::derive(new.as_bytes(), &params)?,
-    };
-    let new_cipher = new_key.payload_cipher();
-    let new_cryptor = new_key.cryptor();
-    let new_db_key = new_key.sqlcipher_key();
+    // Own the open store + key for the duration so we can drop and restore them.
+    let store = session.store.take().ok_or(Error::Locked)?;
+    let old_key = session.key.take().ok_or(Error::Locked)?;
 
-    let store = session.store()?;
-    // Re-seal every row's payload under the new payload key (timestamps + tombstones kept).
-    let resealed: Vec<Record> = store
-        .export_for_sync()
-        .map_err(store_err)?
-        .into_iter()
-        .map(|r| reseal_record(r, &old_cipher, &new_cipher))
-        .collect::<Result<_>>()?;
-    store.import(&resealed).map_err(store_err)?;
-    // Re-encrypt the DB file itself under the new SQLCipher key, then make the new
-    // descriptor authoritative. (Sidecar written after the rekey so it only ever
-    // describes a DB already re-keyed to match.)
-    store.rekey(&new_db_key).map_err(store_err)?;
-    record_kdf_meta(store, &params)?;
-    storage::write_kdf_sidecar(&app, &params.to_json()?)?;
+    // Fresh Argon2id key (new salt). Nothing on disk is touched yet, so on failure
+    // just put the untouched store/key back.
+    let params = KdfParams::default_argon2id();
+    let new_key = match crypto::derive(new.as_bytes(), &params) {
+        Ok(master) => VaultKey::Argon2 { master },
+        Err(e) => {
+            session.set_keyed(old_key, store);
+            return Err(e);
+        }
+    };
+
+    // Recovery point: snapshot the pre-change (old-keyed) DB to a sibling file.
+    let backup = storage::db_rekey_backup_path(&app)?;
+    if let Err(e) = store.snapshot_to(&backup, &old_key.sqlcipher_key()) {
+        let _ = fs::remove_file(&backup);
+        session.set_keyed(old_key, store);
+        return Err(store_err(e));
+    }
+
+    // Destructive sequence. On any error, roll back to the snapshot.
+    if let Err(e) = rekey_vault(&store, &old_key, &new_key, &params, &app) {
+        // Close the (possibly re-keyed) connection, copy the old-keyed snapshot
+        // back over the DB, and reopen under the OLD key (the current password is
+        // unchanged). The OLD sidecar is still on disk (it is rewritten only on a
+        // successful rekey), so the restored DB opens. Keep the snapshot as a
+        // last-resort artifact if the reopen itself fails.
+        drop(store);
+        match restore_db_from_backup(&app, &backup).and_then(|()| open_with_key(&app, &old_key)) {
+            Ok((restored, _)) => session.set_keyed(old_key, restored),
+            Err(_) => session.clear(),
+        }
+        return Err(e);
+    }
+
+    // Success: the change is committed on disk. Drop the recovery point.
+    let _ = fs::remove_file(&backup);
 
     // Re-encrypt the Drive token file under the new key if present (sync parity).
     let token = storage::read_gdrive(&app).unwrap_or_default();
     if !token.is_empty() {
-        if let Ok(plain) = old_cryptor.decrypt(&token) {
-            storage::write_gdrive(&app, &new_cryptor.encrypt(&plain)?)?;
+        if let Ok(plain) = old_key.cryptor().decrypt(&token) {
+            storage::write_gdrive(&app, &new_key.cryptor().encrypt(&plain)?)?;
         }
     }
 
-    // Swap in the new key for the live session.
-    session.key = Some(new_key);
+    // Adopt the new key + store for the live session.
+    session.set_keyed(new_key, store);
     drop(session);
 
     // The biometric-stored key is now stale; re-store the new material or clear it.
@@ -222,6 +246,45 @@ pub fn change_master_password(
             let _ = storage::set_biometric_enrolled(&app, false);
         }
     }
+    Ok(())
+}
+
+// The destructive on-disk sequence, isolated so a single `?` failure triggers the
+// snapshot rollback in the caller. Sidecar (atomic) written last, after the rekey.
+fn rekey_vault(
+    store: &SqliteStore,
+    old_key: &VaultKey,
+    new_key: &VaultKey,
+    params: &KdfParams,
+    app: &AppHandle,
+) -> Result<()> {
+    let old_cipher = old_key.payload_cipher();
+    let new_cipher = new_key.payload_cipher();
+    // Re-seal every row's payload under the new payload key (timestamps + tombstones kept).
+    let resealed: Vec<Record> = store
+        .export_for_sync()
+        .map_err(store_err)?
+        .into_iter()
+        .map(|r| reseal_record(r, &old_cipher, &new_cipher))
+        .collect::<Result<_>>()?;
+    store.import(&resealed).map_err(store_err)?;
+    store.rekey(&new_key.sqlcipher_key()).map_err(store_err)?;
+    record_kdf_meta(store, params)?;
+    storage::write_kdf_sidecar(app, &params.to_json()?)?;
+    Ok(())
+}
+
+// Roll the DB file back to the pre-change snapshot. The connection must already be
+// closed. Stale WAL/SHM sidecars are removed so they can't overlay the restored
+// (old-keyed) file with new-keyed frames.
+fn restore_db_from_backup(app: &AppHandle, backup: &Path) -> Result<()> {
+    let db = storage::db_path(app)?;
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = db.clone().into_os_string();
+        sidecar.push(suffix);
+        let _ = fs::remove_file(std::path::PathBuf::from(sidecar));
+    }
+    fs::copy(backup, &db)?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,10 +1,13 @@
-use crate::commands::{open_and_load, store_err, KDF_DESCRIPTOR};
+use crate::commands::{
+    create_vault, derive_key, open_with_key, record_kdf_meta, store_err, unlock_with_password,
+};
+use crate::crypto::{self, KdfParams, PayloadCipher, VaultKey};
 use crate::error::{Error, Result};
-use crate::models::{Entry, UnlockResult};
+use crate::models::{EntryMetaDto, UnlockResult};
 use crate::secure_store::{self, KeyStore};
 use crate::state::AppState;
 use crate::store::{Record, SqliteStore, VaultStore};
-use crate::{biometrics, crypto, storage};
+use crate::{biometrics, storage};
 use tauri::{AppHandle, State};
 
 // True only when a SQLite vault DB exists. A legacy `vault.swftx` alone does NOT
@@ -16,20 +19,19 @@ pub fn is_initialized(app: AppHandle) -> Result<bool> {
     Ok(storage::db_exists(&app))
 }
 
-// Create a brand-new, empty encrypted store protected by `password`.
+// Create a brand-new, empty encrypted store protected by `password` (Argon2id +
+// a fresh KDF sidecar). The payload key is held in the session, never persisted.
 #[tauri::command]
 pub fn setup(password: String, app: AppHandle, state: State<'_, AppState>) -> Result<()> {
-    let secret = crypto::hash_secret(&password);
-    let db_key = crypto::sqlcipher_key(&secret);
-    let store = SqliteStore::open(&storage::db_path(&app)?, &db_key).map_err(store_err)?;
-    store.meta_set("kdf", KDF_DESCRIPTOR).map_err(store_err)?;
-    state.session.lock().unwrap().set(secret, store, false);
+    let (key, store) = create_vault(&app, &password)?;
+    state.session.lock().unwrap().set(key, store, false);
     Ok(())
 }
 
-// Unlock with the master password: derive the keys, open the existing store, and
-// return the entry metadata list. Opening SQLCipher runs an internal KDF, so the
-// crypto/DB-open runs off the UI thread and unlock never migrates anything.
+// Unlock with the master password: read the KDF sidecar, derive the key, open the
+// existing store, and return the entry metadata list. The Argon2id derive + the
+// SQLCipher open both run on a blocking thread so the UI is never stalled; unlock
+// never migrates anything.
 #[tauri::command]
 pub async fn unlock(
     password: String,
@@ -37,31 +39,42 @@ pub async fn unlock(
     state: State<'_, AppState>,
 ) -> Result<UnlockResult> {
     storage::ensure_migrated(&app);
-    let secret = crypto::hash_secret(&password);
-    let (store, entries) = open_off_thread(&app, &secret).await?;
+    let (key, store, entries) = unlock_off_thread(&app, password).await?;
     let sync_configured = crate::sync::ENABLED && storage::sync_configured(&app);
     state
         .session
         .lock()
         .unwrap()
-        .set(secret, store, sync_configured);
+        .set(key, store, sync_configured);
     Ok(UnlockResult {
         entries,
         sync_configured,
     })
 }
 
-// Run the key-derive + SQLCipher open (both CPU-bound) on a blocking thread so
-// the UI thread is never stalled. Shared by password and biometric unlock.
-async fn open_off_thread(
+// Run the Argon2id derive + SQLCipher open (both CPU-bound) on a blocking thread.
+async fn unlock_off_thread(
     app: &AppHandle,
-    secret: &str,
-) -> Result<(SqliteStore, Vec<crate::models::EntryMetaDto>)> {
+    password: String,
+) -> Result<(VaultKey, SqliteStore, Vec<EntryMetaDto>)> {
     let app = app.clone();
-    let secret = secret.to_owned();
-    tauri::async_runtime::spawn_blocking(move || open_and_load(&app, &secret))
+    tauri::async_runtime::spawn_blocking(move || unlock_with_password(&app, &password))
         .await
         .map_err(|e| Error::Other(e.to_string()))?
+}
+
+// Open the store for an already-resolved key (biometric path) off the UI thread.
+async fn open_off_thread(
+    app: &AppHandle,
+    key: VaultKey,
+) -> Result<(VaultKey, SqliteStore, Vec<EntryMetaDto>)> {
+    let app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let (store, entries) = open_with_key(&app, &key)?;
+        Ok((key, store, entries))
+    })
+    .await
+    .map_err(|e| Error::Other(e.to_string()))?
 }
 
 // Clear the in-memory key and close the store.
@@ -72,15 +85,16 @@ pub fn lock(state: State<'_, AppState>) -> Result<()> {
 }
 
 // Unlock from a locked start using the biometric-gated key in the OS secure
-// store. Retrieving the key triggers the biometric prompt; the key then opens
-// the existing store off the UI thread. No migration on unlock.
+// store. Retrieving the key triggers the biometric prompt; the sidecar decides
+// how to interpret the stored bytes (Argon2id master vs legacy secret). The
+// store then opens off the UI thread. No migration on unlock.
 #[tauri::command]
 pub async fn unlock_biometric(app: AppHandle, state: State<'_, AppState>) -> Result<UnlockResult> {
     storage::ensure_migrated(&app);
     if !storage::biometric_enrolled(&app) {
         return Err(Error::Other("biometric unlock is not enabled".into()));
     }
-    let key = match secure_store::Platform.retrieve() {
+    let material = match secure_store::Platform.retrieve() {
         Ok(k) => k,
         Err(Error::NotFound) => {
             // The OS invalidated the item (e.g. enrolled fingerprints changed).
@@ -90,14 +104,19 @@ pub async fn unlock_biometric(app: AppHandle, state: State<'_, AppState>) -> Res
         }
         Err(e) => return Err(e),
     };
-    let secret = String::from_utf8(key.to_vec()).map_err(|e| Error::Crypto(e.to_string()))?;
-    let (store, entries) = open_off_thread(&app, &secret).await?;
+    // A sidecar means the stored bytes are an Argon2id master; without one they
+    // are the legacy secret string (a pre-sidecar dev vault).
+    let key = match storage::read_kdf_sidecar(&app)? {
+        Some(_) => VaultKey::Argon2 { master: material },
+        None => VaultKey::Legacy { secret: material },
+    };
+    let (key, store, entries) = open_off_thread(&app, key).await?;
     let sync_configured = crate::sync::ENABLED && storage::sync_configured(&app);
     state
         .session
         .lock()
         .unwrap()
-        .set(secret, store, sync_configured);
+        .set(key, store, sync_configured);
     Ok(UnlockResult {
         entries,
         sync_configured,
@@ -122,8 +141,7 @@ pub fn enable_biometric(app: AppHandle, state: State<'_, AppState>) -> Result<()
     }
     {
         let session = state.session.lock().unwrap();
-        let key = session.master_key.as_ref().ok_or(Error::Locked)?;
-        secure_store::Platform.store(key)?;
+        secure_store::Platform.store(session.key()?.biometric_material())?;
     }
     storage::set_biometric_enrolled(&app, true)?;
     Ok(())
@@ -137,8 +155,9 @@ pub fn disable_biometric(app: AppHandle) -> Result<()> {
     Ok(())
 }
 
-// Re-encrypt every payload under the new key, then re-key the encrypted DB.
-// Correct even if slow: touches every row once. Requires an unlocked session.
+// Re-derive a fresh Argon2id key (new salt), re-seal every payload under the new
+// payload key, then re-key the encrypted DB and rewrite the sidecar. Correct even
+// if slow: touches every row once. Requires an unlocked session.
 #[tauri::command]
 pub fn change_master_password(
     current: String,
@@ -146,29 +165,40 @@ pub fn change_master_password(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<()> {
-    let old_secret = crypto::hash_secret(&current);
-    let new_secret = crypto::hash_secret(&new);
-    let old_cryptor = crypto::Cryptor::new(&old_secret);
-    let new_cryptor = crypto::Cryptor::new(&new_secret);
-    let new_db_key = crypto::sqlcipher_key(&new_secret);
-
     let mut session = state.session.lock().unwrap();
-    // Verify the current password matches the unlocked session.
-    match session.master_key.as_deref() {
-        Some(k) if k == old_secret.as_bytes() => {}
-        Some(_) => return Err(Error::InvalidPassword),
-        None => return Err(Error::Locked),
+
+    // Verify the current password reproduces the unlocked session key.
+    let current_key = derive_key(&app, &current)?;
+    if current_key.sqlcipher_key() != session.key()?.sqlcipher_key() {
+        return Err(Error::InvalidPassword);
     }
 
+    // Old ciphers from the session; fresh Argon2id key (new salt) for the new one.
+    let old_cipher = session.key()?.payload_cipher();
+    let old_cryptor = session.key()?.cryptor();
+    let params = KdfParams::default_argon2id();
+    let new_key = VaultKey::Argon2 {
+        master: crypto::derive(new.as_bytes(), &params)?,
+    };
+    let new_cipher = new_key.payload_cipher();
+    let new_cryptor = new_key.cryptor();
+    let new_db_key = new_key.sqlcipher_key();
+
     let store = session.store()?;
-    // Re-seal every row's payload under the new key (timestamps + tombstones kept).
-    let reencrypted: Vec<Record> = live_or_all(store)?
+    // Re-seal every row's payload under the new payload key (timestamps + tombstones kept).
+    let resealed: Vec<Record> = store
+        .export_for_sync()
+        .map_err(store_err)?
         .into_iter()
-        .map(|r| reencrypt_record(r, &old_cryptor, &new_cryptor))
+        .map(|r| reseal_record(r, &old_cipher, &new_cipher))
         .collect::<Result<_>>()?;
-    store.import(&reencrypted).map_err(store_err)?;
-    // Re-encrypt the DB file itself under the new SQLCipher key.
+    store.import(&resealed).map_err(store_err)?;
+    // Re-encrypt the DB file itself under the new SQLCipher key, then make the new
+    // descriptor authoritative. (Sidecar written after the rekey so it only ever
+    // describes a DB already re-keyed to match.)
     store.rekey(&new_db_key).map_err(store_err)?;
+    record_kdf_meta(store, &params)?;
+    storage::write_kdf_sidecar(&app, &params.to_json()?)?;
 
     // Re-encrypt the Drive token file under the new key if present (sync parity).
     let token = storage::read_gdrive(&app).unwrap_or_default();
@@ -179,31 +209,26 @@ pub fn change_master_password(
     }
 
     // Swap in the new key for the live session.
-    session.master_key = Some(zeroize::Zeroizing::new(new_secret.clone().into_bytes()));
+    session.key = Some(new_key);
     drop(session);
 
     // The biometric-stored key is now stale; re-store the new material or clear it.
-    if storage::biometric_enrolled(&app)
-        && secure_store::Platform.store(new_secret.as_bytes()).is_err()
-    {
-        let _ = secure_store::Platform.delete();
-        let _ = storage::set_biometric_enrolled(&app, false);
+    if storage::biometric_enrolled(&app) {
+        let session = state.session.lock().unwrap();
+        let stored = secure_store::Platform.store(session.key()?.biometric_material());
+        drop(session);
+        if stored.is_err() {
+            let _ = secure_store::Platform.delete();
+            let _ = storage::set_biometric_enrolled(&app, false);
+        }
     }
     Ok(())
 }
 
-// All records including tombstones (they carry payloads that must be re-keyed).
-fn live_or_all(store: &SqliteStore) -> Result<Vec<Record>> {
-    store.export_for_sync().map_err(store_err)
-}
-
-// Unseal a record's payload under the old key and re-seal it under the new one,
+// Unseal a record's payload under the old cipher and re-seal it under the new one,
 // preserving all metadata (id/kind/title/tags/url_host/timestamps/tombstone).
-fn reencrypt_record(mut r: Record, old: &crypto::Cryptor, new: &crypto::Cryptor) -> Result<Record> {
-    let blob = String::from_utf8(r.payload).map_err(|e| Error::Crypto(e.to_string()))?;
-    let obscured: Entry = old.decrypt_data(&blob)?;
-    let exposed = old.expose(&obscured)?;
-    let reobscured = new.obscure(&exposed)?;
-    r.payload = new.encrypt_data(&reobscured)?.into_bytes();
+fn reseal_record(mut r: Record, old: &PayloadCipher, new: &PayloadCipher) -> Result<Record> {
+    let entry = old.unseal(&r.payload)?;
+    r.payload = new.seal(&entry)?;
     Ok(r)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,19 +7,78 @@ pub mod vault;
 
 use tauri::AppHandle;
 
-use crate::crypto::{self, Cryptor};
+use crate::crypto::{self, Cryptor, KdfParams, VaultKey};
 use crate::error::{Error, Result};
 use crate::models::{Entry, EntryMetaDto};
 use crate::storage;
 use crate::store::{EntryMeta, Record, SqliteStore, StoreError, VaultStore};
 
-// KDF descriptor recorded in the store `meta` table. A placeholder for Phase 2
-// (Argon2id): the app still derives keys from the current PBKDF2-based secret,
-// but the descriptor makes the on-disk format self-describing for the upgrade.
-pub const KDF_DESCRIPTOR: &str = "pbkdf2-sha512-100000";
-
 pub fn store_err(e: StoreError) -> Error {
     Error::Other(e.to_string())
+}
+
+// Resolve the vault key for `password`: Argon2id when the KDF sidecar is present
+// (the current scheme), or the legacy deterministic key when a DB exists without
+// a sidecar (interim/dev vaults created before this wiring). Feeds the password
+// **directly** to Argon2id — no `hash_secret` pre-hash on this path.
+pub fn derive_key(app: &AppHandle, password: &str) -> Result<VaultKey> {
+    match storage::read_kdf_sidecar(app)? {
+        Some(json) => {
+            let params = KdfParams::from_json(&json)?;
+            Ok(VaultKey::Argon2 {
+                master: crypto::derive(password.as_bytes(), &params)?,
+            })
+        }
+        None => Ok(VaultKey::legacy_from_password(password)),
+    }
+}
+
+// Open the existing store with `key` and return its handle + entry metadata. A
+// wrong key fails SQLCipher's open verification -> surfaced as invalid password.
+pub fn open_with_key(app: &AppHandle, key: &VaultKey) -> Result<(SqliteStore, Vec<EntryMetaDto>)> {
+    let store = SqliteStore::open(&storage::db_path(app)?, &key.sqlcipher_key())
+        .map_err(|_| Error::InvalidPassword)?;
+    let metas = list_metas(&store)?;
+    Ok((store, metas))
+}
+
+// Password unlock (run inside spawn_blocking): derive the key, then open + list.
+// Fresh-start default: a legacy `vault.swftx` is never migrated here — importing
+// one is an explicit, off-thread action (see `import_swftx`).
+pub fn unlock_with_password(
+    app: &AppHandle,
+    password: &str,
+) -> Result<(VaultKey, SqliteStore, Vec<EntryMetaDto>)> {
+    let key = derive_key(app, password)?;
+    let (store, metas) = open_with_key(app, &key)?;
+    Ok((key, store, metas))
+}
+
+// Create a brand-new Argon2id-keyed vault: fresh params -> write the sidecar
+// (authoritative) -> derive the master -> create the encrypted DB keyed with the
+// SQLCipher subkey -> record the KDF descriptor in `meta` too (for reference).
+pub fn create_vault(app: &AppHandle, password: &str) -> Result<(VaultKey, SqliteStore)> {
+    let params = KdfParams::default_argon2id();
+    let descriptor = params.to_json()?;
+    // Sidecar first: a DB must never exist without the descriptor needed to open it.
+    storage::write_kdf_sidecar(app, &descriptor)?;
+    let key = VaultKey::Argon2 {
+        master: crypto::derive(password.as_bytes(), &params)?,
+    };
+    let store =
+        SqliteStore::open(&storage::db_path(app)?, &key.sqlcipher_key()).map_err(store_err)?;
+    record_kdf_meta(&store, &params)?;
+    Ok((key, store))
+}
+
+// Mirror the KDF descriptor into `meta` (the sidecar stays authoritative for
+// opening; `meta` is reference/integrity only).
+pub fn record_kdf_meta(store: &SqliteStore, params: &KdfParams) -> Result<()> {
+    store.meta_set("kdf", params.algo()).map_err(store_err)?;
+    store
+        .meta_set("kdf_params", &params.to_json()?)
+        .map_err(store_err)?;
+    Ok(())
 }
 
 // Decrypt one entry's sensitive fields (legacy per-field ciphertext -> plaintext).
@@ -71,17 +130,4 @@ pub fn live_records(store: &SqliteStore) -> Result<Vec<Record>> {
         .into_iter()
         .filter(|r| r.deleted_at.is_none())
         .collect())
-}
-
-// Open the existing store for `secret` and return the open handle plus the entry
-// metadata list. Fresh-start default: a legacy `vault.swftx` is never migrated
-// here — importing one is an explicit, off-thread action (see `import_swftx`).
-pub fn open_and_load(app: &AppHandle, secret: &str) -> Result<(SqliteStore, Vec<EntryMetaDto>)> {
-    let db_key = crypto::sqlcipher_key(secret);
-    let db = storage::db_path(app)?;
-    // A wrong password derives a wrong SQLCipher key and the open fails
-    // verification -> surface as an invalid password.
-    let store = SqliteStore::open(&db, &db_key).map_err(|_| Error::InvalidPassword)?;
-    let metas = list_metas(&store)?;
-    Ok((store, metas))
 }

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -1,4 +1,6 @@
-use crate::commands::{list_metas, live_records, record_meta_dto, store_err};
+use crate::commands::{
+    create_vault, derive_key, list_metas, live_records, record_meta_dto, store_err,
+};
 use crate::error::{Error, Result};
 use crate::models::{Entry, EntryMetaDto, UnlockResult, VaultData};
 use crate::state::AppState;
@@ -17,35 +19,30 @@ pub fn read_vault(state: State<'_, AppState>) -> Result<Vec<EntryMetaDto>> {
     list_metas(session.store()?)
 }
 
-// Decrypt one entry on demand (view/edit): fetch its payload, unseal it, then
-// decrypt its per-field secrets. Nothing is cached in the session.
+// Decrypt one entry on demand (view/edit): fetch its payload and unseal it with
+// the session payload key. Nothing is cached in the session.
 #[tauri::command]
 pub fn reveal_entry(id: String, state: State<'_, AppState>) -> Result<Entry> {
     let session = state.session.lock().unwrap();
-    let cryptor = session.cryptor()?;
+    let cipher = session.payload_cipher()?;
     let record = session
         .store()?
         .get(&id)
         .map_err(store_err)?
         .ok_or(Error::NotFound)?;
-    let blob = String::from_utf8(record.payload).map_err(|e| Error::Crypto(e.to_string()))?;
-    let obscured: Entry = cryptor.decrypt_data(&blob)?;
-    cryptor.expose(&obscured)
+    cipher.unseal(&record.payload)
 }
 
-// Persist one entry: seal its secrets into a fresh payload and upsert a single
-// row (metadata + payload), stamping updated_at. No whole-vault rewrite.
+// Persist one entry: seal it into a fresh payload and upsert a single row
+// (metadata + payload), stamping updated_at. No whole-vault rewrite.
 #[tauri::command]
 pub fn save_entry(entry: Entry, state: State<'_, AppState>) -> Result<EntryMetaDto> {
     let session = state.session.lock().unwrap();
-    let cryptor = session.cryptor()?;
+    let cipher = session.payload_cipher()?;
     let store = session.store()?;
 
-    let obscured = cryptor.obscure(&entry)?;
-    let record = migrate::records_from_entries(&[obscured], &cryptor)?
-        .into_iter()
-        .next()
-        .ok_or_else(|| Error::Other("record build failed".into()))?;
+    let payload = cipher.seal(&entry)?;
+    let record = migrate::build_record(&entry, payload)?;
     store.upsert(&record).map_err(store_err)?;
 
     let saved = store
@@ -75,8 +72,9 @@ pub fn pick_backup(app: AppHandle) -> Result<Option<String>> {
         .map(|p| p.to_string_lossy().into_owned()))
 }
 
-// Restore a `.swftx` backup: decrypt it with `password`, import every entry into
-// the store, and adopt it as the unlocked session.
+// Restore a `.swftx` backup: decrypt it with `password` (legacy format), create a
+// fresh Argon2id vault under the same password, re-seal every entry under the new
+// payload key, and adopt it as the unlocked session.
 #[tauri::command]
 pub fn import_backup(
     path: String,
@@ -85,20 +83,14 @@ pub fn import_backup(
     state: State<'_, AppState>,
 ) -> Result<UnlockResult> {
     let blob = storage::read_backup(&path)?;
-    let secret = crypto::hash_secret(&password);
-    let cryptor = crypto::Cryptor::new(&secret);
+    let src_cryptor = crypto::Cryptor::new(&crypto::hash_secret(&password));
     // Validate it decrypts before touching the store.
-    let vault: VaultData = cryptor
+    let vault: VaultData = src_cryptor
         .decrypt_data(&blob)
         .map_err(|_| Error::InvalidPassword)?;
 
-    let db_key = crypto::sqlcipher_key(&secret);
-    let store =
-        crate::store::SqliteStore::open(&storage::db_path(&app)?, &db_key).map_err(store_err)?;
-    store
-        .meta_set("kdf", crate::commands::KDF_DESCRIPTOR)
-        .map_err(store_err)?;
-    let records = migrate::records_from_entries(&vault.entries, &cryptor)?;
+    let (key, store) = create_vault(&app, &password)?;
+    let records = migrate::reseal_swftx(&vault.entries, &src_cryptor, &key.payload_cipher())?;
     store.import(&records).map_err(store_err)?;
 
     let metas = list_metas(&store)?;
@@ -107,7 +99,7 @@ pub fn import_backup(
         .session
         .lock()
         .unwrap()
-        .set(secret, store, sync_configured);
+        .set(key, store, sync_configured);
     Ok(UnlockResult {
         entries: metas,
         sync_configured,
@@ -117,8 +109,8 @@ pub fn import_backup(
 // Import a `.swftx` backup into the *currently unlocked* vault. The file is
 // independently encrypted and carries its own master password (which may differ
 // from the current vault's). Each entry is decrypted under the source key and
-// re-sealed under the current session key, then upserted (merge/add by id). The
-// CPU-bound re-encrypt loop runs off the UI thread and emits `import:progress`.
+// re-sealed under the current session payload key, then upserted (merge/add by
+// id). The CPU-bound re-seal loop runs off the UI thread and emits `import:progress`.
 #[tauri::command]
 pub async fn import_swftx(
     path: String,
@@ -132,16 +124,16 @@ pub async fn import_swftx(
     let src: VaultData = src_cryptor
         .decrypt_data(&blob)
         .map_err(|_| Error::InvalidPassword)?;
-    let cur_cryptor = state.session.lock().unwrap().cryptor()?;
+    let cur_cipher = state.session.lock().unwrap().payload_cipher()?;
 
-    // Re-key every entry off the UI thread: expose under the source key, re-obscure
-    // under the current key, seal one payload each — emitting progress as it goes.
+    // Re-seal every entry off the UI thread: expose under the source key, re-seal
+    // under the current payload key — emitting progress as it goes.
     let emitter = app.clone();
     let records = tauri::async_runtime::spawn_blocking(move || -> Result<Vec<Record>> {
         let total = src.entries.len();
         let mut records = Vec::with_capacity(total);
         for (i, obscured) in src.entries.iter().enumerate() {
-            records.push(migrate::rekey_record(&src_cryptor, &cur_cryptor, obscured)?);
+            records.push(migrate::reseal_one(obscured, &src_cryptor, &cur_cipher)?);
             let _ = emitter.emit("import:progress", json!({ "done": i + 1, "total": total }));
         }
         Ok(records)
@@ -163,22 +155,30 @@ pub async fn import_swftx(
 }
 
 // Export the vault to a user-chosen file. Reconstructs the legacy `.swftx` blob
-// (obscured entries sealed under the master key) so backups stay restorable via
-// import_backup. Returns the path, or None if cancelled.
+// (entries obscured + sealed under `hash_secret(password)`) so backups stay
+// restorable via import_backup on any install. `password` must be the current
+// master password; a mismatch is rejected so a backup is never unrecoverable.
 #[tauri::command]
-pub fn export_vault(app: AppHandle, state: State<'_, AppState>) -> Result<Option<String>> {
+pub fn export_vault(
+    password: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Option<String>> {
     let blob = {
         let session = state.session.lock().unwrap();
-        let cryptor = session.cryptor()?;
-        // Each payload already holds the obscured entry; unseal to rebuild VaultData.
+        // Guard: the export key must match the unlocked vault.
+        if derive_key(&app, &password)?.sqlcipher_key() != session.key()?.sqlcipher_key() {
+            return Err(Error::InvalidPassword);
+        }
+        let cipher = session.payload_cipher()?;
+        // Rebuild each plaintext entry from its stored payload, then obscure + seal
+        // under the legacy password-derived cryptor for a portable `.swftx`.
+        let out = crypto::Cryptor::new(&crypto::hash_secret(&password));
         let entries = live_records(session.store()?)?
             .into_iter()
-            .map(|r| {
-                let s = String::from_utf8(r.payload).map_err(|e| Error::Crypto(e.to_string()))?;
-                cryptor.decrypt_data::<Entry>(&s)
-            })
+            .map(|r| out.obscure(&cipher.unseal(&r.payload)?))
             .collect::<Result<Vec<Entry>>>()?;
-        cryptor.encrypt_data(&VaultData { entries })?
+        out.encrypt_data(&VaultData { entries })?
     };
 
     let dest = app

--- a/src-tauri/src/crypto/mod.rs
+++ b/src-tauri/src/crypto/mod.rs
@@ -19,6 +19,9 @@ use crate::models::Entry;
 pub mod kdf;
 pub use kdf::{derive, KdfParams};
 
+mod vault;
+pub use vault::{PayloadCipher, VaultKey};
+
 #[cfg(test)]
 mod tests;
 
@@ -37,10 +40,9 @@ pub fn hash_secret(password: &str) -> String {
     STANDARD.encode(Sha512::digest(password.as_bytes()))
 }
 
-/// Derive the 32-byte SQLCipher database key from the session secret via HKDF,
-/// as a subkey distinct from the per-entry payload key (which uses `secret`
-/// directly through PBKDF2). One password yields both keys with no extra prompt.
-/// Phase 2 will swap the input for an Argon2id output without changing this glue.
+/// Legacy deterministic SQLCipher key: HKDF of the `hash_secret` string, with no
+/// per-vault salt. Retained only for sidecar-less interim/dev DBs so they still
+/// open; Argon2id vaults derive their SQLCipher key via [`VaultKey`] instead.
 pub fn sqlcipher_key(secret: &str) -> [u8; KEY_LEN] {
     const SALT: &[u8] = b"swifty-sqlcipher-v1";
     const INFO: &[u8] = b"sqlcipher-db-key";
@@ -51,6 +53,62 @@ pub fn sqlcipher_key(secret: &str) -> [u8; KEY_LEN] {
     let mut key = [0u8; KEY_LEN];
     okm.fill(&mut key).expect("hkdf fill");
     key
+}
+
+/// Derive a 32-byte subkey from `ikm` (an Argon2id master key) for the given
+/// `info` label via HKDF-SHA256. One master yields the SQLCipher key and the
+/// payload key as independent subkeys (distinct `info`), so a single KDF pass
+/// covers both without either revealing the other.
+pub(crate) fn hkdf_subkey(ikm: &[u8], info: &[u8]) -> [u8; KEY_LEN] {
+    const SALT: &[u8] = b"swifty-kdf-hkdf-v1";
+    let prk = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, SALT).extract(ikm);
+    let info = [info];
+    let okm = prk
+        .expand(&info, ring::hkdf::HKDF_SHA256)
+        .expect("hkdf expand");
+    let mut key = [0u8; KEY_LEN];
+    okm.fill(&mut key).expect("hkdf fill");
+    key
+}
+
+/// Seal `plaintext` with AES-256-GCM under `key` and a fresh random 16-byte
+/// nonce, returning `nonce ‖ ciphertext ‖ tag`. This is the per-payload AEAD for
+/// Argon2id-keyed vaults — no per-payload KDF; the caller derives `key` once.
+pub(crate) fn seal_aead(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+    let cipher = Aes256Gcm16::new_from_slice(key).map_err(err)?;
+    let mut nonce = [0u8; IV_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    let sealed = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(err)?;
+    let mut out = Vec::with_capacity(IV_LEN + sealed.len());
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&sealed);
+    Ok(out)
+}
+
+/// Reverse of [`seal_aead`]: split off the 16-byte nonce and decrypt the rest.
+pub(crate) fn unseal_aead(key: &[u8], blob: &[u8]) -> Result<Vec<u8>> {
+    if blob.len() < IV_LEN + TAG_LEN {
+        return Err(Error::Crypto("payload too short".into()));
+    }
+    let (nonce, sealed) = blob.split_at(IV_LEN);
+    let cipher = Aes256Gcm16::new_from_slice(key).map_err(err)?;
+    cipher
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: sealed,
+                aad: &[],
+            },
+        )
+        .map_err(err)
 }
 
 fn err<E: std::fmt::Display>(e: E) -> Error {

--- a/src-tauri/src/crypto/vault.rs
+++ b/src-tauri/src/crypto/vault.rs
@@ -1,0 +1,192 @@
+//! Session key material and the per-entry payload cipher.
+//!
+//! A vault is keyed one of two ways, resolved at unlock by the presence of the
+//! KDF sidecar (`vault.kdf.json`):
+//!
+//! - [`VaultKey::Argon2`] — the current scheme. The master password is fed
+//!   **directly** to Argon2id (no `hash_secret` pre-hash); the 32-byte output is
+//!   HKDF-split into a SQLCipher key and a payload key. Payloads are sealed with
+//!   AES-256-GCM under the payload key ([`PayloadCipher::Aead`]) — one AEAD per
+//!   entry, no per-payload KDF.
+//! - [`VaultKey::Legacy`] — back-compat for interim/dev DBs created before the
+//!   Argon2id wiring, which have no sidecar. Keeps the old deterministic
+//!   SQLCipher key and the per-field PBKDF2 [`Cryptor`] payload format so those
+//!   vaults still open.
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use zeroize::Zeroizing;
+
+use super::{hash_secret, hkdf_subkey, seal_aead, sqlcipher_key, unseal_aead, Cryptor, KEY_LEN};
+use crate::error::{Error, Result};
+use crate::models::Entry;
+
+// HKDF `info` labels — one master key, three independent subkeys.
+const INFO_SQLCIPHER: &[u8] = b"sqlcipher-db-key";
+const INFO_PAYLOAD: &[u8] = b"payload-aead-key";
+// The gdrive/sync token blob is encrypted with a legacy `Cryptor`; give it a
+// stable, install-specific secret derived from the master so the (disabled) sync
+// path keeps a self-consistent cipher without holding the password.
+const INFO_LEGACY_CRYPTOR: &[u8] = b"legacy-cryptor-secret";
+
+/// The active vault key. Held by the session; scrubbed on drop.
+pub enum VaultKey {
+    /// Argon2id master key (32 bytes of KDF output).
+    Argon2 { master: Zeroizing<Vec<u8>> },
+    /// Legacy `hash_secret(password)` string bytes (sidecar-less DBs only).
+    Legacy { secret: Zeroizing<Vec<u8>> },
+}
+
+impl VaultKey {
+    /// Build the legacy key material for a password (the deterministic pre-Argon2
+    /// scheme). Used only when a DB exists without a sidecar.
+    pub fn legacy_from_password(password: &str) -> Self {
+        Self::Legacy {
+            secret: Zeroizing::new(hash_secret(password).into_bytes()),
+        }
+    }
+
+    /// The 32-byte SQLCipher key for this vault.
+    pub fn sqlcipher_key(&self) -> [u8; KEY_LEN] {
+        match self {
+            Self::Argon2 { master } => hkdf_subkey(master, INFO_SQLCIPHER),
+            Self::Legacy { secret } => sqlcipher_key(&secret_str(secret)),
+        }
+    }
+
+    /// The cipher that seals/unseals per-entry payloads for this vault.
+    pub fn payload_cipher(&self) -> PayloadCipher {
+        match self {
+            Self::Argon2 { master } => {
+                PayloadCipher::Aead(Zeroizing::new(hkdf_subkey(master, INFO_PAYLOAD)))
+            }
+            Self::Legacy { secret } => PayloadCipher::Legacy(Cryptor::new(&secret_str(secret))),
+        }
+    }
+
+    /// A legacy `Cryptor` for the gdrive/sync token blob (sync only).
+    pub fn cryptor(&self) -> Cryptor {
+        match self {
+            Self::Argon2 { master } => {
+                Cryptor::new(&STANDARD.encode(hkdf_subkey(master, INFO_LEGACY_CRYPTOR)))
+            }
+            Self::Legacy { secret } => Cryptor::new(&secret_str(secret)),
+        }
+    }
+
+    /// The opaque bytes to persist in the OS secure store for biometric unlock:
+    /// the Argon2id master, or the legacy secret. Interpreted back by sidecar
+    /// presence at unlock (see `unlock_biometric`).
+    pub fn biometric_material(&self) -> &[u8] {
+        match self {
+            Self::Argon2 { master } => master,
+            Self::Legacy { secret } => secret,
+        }
+    }
+}
+
+// The legacy secret is always UTF-8 (base64); fall back to empty on the
+// impossible non-UTF-8 case rather than panic.
+fn secret_str(secret: &[u8]) -> String {
+    String::from_utf8_lossy(secret).into_owned()
+}
+
+/// Seals and unseals a single entry's payload. The stored payload is opaque
+/// bytes; only this type knows the format.
+pub enum PayloadCipher {
+    /// AES-256-GCM over the plaintext entry JSON, keyed by the payload subkey.
+    Aead(Zeroizing<[u8; KEY_LEN]>),
+    /// Legacy double layer: per-field `obscure` then whole-entry `encrypt_data`.
+    Legacy(Cryptor),
+}
+
+impl PayloadCipher {
+    /// Seal a plaintext entry into its stored payload bytes.
+    pub fn seal(&self, entry: &Entry) -> Result<Vec<u8>> {
+        match self {
+            Self::Aead(key) => seal_aead(&**key, &serde_json::to_vec(entry)?),
+            Self::Legacy(c) => Ok(c.encrypt_data(&c.obscure(entry)?)?.into_bytes()),
+        }
+    }
+
+    /// Unseal stored payload bytes back into a plaintext entry.
+    pub fn unseal(&self, payload: &[u8]) -> Result<Entry> {
+        match self {
+            Self::Aead(key) => Ok(serde_json::from_slice(&unseal_aead(&**key, payload)?)?),
+            Self::Legacy(c) => {
+                let blob =
+                    std::str::from_utf8(payload).map_err(|e| Error::Crypto(e.to_string()))?;
+                let obscured: Entry = c.decrypt_data(blob)?;
+                c.expose(&obscured)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry() -> Entry {
+        serde_json::from_value(serde_json::json!({
+            "id": "1", "type": "login", "title": "Site",
+            "website": "https://ex.com/login", "username": "alice",
+            "password": "s3cret", "otp": "SEED", "tags": ["work"]
+        }))
+        .unwrap()
+    }
+
+    fn argon2_key() -> VaultKey {
+        VaultKey::Argon2 {
+            master: Zeroizing::new(vec![7u8; KEY_LEN]),
+        }
+    }
+
+    #[test]
+    fn argon2_split_keys_are_distinct() {
+        let k = argon2_key();
+        let sql = k.sqlcipher_key();
+        let PayloadCipher::Aead(payload) = k.payload_cipher() else {
+            panic!("argon2 vault must use the AEAD payload cipher");
+        };
+        assert_ne!(sql, *payload, "sqlcipher and payload subkeys must differ");
+    }
+
+    #[test]
+    fn aead_payload_round_trips_under_payload_key() {
+        let cipher = argon2_key().payload_cipher();
+        let sealed = cipher.seal(&entry()).unwrap();
+        // The plaintext secret never appears in the sealed bytes.
+        assert!(!sealed.windows(6).any(|w| w == b"s3cret"));
+        let back = cipher.unseal(&sealed).unwrap();
+        assert_eq!(back.password.as_deref(), Some("s3cret"));
+        assert_eq!(back.otp.as_deref(), Some("SEED"));
+        assert_eq!(back.username.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn aead_reseal_uses_a_fresh_nonce() {
+        let cipher = argon2_key().payload_cipher();
+        assert_ne!(
+            cipher.seal(&entry()).unwrap(),
+            cipher.seal(&entry()).unwrap(),
+            "each seal must use a fresh random nonce"
+        );
+    }
+
+    #[test]
+    fn wrong_payload_key_fails_to_unseal() {
+        let sealed = argon2_key().payload_cipher().seal(&entry()).unwrap();
+        let other = VaultKey::Argon2 {
+            master: Zeroizing::new(vec![9u8; KEY_LEN]),
+        };
+        assert!(other.payload_cipher().unseal(&sealed).is_err());
+    }
+
+    #[test]
+    fn legacy_payload_round_trips() {
+        let cipher = VaultKey::legacy_from_password("pw").payload_cipher();
+        let sealed = cipher.seal(&entry()).unwrap();
+        let back = cipher.unseal(&sealed).unwrap();
+        assert_eq!(back.password.as_deref(), Some("s3cret"));
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -50,6 +50,14 @@ impl Session {
         self.sync_configured = sync_configured;
     }
 
+    // Re-adopt a key + store, leaving sync_configured untouched. Used by
+    // change-master-password's success and rollback paths, where the store is
+    // taken out of the session and later put back (or replaced by a restore).
+    pub fn set_keyed(&mut self, key: VaultKey, store: SqliteStore) {
+        self.key = Some(key);
+        self.store = Some(store);
+    }
+
     // Drop the in-memory key and close the store. Used by the inactivity auto-lock.
     pub fn clear(&mut self) {
         self.key = None;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,19 +1,18 @@
 use std::sync::Mutex;
-use zeroize::Zeroizing;
 
-use crate::crypto::Cryptor;
+use crate::crypto::{Cryptor, PayloadCipher, VaultKey};
 use crate::error::{Error, Result};
 use crate::store::SqliteStore;
 
-// In-memory session. The master key never leaves Rust; the frontend only ever
+// In-memory session. The vault key never leaves Rust; the frontend only ever
 // receives non-secret entry metadata for the list and one decrypted entry at a
 // time (reveal). The open, encrypted store handle lives here — not a decrypted
 // vault — so plaintext secrets are never all held in memory.
 #[derive(Default)]
 pub struct Session {
-    // Wrapped in `Zeroizing` so the key is scrubbed from the heap on drop and
-    // whenever it's replaced or cleared (auto-lock / explicit lock).
-    pub master_key: Option<Zeroizing<Vec<u8>>>,
+    // The active vault key (Argon2id master or legacy secret). It owns its own
+    // zeroize-on-drop, so the material is scrubbed on lock/clear/replace.
+    pub key: Option<VaultKey>,
     // The open SQLCipher store. Dropped (connection closed) on lock.
     pub store: Option<SqliteStore>,
     pub sync_configured: bool,
@@ -21,14 +20,22 @@ pub struct Session {
 
 impl Session {
     pub fn is_unlocked(&self) -> bool {
-        self.master_key.is_some()
+        self.key.is_some()
     }
 
-    // Rebuild a Cryptor from the held key, or fail if locked.
+    // The held vault key, or fail if locked.
+    pub fn key(&self) -> Result<&VaultKey> {
+        self.key.as_ref().ok_or(Error::Locked)
+    }
+
+    // The per-entry payload cipher for this session, or fail if locked.
+    pub fn payload_cipher(&self) -> Result<PayloadCipher> {
+        Ok(self.key()?.payload_cipher())
+    }
+
+    // The legacy Cryptor for the (disabled) gdrive/sync token blob.
     pub fn cryptor(&self) -> Result<Cryptor> {
-        let key = self.master_key.as_ref().ok_or(Error::Locked)?;
-        let secret = std::str::from_utf8(key).map_err(|e| Error::Crypto(e.to_string()))?;
-        Ok(Cryptor::new(secret))
+        Ok(self.key()?.cryptor())
     }
 
     // Borrow the open store, or fail if locked.
@@ -37,15 +44,15 @@ impl Session {
     }
 
     // Adopt the derived key and open store for this session.
-    pub fn set(&mut self, secret: String, store: SqliteStore, sync_configured: bool) {
-        self.master_key = Some(Zeroizing::new(secret.into_bytes()));
+    pub fn set(&mut self, key: VaultKey, store: SqliteStore, sync_configured: bool) {
+        self.key = Some(key);
         self.store = Some(store);
         self.sync_configured = sync_configured;
     }
 
     // Drop the in-memory key and close the store. Used by the inactivity auto-lock.
     pub fn clear(&mut self) {
-        self.master_key = None;
+        self.key = None;
         self.store = None;
         self.sync_configured = false;
     }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -3,7 +3,8 @@
 //! export copy. Also handles one-time migration from the Electron location.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tauri::{AppHandle, Manager};
 
@@ -11,6 +12,9 @@ use crate::error::{Error, Result};
 
 pub const VAULT_FILE: &str = "vault.swftx";
 pub const DB_FILE: &str = "vault.db";
+// Pre-change recovery snapshot of the encrypted DB, written next to it before the
+// destructive change-master-password sequence (see `change_master_password`).
+pub const DB_REKEY_BACKUP_FILE: &str = "vault.db.rekey-backup";
 // Plaintext KDF descriptor stored next to the DB. It holds the Argon2id params +
 // salt (public by design) and is read *before* deriving the key — the salt/params
 // cannot live inside the encrypted DB, since deriving the key is what opens it.
@@ -43,6 +47,11 @@ pub fn db_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(DB_FILE))
 }
 
+// Sibling recovery snapshot of the DB (change-master-password rollback point).
+pub fn db_rekey_backup_path(app: &AppHandle) -> Result<PathBuf> {
+    Ok(app_dir(app)?.join(DB_REKEY_BACKUP_FILE))
+}
+
 // Whether the SQLite store has been created (non-empty file present).
 pub fn db_exists(app: &AppHandle) -> bool {
     db_path(app)
@@ -69,9 +78,41 @@ pub fn read_kdf_sidecar(app: &AppHandle) -> Result<Option<String>> {
     Ok(Some(fs::read_to_string(path)?))
 }
 
-// Write (or overwrite) the KDF descriptor sidecar. Authoritative for opening.
+// Write (or overwrite) the KDF descriptor sidecar. The sidecar is the single
+// source of truth for opening the vault, so the write is durable + atomic: a
+// crash never leaves it truncated.
 pub fn write_kdf_sidecar(app: &AppHandle, json: &str) -> Result<()> {
-    write_file(&kdf_sidecar_path(app)?, json)
+    atomic_write_file(&kdf_sidecar_path(app)?, json)
+}
+
+// Durably overwrite `path`: write a temp sibling, fsync it, atomically rename it
+// over the target, then fsync the directory. The target ends up as either the
+// complete old bytes or the complete new bytes — never a truncated/empty file.
+// A leftover `<path>.tmp` (from a crash before the rename) is ignored by readers,
+// which only ever open the target path.
+fn atomic_write_file(path: &Path, data: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::Other("sidecar path has no parent directory".into()))?;
+    fs::create_dir_all(parent)?;
+
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+
+    let mut file = fs::File::create(&tmp)?;
+    file.write_all(data.as_bytes())?;
+    file.sync_all()?;
+    drop(file);
+
+    fs::rename(&tmp, path)?;
+
+    // Persist the directory entry for the rename where the platform supports it
+    // (opening a directory as a file fails on Windows — best-effort there).
+    if let Ok(dir) = fs::File::open(parent) {
+        let _ = dir.sync_all();
+    }
+    Ok(())
 }
 
 // Read a file as utf8, returning "" when it doesn't exist (legacy ensure-file).
@@ -180,4 +221,58 @@ pub fn ensure_migrated(app: &AppHandle) {
             log::warn!("legacy vault migration failed: {e}");
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write_file;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn tmp_sidecar() -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "swifty-storage-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("vault.kdf.json")
+    }
+
+    fn tmp_sibling(path: &Path) -> PathBuf {
+        let mut tmp = path.to_path_buf().into_os_string();
+        tmp.push(".tmp");
+        PathBuf::from(tmp)
+    }
+
+    #[test]
+    fn atomic_write_round_trips_and_overwrites() {
+        let path = tmp_sidecar();
+        atomic_write_file(&path, "{\"algo\":\"argon2id\"}").unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "{\"algo\":\"argon2id\"}"
+        );
+
+        // Overwrite in place with shorter content — the target is fully replaced.
+        atomic_write_file(&path, "{}").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{}");
+
+        // A completed write leaves no temp file behind.
+        assert!(!tmp_sibling(&path).exists());
+    }
+
+    #[test]
+    fn leftover_temp_file_does_not_affect_the_target() {
+        let path = tmp_sidecar();
+        atomic_write_file(&path, "real").unwrap();
+
+        // Simulate a crash before a prior rename: a stale, partial temp sibling.
+        fs::write(tmp_sibling(&path), "garbage-partial").unwrap();
+
+        // Reading the sidecar (the target path) is unaffected by the temp file.
+        assert_eq!(fs::read_to_string(&path).unwrap(), "real");
+    }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -11,6 +11,10 @@ use crate::error::{Error, Result};
 
 pub const VAULT_FILE: &str = "vault.swftx";
 pub const DB_FILE: &str = "vault.db";
+// Plaintext KDF descriptor stored next to the DB. It holds the Argon2id params +
+// salt (public by design) and is read *before* deriving the key — the salt/params
+// cannot live inside the encrypted DB, since deriving the key is what opens it.
+pub const KDF_SIDECAR_FILE: &str = "vault.kdf.json";
 pub const GDRIVE_FILE: &str = "auth/gdrive.swftx";
 // Marker for "biometric unlock is enabled". The key itself lives in the OS
 // secure store; this flag lets us report availability without a biometric prompt.
@@ -50,6 +54,24 @@ pub fn db_exists(app: &AppHandle) -> bool {
 
 fn gdrive_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(GDRIVE_FILE))
+}
+
+fn kdf_sidecar_path(app: &AppHandle) -> Result<PathBuf> {
+    Ok(app_dir(app)?.join(KDF_SIDECAR_FILE))
+}
+
+// The KDF descriptor JSON, or `None` when absent (a sidecar-less legacy/dev DB).
+pub fn read_kdf_sidecar(app: &AppHandle) -> Result<Option<String>> {
+    let path = kdf_sidecar_path(app)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(fs::read_to_string(path)?))
+}
+
+// Write (or overwrite) the KDF descriptor sidecar. Authoritative for opening.
+pub fn write_kdf_sidecar(app: &AppHandle, json: &str) -> Result<()> {
+    write_file(&kdf_sidecar_path(app)?, json)
 }
 
 // Read a file as utf8, returning "" when it doesn't exist (legacy ensure-file).

--- a/src-tauri/src/store/migrate.rs
+++ b/src-tauri/src/store/migrate.rs
@@ -1,54 +1,16 @@
-//! Boundary adapter: legacy JSON `vault.swftx` → the new store. This is the one
+//! Boundary adapter between app entries and store `Record`s. This is the one
 //! file in the module that references the app's crypto/models — it is glue, not
-//! part of the pure trait, and stays thin. The store itself never sees this.
+//! part of the pure trait, and stays thin. The store itself never sees it.
 
-use std::fs;
-use std::path::Path;
+use super::Record;
+use crate::crypto::{Cryptor, PayloadCipher};
+use crate::error::Result;
+use crate::models::Entry;
 
-use super::{Record, VaultStore};
-use crate::crypto::Cryptor;
-use crate::error::{Error, Result};
-use crate::models::{Entry, VaultData};
-
-/// Read the encrypted legacy vault at `path`, decrypt it with `cryptor`, write
-/// every entry into `store` as a `Record` (payload = the app-encrypted blob),
-/// and retain the JSON alongside as `<path>.bak`. Returns the entry count.
-pub fn migrate_from_json(path: &Path, cryptor: &Cryptor, store: &impl VaultStore) -> Result<usize> {
-    let blob = fs::read_to_string(path)?;
-    let vault: VaultData = cryptor.decrypt_data(&blob)?;
-
-    let records = records_from_entries(&vault.entries, cryptor)?;
-    store
-        .import(&records)
-        .map_err(|e| Error::Other(e.to_string()))?;
-
-    backup(path)?;
-    Ok(records.len())
-}
-
-/// Map obscured (per-field-encrypted) entries to store `Record`s: metadata to
-/// columns, the whole entry re-sealed into the opaque payload. Shared by the
-/// JSON migration, backup restore, and per-entry save so the payload/metadata
-/// convention lives in exactly one place.
-pub fn records_from_entries(entries: &[Entry], cryptor: &Cryptor) -> Result<Vec<Record>> {
-    entries.iter().map(|e| to_record(e, cryptor)).collect()
-}
-
-/// Re-key one obscured entry from a *source* cryptor to the *current* one: expose
-/// its fields under `src`, re-obscure under `cur`, then seal a fresh `Record`.
-/// Used by `import_swftx` to merge a foreign `.swftx` encrypted under a different
-/// master password than the open vault's. Reuses `to_record`, so the
-/// payload/metadata convention stays in one place.
-pub fn rekey_record(src: &Cryptor, cur: &Cryptor, entry: &Entry) -> Result<Record> {
-    let exposed = src.expose(entry)?;
-    let reobscured = cur.obscure(&exposed)?;
-    to_record(&reobscured, cur)
-}
-
-// One obscured entry → one Record. Metadata goes to columns; the whole entry is
-// re-sealed by the app cryptor into the opaque payload (lossless round-trip).
-fn to_record(entry: &Entry, cryptor: &Cryptor) -> Result<Record> {
-    let payload = cryptor.encrypt_data(entry)?.into_bytes();
+/// Package a plaintext entry + its already-sealed payload into a store `Record`:
+/// non-secret metadata to columns, the opaque payload as-is. The single place the
+/// metadata/payload convention lives, shared by save and the `.swftx` imports.
+pub fn build_record(entry: &Entry, payload: Vec<u8>) -> Result<Record> {
     Ok(Record {
         id: entry.id.clone(),
         kind: entry.kind.clone(),
@@ -62,12 +24,23 @@ fn to_record(entry: &Entry, cryptor: &Cryptor) -> Result<Record> {
     })
 }
 
-// Copy the JSON vault to `<path>.bak`, never removing the original.
-fn backup(path: &Path) -> Result<()> {
-    let mut bak = path.as_os_str().to_owned();
-    bak.push(".bak");
-    fs::copy(path, bak)?;
-    Ok(())
+/// Re-seal `.swftx` entries (obscured under the source `Cryptor`, possibly a
+/// different master password) under the current session's payload cipher: expose
+/// each entry's plaintext, seal it, build a `Record`. Used by `import_backup` and
+/// `import_swftx`.
+pub fn reseal_swftx(
+    entries: &[Entry],
+    src: &Cryptor,
+    cipher: &PayloadCipher,
+) -> Result<Vec<Record>> {
+    entries.iter().map(|e| reseal_one(e, src, cipher)).collect()
+}
+
+/// Re-seal a single `.swftx` entry (used by the progress-emitting import loop).
+pub fn reseal_one(obscured: &Entry, src: &Cryptor, cipher: &PayloadCipher) -> Result<Record> {
+    let plain = src.expose(obscured)?;
+    let payload = cipher.seal(&plain)?;
+    build_record(&plain, payload)
 }
 
 fn host_of(website: &str) -> String {

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,10 +1,32 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::migrate::migrate_from_json;
-use super::{Record, SqliteStore, VaultStore};
+use super::{migrate, Record, SqliteStore, VaultStore};
+use crate::crypto::{self, KdfParams, VaultKey};
+use crate::models::Entry;
 
 const KEY: &[u8] = &[0x11; 32];
+
+// Low-cost Argon2id params keep the key-schedule tests fast; production uses the
+// 64 MiB defaults.
+fn argon2_params(salt: &[u8]) -> KdfParams {
+    KdfParams::argon2id(salt, 256, 1, 1)
+}
+
+fn argon2_key(password: &str, params: &KdfParams) -> VaultKey {
+    VaultKey::Argon2 {
+        master: crypto::derive(password.as_bytes(), params).unwrap(),
+    }
+}
+
+fn sample_entry() -> Entry {
+    serde_json::from_value(serde_json::json!({
+        "id": "1", "type": "login", "title": "Site",
+        "website": "https://ex.com/login", "username": "alice",
+        "password": "s3cret", "tags": ["work"]
+    }))
+    .unwrap()
+}
 
 // A fresh, unique DB path under the temp dir for each test.
 fn tmp_db() -> PathBuf {
@@ -180,31 +202,23 @@ fn reopening_a_migrated_db_is_idempotent() {
     assert_eq!(store.meta_get("schema_version").unwrap(), None);
 }
 
+// save_entry then reveal_entry, exercised through the Argon2id key schedule:
+// seal a plaintext entry under the payload key, upsert one row, unseal it back.
 #[test]
 fn save_then_reveal_round_trips_one_row() {
-    use super::migrate::records_from_entries;
-    use crate::crypto::Cryptor;
-    use crate::models::Entry;
+    let key = argon2_key("pw", &argon2_params(b"salt-a-01234567890123456789012345"));
+    let cipher = key.payload_cipher();
+    let store = SqliteStore::open(&tmp_db(), &key.sqlcipher_key()).unwrap();
 
-    let cryptor = Cryptor::new(&crate::crypto::hash_secret("pw"));
-    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
-
-    // save_entry: obscure the plaintext entry, seal it into one payload, upsert.
-    let plain: Entry = serde_json::from_value(serde_json::json!({
-        "id": "1", "type": "login", "title": "Site",
-        "website": "https://ex.com/login", "username": "alice",
-        "password": "s3cret", "tags": ["work"]
-    }))
-    .unwrap();
-    let obscured = cryptor.obscure(&plain).unwrap();
-    let recs = records_from_entries(&[obscured], &cryptor).unwrap();
-    store.upsert(&recs[0]).unwrap();
-
+    let entry = sample_entry();
+    let payload = cipher.seal(&entry).unwrap();
+    let record = migrate::build_record(&entry, payload).unwrap();
+    store.upsert(&record).unwrap();
     // Saving the same id again updates the single row (no whole-vault rewrite).
-    store.upsert(&recs[0]).unwrap();
+    store.upsert(&record).unwrap();
+
     let list = store.list().unwrap();
     assert_eq!(list.len(), 1);
-
     // The list carries only non-secret metadata — the password never appears.
     assert_eq!(list[0].url_host, "ex.com");
     let meta_json = serde_json::to_string(&(
@@ -216,29 +230,132 @@ fn save_then_reveal_round_trips_one_row() {
     .unwrap();
     assert!(!meta_json.contains("s3cret"));
 
-    // reveal_entry: unseal the payload, then decrypt the per-field secrets.
+    // reveal_entry: unseal the stored payload with the session payload key.
     let rec = store.get("1").unwrap().unwrap();
-    let blob = String::from_utf8(rec.payload).unwrap();
-    let revealed = cryptor
-        .expose(&cryptor.decrypt_data::<Entry>(&blob).unwrap())
-        .unwrap();
+    let revealed = cipher.unseal(&rec.payload).unwrap();
     assert_eq!(revealed.password.as_deref(), Some("s3cret"));
     assert_eq!(revealed.username.as_deref(), Some("alice"));
 }
 
-// import_swftx re-keys a `.swftx` encrypted under a *different* master password
-// into the open store: expose under the source key, re-obscure under the current
-// key, upsert. Reveal with the current key must return the original plaintext,
-// and importing twice must merge by id (no duplicate rows).
+// Setup writes an Argon2id descriptor; unlock re-derives from that (serialized)
+// descriptor and opens the same DB. A wrong password derives a different key and
+// the open fails.
 #[test]
-fn import_swftx_rekeys_across_passwords_and_upserts_by_id() {
-    use super::migrate::rekey_record;
+fn argon2_descriptor_reproduces_key_and_opens() {
+    let path = tmp_db();
+    let params = argon2_params(b"salt-b-01234567890123456789012345");
+
+    // setup: derive, open, save a sealed entry.
+    let key = argon2_key("master-pw", &params);
+    {
+        let store = SqliteStore::open(&path, &key.sqlcipher_key()).unwrap();
+        let cipher = key.payload_cipher();
+        let payload = cipher.seal(&sample_entry()).unwrap();
+        store
+            .upsert(&migrate::build_record(&sample_entry(), payload).unwrap())
+            .unwrap();
+    }
+
+    // The persisted descriptor is Argon2id and round-trips through JSON (sidecar).
+    let sidecar = params.to_json().unwrap();
+    assert!(sidecar.contains("\"algo\":\"argon2id\""));
+    let reloaded = KdfParams::from_json(&sidecar).unwrap();
+
+    // unlock: re-derive from the reloaded descriptor and reopen.
+    let key2 = argon2_key("master-pw", &reloaded);
+    let store2 = SqliteStore::open(&path, &key2.sqlcipher_key()).unwrap();
+    let revealed = key2
+        .payload_cipher()
+        .unseal(&store2.get("1").unwrap().unwrap().payload)
+        .unwrap();
+    assert_eq!(revealed.password.as_deref(), Some("s3cret"));
+
+    // A wrong password derives a different SQLCipher key → open fails.
+    let wrong = argon2_key("wrong-pw", &reloaded);
+    assert!(SqliteStore::open(&path, &wrong.sqlcipher_key()).is_err());
+}
+
+// Back-compat: a DB created with the legacy deterministic key (no sidecar) still
+// opens via the legacy `VaultKey` fallback, and its payloads unseal.
+#[test]
+fn legacy_sidecarless_vault_opens() {
+    let path = tmp_db();
+    let key = VaultKey::legacy_from_password("master-pw");
+    {
+        let store = SqliteStore::open(&path, &key.sqlcipher_key()).unwrap();
+        let payload = key.payload_cipher().seal(&sample_entry()).unwrap();
+        store
+            .upsert(&migrate::build_record(&sample_entry(), payload).unwrap())
+            .unwrap();
+    }
+
+    let key2 = VaultKey::legacy_from_password("master-pw");
+    let store2 = SqliteStore::open(&path, &key2.sqlcipher_key()).unwrap();
+    let revealed = key2
+        .payload_cipher()
+        .unseal(&store2.get("1").unwrap().unwrap().payload)
+        .unwrap();
+    assert_eq!(revealed.password.as_deref(), Some("s3cret"));
+}
+
+// change_master_password: re-seal every payload under the new payload key, rekey
+// the DB to the new SQLCipher key, and write a fresh descriptor. The new
+// descriptor + new password opens and reveals; the old key no longer opens.
+#[test]
+fn change_password_reseals_rekeys_and_new_descriptor_opens() {
+    let path = tmp_db();
+    let old = argon2_key(
+        "old-pw",
+        &argon2_params(b"salt-c-01234567890123456789012345"),
+    );
+    let store = SqliteStore::open(&path, &old.sqlcipher_key()).unwrap();
+    let payload = old.payload_cipher().seal(&sample_entry()).unwrap();
+    store
+        .upsert(&migrate::build_record(&sample_entry(), payload).unwrap())
+        .unwrap();
+
+    // Fresh Argon2id params (new salt) → new key; re-seal old→new, import, rekey.
+    let new_params = argon2_params(b"salt-d-01234567890123456789012345");
+    let new = argon2_key("new-pw", &new_params);
+    let (old_cipher, new_cipher) = (old.payload_cipher(), new.payload_cipher());
+    let resealed: Vec<Record> = store
+        .export_for_sync()
+        .unwrap()
+        .into_iter()
+        .map(|mut r| {
+            let entry = old_cipher.unseal(&r.payload).unwrap();
+            r.payload = new_cipher.seal(&entry).unwrap();
+            r
+        })
+        .collect();
+    store.import(&resealed).unwrap();
+    store.rekey(&new.sqlcipher_key()).unwrap();
+    drop(store);
+
+    // The old key no longer opens; the new descriptor + password does.
+    assert!(SqliteStore::open(&path, &old.sqlcipher_key()).is_err());
+    let reopened = argon2_key(
+        "new-pw",
+        &KdfParams::from_json(&new_params.to_json().unwrap()).unwrap(),
+    );
+    let store2 = SqliteStore::open(&path, &reopened.sqlcipher_key()).unwrap();
+    let revealed = reopened
+        .payload_cipher()
+        .unseal(&store2.get("1").unwrap().unwrap().payload)
+        .unwrap();
+    assert_eq!(revealed.password.as_deref(), Some("s3cret"));
+}
+
+// import_swftx re-seals a `.swftx` encrypted under a *different* master password
+// into the open store: expose under the source key, re-seal under the current
+// payload key, upsert. Reveal with the current key must return the original
+// plaintext, and importing twice must merge by id (no duplicate rows).
+#[test]
+fn import_swftx_reseals_across_passwords_and_upserts_by_id() {
     use crate::crypto::{hash_secret, Cryptor};
-    use crate::models::{Entry, VaultData};
+    use crate::models::VaultData;
 
     let src = Cryptor::new(&hash_secret("source-pw"));
-    let cur = Cryptor::new(&hash_secret("current-pw"));
-
     let plain: Vec<Entry> = ["1", "2"]
         .iter()
         .map(|id| {
@@ -258,30 +375,27 @@ fn import_swftx_rekeys_across_passwords_and_upserts_by_id() {
         })
         .unwrap();
 
-    // Decrypt the file with the source cryptor (as the command does), then re-key
-    // each entry into a store opened for the *current* session.
+    // Decrypt with the source cryptor (as the command does), then re-seal each
+    // entry under the current session's Argon2id payload key.
     let file: VaultData = src.decrypt_data(&blob).unwrap();
-    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
-    for obscured in &file.entries {
-        store
-            .upsert(&rekey_record(&src, &cur, obscured).unwrap())
-            .unwrap();
+    let key = argon2_key(
+        "current-pw",
+        &argon2_params(b"salt-e-01234567890123456789012345"),
+    );
+    let cipher = key.payload_cipher();
+    let store = SqliteStore::open(&tmp_db(), &key.sqlcipher_key()).unwrap();
+    for r in migrate::reseal_swftx(&file.entries, &src, &cipher).unwrap() {
+        store.upsert(&r).unwrap();
     }
-
     // Re-importing the same file merges by id — the count stays at 2.
-    for obscured in &file.entries {
-        store
-            .upsert(&rekey_record(&src, &cur, obscured).unwrap())
-            .unwrap();
+    for r in migrate::reseal_swftx(&file.entries, &src, &cipher).unwrap() {
+        store.upsert(&r).unwrap();
     }
-    let list = store.list().unwrap();
-    assert_eq!(list.len(), 2);
+    assert_eq!(store.list().unwrap().len(), 2);
 
-    // Reveal with the *current* key returns the original plaintext secrets.
-    let rec = store.get("1").unwrap().unwrap();
-    let payload = String::from_utf8(rec.payload).unwrap();
-    let revealed = cur
-        .expose(&cur.decrypt_data::<Entry>(&payload).unwrap())
+    // Reveal with the current payload key returns the original plaintext secrets.
+    let revealed = cipher
+        .unseal(&store.get("1").unwrap().unwrap().payload)
         .unwrap();
     assert_eq!(revealed.password.as_deref(), Some("hunter2"));
     assert_eq!(revealed.username.as_deref(), Some("alice"));
@@ -291,7 +405,7 @@ fn import_swftx_rekeys_across_passwords_and_upserts_by_id() {
 #[test]
 fn import_swftx_wrong_source_password_errors() {
     use crate::crypto::{hash_secret, Cryptor};
-    use crate::models::{Entry, VaultData};
+    use crate::models::VaultData;
 
     let src = Cryptor::new(&hash_secret("source-pw"));
     let entry: Entry = serde_json::from_value(serde_json::json!({
@@ -306,60 +420,4 @@ fn import_swftx_wrong_source_password_errors() {
 
     let wrong = Cryptor::new(&hash_secret("not-the-password"));
     assert!(wrong.decrypt_data::<VaultData>(&blob).is_err());
-}
-
-#[test]
-fn migrate_from_json_round_trips_and_keeps_bak() {
-    use crate::crypto::Cryptor;
-    use crate::models::{Entry, VaultData};
-
-    let cryptor = Cryptor::new(&crate::crypto::hash_secret("master-pw"));
-    let entries: Vec<Entry> = ["1", "2"]
-        .iter()
-        .map(|id| {
-            serde_json::from_value(serde_json::json!({
-                "id": id, "type": "login", "title": format!("Site {id}"),
-                "website": "https://example.com/login", "password": "hunter2",
-                "tags": ["work"], "createdAt": "2024-01-02T03:04:05Z"
-            }))
-            .unwrap()
-        })
-        .collect();
-    let obscured: Vec<Entry> = entries
-        .iter()
-        .map(|e| cryptor.obscure(e).unwrap())
-        .collect();
-    let blob = cryptor
-        .encrypt_data(&VaultData {
-            entries: obscured.clone(),
-        })
-        .unwrap();
-
-    let json_path = tmp_db().with_file_name("vault.swftx");
-    std::fs::write(&json_path, &blob).unwrap();
-
-    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
-    let n = migrate_from_json(&json_path, &cryptor, &store).unwrap();
-    assert_eq!(n, 2);
-
-    // Metadata landed in columns.
-    let list = store.list().unwrap();
-    assert_eq!(list.len(), 2);
-    assert_eq!(list[0].url_host, "example.com");
-
-    // Payload decrypts back to the identical (obscured) entries.
-    for (want, meta) in obscured.iter().zip(&list) {
-        let record = store.get(&meta.id).unwrap().unwrap();
-        let payload = String::from_utf8(record.payload).unwrap();
-        let got: Entry = cryptor.decrypt_data(&payload).unwrap();
-        assert_eq!(
-            serde_json::to_value(&got).unwrap(),
-            serde_json::to_value(want).unwrap()
-        );
-    }
-
-    // The legacy JSON is retained as a .bak sidecar.
-    let mut bak = json_path.into_os_string();
-    bak.push(".bak");
-    assert!(PathBuf::from(bak).exists());
 }

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -346,6 +346,51 @@ fn change_password_reseals_rekeys_and_new_descriptor_opens() {
     assert_eq!(revealed.password.as_deref(), Some("s3cret"));
 }
 
+// Crash-recovery composition for change_master_password: snapshot the old-keyed
+// DB, then re-key it (simulating a change that then "crashes"), then restore the
+// snapshot back over the DB. The recovered DB must open under the OLD key with the
+// original payload intact — proving the snapshot is a valid rollback point.
+#[test]
+fn snapshot_then_rekey_then_restore_recovers_old_key() {
+    let path = tmp_db();
+    let backup = path.with_file_name("vault.db.rekey-backup");
+    let old = argon2_key(
+        "old-pw",
+        &argon2_params(b"salt-f-01234567890123456789012345"),
+    );
+
+    {
+        let store = SqliteStore::open(&path, &old.sqlcipher_key()).unwrap();
+        let payload = old.payload_cipher().seal(&sample_entry()).unwrap();
+        store
+            .upsert(&migrate::build_record(&sample_entry(), payload).unwrap())
+            .unwrap();
+        // Recovery point, then the destructive rekey.
+        store.snapshot_to(&backup, &old.sqlcipher_key()).unwrap();
+        let new = argon2_key(
+            "new-pw",
+            &argon2_params(b"salt-g-01234567890123456789012345"),
+        );
+        store.rekey(&new.sqlcipher_key()).unwrap();
+    } // connection closed
+
+    // "Crash" rollback: drop stale WAL/SHM, copy the snapshot back over the DB.
+    for suffix in ["-wal", "-shm"] {
+        let mut p = path.clone().into_os_string();
+        p.push(suffix);
+        let _ = std::fs::remove_file(PathBuf::from(p));
+    }
+    std::fs::copy(&backup, &path).unwrap();
+
+    // The restored DB opens with the OLD key and the payload is intact.
+    let store = SqliteStore::open(&path, &old.sqlcipher_key()).unwrap();
+    let revealed = old
+        .payload_cipher()
+        .unseal(&store.get("1").unwrap().unwrap().payload)
+        .unwrap();
+    assert_eq!(revealed.password.as_deref(), Some("s3cret"));
+}
+
 // import_swftx re-seals a `.swftx` encrypted under a *different* master password
 // into the open store: expose under the source key, re-seal under the current
 // payload key, upsert. Reveal with the current key must return the original

--- a/src/components/Main/Sidebar/Settings/Vault.tsx
+++ b/src/components/Main/Sidebar/Settings/Vault.tsx
@@ -13,6 +13,9 @@ interface Props {
 
 export default function Vault({ section }: Props) {
   const [connecting, setConnecting] = useState(false)
+  const [password, setPassword] = useState('')
+  const [exporting, setExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const syncEnabled = useStore(state => state.sync.enabled)
 
   useEffect(() => setConnecting(false), [syncEnabled])
@@ -20,6 +23,16 @@ export default function Vault({ section }: Props) {
   const onConnect = () => {
     setConnecting(true)
     syncConnect()
+  }
+
+  const onExport = () => {
+    if (!password || exporting) return
+    setExporting(true)
+    setError(null)
+    exportVault(password)
+      .then(() => setPassword(''))
+      .catch(() => setError(t('Invalid master password')))
+      .finally(() => setExporting(false))
   }
 
   const syncAction = () => {
@@ -52,9 +65,26 @@ export default function Vault({ section }: Props) {
       <div className="section">
         <strong>{t('Backup')}</strong>
         <div>{t('Allows you to save a backup of your default vault file')}</div>
-        <div className="button pale iconed" onClick={() => exportVault()}>
+        <div className="threefour">
+          <input
+            type="password"
+            name="export_password"
+            placeholder={t('Master password')}
+            value={password}
+            disabled={exporting}
+            onChange={event => {
+              setError(null)
+              setPassword(event.target.value)
+            }}
+          />
+        </div>
+        <div
+          className={cx('button pale iconed', { disabled: !password || exporting })}
+          onClick={onExport}
+        >
           <DownloadIcon width="16" height="16" /> {t('Save Vault File')}
         </div>
+        {error && <span className="danger">{error}</span>}
       </div>
     </>
   )

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -185,7 +185,11 @@ export const importSwftx = (
   password: string
 ): Promise<number> => invoke('import_swftx', { path, password })
 
-export const exportVault = (): Promise<string | null> => invoke('export_vault')
+// Export a portable `.swftx` backup, encrypted under the master `password` so it
+// can be restored via import_backup on any install. The password must match the
+// unlocked vault.
+export const exportVault = (password: string): Promise<string | null> =>
+  invoke('export_vault', { password })
 
 // ---------------------------------------------------------------------------
 // Generator & OTP


### PR DESCRIPTION
Finishes **T-KDF-1** (Phase 2, KDF hardening) by wiring the merged Argon2id primitive into the merged SQLite storage. 🔴 OWNER-REVIEW (crypto).

## Key schedule
- `master = kdf::derive(password_bytes, &KdfParams)` — the master password is fed **directly** to Argon2id (`m=64MiB, t=3, p=4`); the `hash_secret` (`base64(SHA512(pw))`) pre-hash is dropped on this path.
- The 32-byte master is **HKDF-SHA256 split** (`crypto::hkdf_subkey`, one extract salt, distinct `info` labels) into two independent subkeys:
  - `sqlcipher-db-key` → the SQLCipher raw key
  - `payload-aead-key` → the per-entry payload key
- One KDF pass yields both keys; neither reveals the other. A third subkey (`legacy-cryptor-secret`) backs the disabled gdrive/sync token blob so that path stays self-consistent without holding the password.
- Modeled as `crypto::VaultKey` (held by the session) + `crypto::PayloadCipher`.

## Sidecar (the chicken-and-egg fix)
The KDF salt+params **cannot** live inside the encrypted DB — you need the key to open it. They live in a plaintext **`vault.kdf.json`** next to `vault.db` in the app-data dir (the `KdfParams` JSON: `algo`/`m_cost`/`t_cost`/`p_cost`/`salt`; the salt is public by design). It is read **before** deriving/opening and is **authoritative**; the descriptor is also mirrored into the `meta` table (`kdf` + `kdf_params`) for reference/integrity.

## Payload AEAD (new format)
Each entry payload is sealed with `payload_key` + a fresh random **16-byte nonce** (AES-256-GCM, matching the app's 16-byte-nonce convention): `nonce ‖ ciphertext ‖ tag`. No per-payload KDF. `reveal`/`save`/`get_audit`/import all use the session payload key (fast). `get_audit` now unseals straight to plaintext entries (no per-field decrypt).

## Back-compat (sidecar-less DBs)
If a `vault.db` exists with **no sidecar** (an interim/dev DB created before this change), unlock falls back to the legacy deterministic `sqlcipher_key(hash_secret(pw))` **and** the legacy per-field PBKDF2 `Cryptor` payload format, so existing dev vaults still open. Biometric unlock interprets the stored bytes by sidecar presence (Argon2id master vs legacy secret string).

## Command wiring
- **setup**: fresh `default_argon2id()` → write sidecar → derive → create DB keyed with `sqlcipher_key`; hold `payload_key` in the session.
- **unlock / unlock_biometric**: read sidecar → derive → open (wrong password fails the SQLCipher open → `InvalidPassword`); whole derive+open stays in the existing `spawn_blocking` off-thread path.
- **change_master_password**: verify current password → fresh Argon2id key (new salt) → re-seal every payload under the new `payload_key` → `PRAGMA rekey` the DB → rewrite the sidecar + `meta` → re-store the biometric key. Also upgrades a legacy sidecar-less vault to Argon2id.
- **import_swftx**: still decrypt the source `.swftx` with the legacy `Cryptor(source_password)`, then re-seal each entry under the current session `payload_key` (off-thread, emits `import:progress`).
- **import_backup**: decrypt `.swftx` (legacy) → create a fresh Argon2id vault under the same password → re-seal every entry.
- **export_vault**: now takes the master `password` (verified against the session) and rebuilds a portable legacy `.swftx` under `hash_secret(password)` so backups stay restorable via `import_backup`; the frontend prompts for it.

## Legacy harness
The legacy PBKDF2 `Cryptor` + golden/crosscheck harness are untouched (used for `.swftx` reads).

## Tests
`crypto/vault.rs`: key-schedule split is distinct, AEAD payload round-trips under the payload key, fresh nonce per seal, wrong key fails, legacy payload round-trips. `store/tests.rs`: setup writes an Argon2id descriptor + unlock re-derives from it and opens (wrong password fails), sidecar-less legacy DB opens, save→reveal round-trip, `.swftx` re-seal across passwords + upsert-by-id, change-password re-seals+rekeys+new-descriptor-opens (old key fails).

## Manual test steps
1. **New setup**: fresh start → create vault → confirm `vault.kdf.json` appears next to `vault.db`, contains `"algo":"argon2id"`.
2. **Lock/unlock**: add entries, lock (or wait for auto-lock), unlock with the master password → entries return; a wrong password is rejected.
3. **Reveal**: open an entry → secrets decrypt.
4. **Import**: Settings → Import from `.swftx` (a file under a *different* master password) → entries merge with a progress bar.
5. **Change password**: Settings → change master password → confirm the sidecar is rewritten and the vault re-locks/unlocks with the **new** password; the old password now fails.
6. **Export**: Settings → Vault → enter master password → Save Vault File → the exported `.swftx` restores via the fresh-start restore flow.
7. **Back-compat**: an existing dev `vault.db` with no sidecar still unlocks.

## Gates
`bun run typecheck` · `bun run lint` (0) · `bun run test` (56) · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` (0) · `cargo test --locked` (76) · crypto crosscheck (13 checks) — all green.
