### PR TITLE
fix(import): seal third-party entries via PayloadCipher after KDF wiring

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -1,6 +1,7 @@
 //! Import/export commands — the boundary between the pure `import` parser and the
 //! app's crypto/store. Parsing produces plaintext `ImportedEntry` values; writing
-//! reuses the same seal (`obscure` + `records_from_entries`) and upsert path as
+//! seals each with the session payload cipher (`PayloadCipher::seal` +
+//! `migrate::build_record`) and upserts — the same seal/record convention as
 //! `import_swftx`, so payload sealing is never reimplemented here.
 
 use std::fs;
@@ -108,23 +109,18 @@ pub async fn import_entries(
         });
     }
 
-    let cryptor = state.session.lock().unwrap().cryptor()?;
+    let cipher = state.session.lock().unwrap().payload_cipher()?;
     let entries: Vec<Entry> = parsed.entries.iter().map(imported_to_entry).collect();
 
-    // Seal every entry off the UI thread (obscure + build a Record), emitting
-    // progress — the same seal helper the rest of the app uses.
+    // Seal every plaintext entry off the UI thread (seal payload + build a
+    // Record), emitting progress — the same seal helper the rest of the app uses.
     let emitter = app.clone();
     let records = tauri::async_runtime::spawn_blocking(move || -> Result<Vec<Record>> {
         let total = entries.len();
         let mut records = Vec::with_capacity(total);
         for (i, entry) in entries.iter().enumerate() {
-            let obscured = cryptor.obscure(entry)?;
-            let mut built = migrate::records_from_entries(&[obscured], &cryptor)?;
-            records.push(
-                built
-                    .pop()
-                    .ok_or_else(|| Error::Other("record build failed".into()))?,
-            );
+            let payload = cipher.seal(entry)?;
+            records.push(migrate::build_record(entry, payload)?);
             let _ = emitter.emit("import:progress", json!({ "done": i + 1, "total": total }));
         }
         Ok(records)


### PR DESCRIPTION
## Problem — merged `v1-0-0` doesn't compile

The wave merged in the reverse of the recommended order: **#251 (import/export) landed before #252 (KDF wiring)**. #252 replaced the per-field `Cryptor` payload with the session `PayloadCipher` and removed `migrate::records_from_entries`, but #251's `commands/import.rs` still called it (`Cryptor::obscure` + `records_from_entries`).

GitHub merged both cleanly at the text level, but the combined tree fails to build:

```
error[E0425]: cannot find function `records_from_entries` in module `migrate`
  --> src/commands/import.rs:122
```

This broke **all Rust CI jobs** (Rust ×3 + Crypto compatibility) from `99e9d04` onward. The Frontend job was unaffected and stayed green.

## Fix

Third-party parsing already produces **plaintext** `Entry` values, so there's no need to obscure-then-reseal. Seal each directly with the session `PayloadCipher` and build the record via `migrate::build_record` — the same convention `save_entry` / `import_swftx` now use:

```rust
let cipher = state.session.lock().unwrap().payload_cipher()?;
// ...
let payload = cipher.seal(entry)?;
records.push(migrate::build_record(entry, payload)?);
```

No behavior change to the import flow (progress events, upsert, dry-run all untouched). Module doc comment updated to match.

## Verification (local, merged tree)

- `cargo build` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ (0) · `cargo test --locked` ✓ (91) · crypto crosscheck ✓ (13)
- Frontend `bun run build` ✓ · `bun run lint` ✓ · `typecheck` ✓ (0, after `bun install`)

Note: the `.tsx` vitest suites throw `transformWithOxc is not a function` on my local machine — that's a local node/bun toolchain quirk, not this tree: CI's Frontend job (which runs `bun run test`) is green on the same frozen lockfile.
