### PR TITLE
fix(ui): stop Tags filter infinite render loop (blank app)

### DIFF
--- a/src/components/Main/Header/Tags/index.tsx
+++ b/src/components/Main/Header/Tags/index.tsx
@@ -1,4 +1,4 @@
-import { useShallow } from 'zustand/react/shallow'
+import { useMemo } from 'react'
 import { useStore, setFilterTag, unsetFilterTag } from '@/store'
 import Chip from './Chip'
 
@@ -7,18 +7,22 @@ import Chip from './Chip'
 // chip filters the list to that tag; selecting it again clears the filter.
 export default function Tags() {
   const selected = useStore(state => state.filters.tags[0])
-  const tags = useStore(
-    useShallow(state => {
-      const counts = new Map<string, number>()
-      for (const item of state.entries.items) {
-        if (item.type !== state.filters.scope) continue
-        for (const tag of item.tags ?? []) {
-          counts.set(tag, (counts.get(tag) ?? 0) + 1)
-        }
+  // Select stable store references and derive the tag list in a memo — a
+  // selector that returns a freshly built array re-runs useSyncExternalStore
+  // forever (its snapshot is never referentially equal, even under useShallow,
+  // because the [tag, count] tuples are new references each pass).
+  const items = useStore(state => state.entries.items)
+  const scope = useStore(state => state.filters.scope)
+  const tags = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const item of items) {
+      if (item.type !== scope) continue
+      for (const tag of item.tags ?? []) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1)
       }
-      return Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]))
-    })
-  )
+    }
+    return Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+  }, [items, scope])
 
   if (tags.length === 0) return null
 

--- a/src/test/tags.test.tsx
+++ b/src/test/tags.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import Tags from '@/components/Main/Header/Tags'
+import { makeStore } from '@/store'
+import { renderWithStore, withEntries, loginMeta } from './utils'
+
+describe('Tags filter', () => {
+  // Regression: the selector used to build a fresh [tag, count][] inside the
+  // store selector, so useSyncExternalStore's snapshot was never referentially
+  // stable and React looped ("Maximum update depth exceeded"), blanking the app.
+  // A render that loops throws here; reaching the assertions proves it's stable.
+  it('renders a chip per in-scope tag without an infinite render loop', () => {
+    const store = makeStore()
+    withEntries(store, [
+      loginMeta({ id: 'a', tags: ['work', 'email'] }),
+      loginMeta({ id: 'b', tags: ['work'] })
+    ])
+
+    renderWithStore(<Tags />, { store })
+
+    expect(screen.getByText('work')).toBeInTheDocument()
+    expect(screen.getByText('email')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Symptom
On first live run of the redesigned app, entering the master password opened a **blank window**. Console:
- `The result of getSnapshot should be cached to avoid an infinite loop`
- `Error: Maximum update depth exceeded…`
- `An error occurred in the <Tags> component.`

## Root cause
`Main/Header/Tags/index.tsx` selected its data with `useShallow(state => Array.from(counts).sort())` — a **freshly built array of `[tag, count]` tuples** each call. `useShallow` compares one level deep with `Object.is`, and every nested tuple is a new reference, so the snapshot was *never* referentially equal → `useSyncExternalStore` looped → `<Tags>` threw → with no error boundary, the whole main view blanked. Only manifests once a vault has **tagged entries in the current scope** (empty/untagged vaults hit the `tags.length === 0` early return, which is why it wasn't seen until a real run).

## Fix
Select **stable** store references (`entries.items`, `filters.scope` — zustand returns the same reference until they change) and derive the tag list in a `useMemo`.

## Regression test
Adds `src/test/tags.test.tsx` rendering `<Tags>` with tagged in-scope entries — the exact condition the suite lacked. A looping render throws in the test, so it genuinely guards the regression.

## Verification
typecheck 0 · lint 0 · **58 tests** (57 + new) · build ok. Also confirmed live: the fix HMR'd into the running dev app and the main view renders.

## Notes
- Bug was introduced in the list-column redesign (#262) and is currently live on `v1-0-0`; this restores a working app. Grepped the codebase — `Tags` was the *only* `useShallow`/inline-new-array selector, so this is the sole instance.
- Class of gap: typecheck/lint/unit gates can't observe a `useSyncExternalStore` loop; only running the app surfaces it.