### PR TITLE
perf(ui): defer zxcvbn strength scoring off the render path

### DIFF
--- a/src/components/Main/Body/Aside/ui.tsx
+++ b/src/components/Main/Body/Aside/ui.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import { copy } from '@/services/copy'
-import { evaluate } from '@/services/strength'
+import { useStrength } from '@/hooks/useStrength'
 import { t } from '@/i18n'
 import { CopyGlyph } from '../../icons'
 
@@ -84,8 +84,11 @@ export function CopyButton({ value, title }: { value: string; title?: string }) 
 
 // Five-segment strength meter driven by the existing zxcvbn `evaluate`.
 export function StrengthBar({ password }: { password: string }) {
+  const strength = useStrength(password)
   if (!password) return null
-  const { score } = evaluate(password)
+  // Renders immediately as an empty bar and fills once the deferred score lands,
+  // so scoring never blocks the detail panel from painting on selection.
+  const score = strength?.score ?? null
   return (
     <div className="flex items-center gap-2.5">
       <span className="flex flex-none gap-[3px]">
@@ -94,13 +97,13 @@ export function StrengthBar({ password }: { password: string }) {
             key={i}
             className={cx(
               'h-[3px] w-[22px] rounded-full',
-              i <= score ? STRENGTH_COLOR[score] : 'bg-line2'
+              score !== null && i <= score ? STRENGTH_COLOR[score] : 'bg-line2'
             )}
           />
         ))}
       </span>
       <span className="font-mono text-[11px] text-text3">
-        {t(STRENGTH_LABELS[score])}
+        {score !== null ? t(STRENGTH_LABELS[score]) : ''}
       </span>
     </div>
   )

--- a/src/components/elements/PasswordStrength.tsx
+++ b/src/components/elements/PasswordStrength.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
 import { cx } from '@/utils/cx'
 import { t } from '@/i18n'
-import { evaluate, MIN_LENGTH } from '@/services/strength'
+import { MIN_LENGTH } from '@/services/strength'
+import { useStrength } from '@/hooks/useStrength'
 
 const LABELS = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
@@ -15,16 +15,17 @@ interface Props {
 // Non-punitive strength meter: a zxcvbn score bar plus guidance, no
 // composition rules. Renders nothing until the user starts typing.
 export default function PasswordStrength({ password }: Props) {
-  const { score, warning, suggestions, tooShort } = useMemo(
-    () => evaluate(password),
-    [password]
-  )
+  const strength = useStrength(password)
 
   if (!password) return null
 
+  // The length hint is instant; the zxcvbn-derived score/feedback fills in once
+  // the deferred evaluation lands, so typing never blocks on scoring.
+  const score = strength?.score ?? null
+  const tooShort = password.length < MIN_LENGTH
   const hint = tooShort
     ? `${t('Use at least')} ${MIN_LENGTH} ${t('characters')}`
-    : warning || suggestions[0] || ''
+    : strength?.warning || strength?.suggestions[0] || ''
 
   return (
     <div className="mx-auto mt-4 w-60">
@@ -34,13 +35,13 @@ export default function PasswordStrength({ password }: Props) {
             key={i}
             className={cx(
               'h-1 flex-1 rounded-full transition-colors',
-              i <= score ? SCORE_COLOR[score] : 'bg-line2'
+              score !== null && i <= score ? SCORE_COLOR[score] : 'bg-line2'
             )}
           />
         ))}
       </div>
       <div className="mt-1.5 flex justify-between gap-2 font-mono text-[11px] text-text3">
-        <span>{t(LABELS[score])}</span>
+        <span>{score !== null ? t(LABELS[score]) : ''}</span>
         {hint && <span className="text-right text-text3">{hint}</span>}
       </div>
     </div>

--- a/src/hooks/useStrength.ts
+++ b/src/hooks/useStrength.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import { evaluate, type Strength } from '@/services/strength'
+
+// zxcvbn scoring is synchronous and heavy (tens–hundreds of ms with the loaded
+// dictionaries). Running it inline in render blocks the paint — the entry detail
+// stalls when you select a login, and the setup field stutters while typing.
+// Defer it to a post-paint macrotask (which also debounces rapid changes): the UI
+// paints immediately and the score lands a moment later. Returns null until the
+// first evaluation resolves (and whenever the password is empty).
+export function useStrength(password: string): Strength | null {
+  const [strength, setStrength] = useState<Strength | null>(null)
+
+  useEffect(() => {
+    if (!password) {
+      setStrength(null)
+      return
+    }
+    const id = setTimeout(() => setStrength(evaluate(password)), 0)
+    return () => clearTimeout(id)
+  }, [password])
+
+  return strength
+}

--- a/src/test/strength.test.tsx
+++ b/src/test/strength.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useStrength } from '@/hooks/useStrength'
+
+describe('useStrength', () => {
+  // Guards the perf fix: zxcvbn is heavy and must NOT run during the synchronous
+  // render (that blocked the detail panel from painting on selection). A null on
+  // the first render proves scoring is deferred; the value lands right after.
+  it('defers scoring — null on first render, resolves after paint', async () => {
+    const { result } = renderHook(() => useStrength('a-fairly-strong-passphrase-42'))
+
+    expect(result.current).toBeNull()
+    await waitFor(() => expect(result.current).not.toBeNull())
+    expect(result.current?.score).toBeGreaterThanOrEqual(0)
+  })
+
+  it('resets to null when the password is cleared', async () => {
+    const { result, rerender } = renderHook(({ pw }) => useStrength(pw), {
+      initialProps: { pw: 'a-fairly-strong-passphrase-42' }
+    })
+    await waitFor(() => expect(result.current).not.toBeNull())
+
+    rerender({ pw: '' })
+    expect(result.current).toBeNull()
+  })
+})


### PR DESCRIPTION
## Symptom
Noticeable lag between clicking a **login** in the list and the right-hand detail panel rendering its fields.

## Root cause
`StrengthBar` (`Aside/ui.tsx`) called the **synchronous** `evaluate()` — i.e. `zxcvbn.check()` with the loaded `@zxcvbn-ts` common+en dictionaries + adjacency graphs — **inline in render**. That's tens-to-hundreds of ms on the main thread, so the detail panel only painted *after* scoring completed. The decrypt itself was already cheap: Rust `reveal_entry` is a single-row `get` + one AES-GCM `unseal` (session key in memory, no Argon2, no whole-vault read), and `setCurrentEntry` is synchronous, which is why the header/ledger appeared instantly but the fields stalled. The same inline `evaluate()` ran per keystroke in the setup `PasswordStrength` meter.

## Fix
New shared `useStrength()` hook runs `evaluate()` in a **post-paint macrotask** (which also debounces rapid changes) and returns `null` until it resolves. `StrengthBar` and `PasswordStrength` now paint immediately (empty bar) and fill a frame later — imperceptible, and the click→paint path no longer blocks. The setup length hint stays instant (not zxcvbn-derived). The one-shot `evaluate()` in `Setup/Enter`'s submit handler is intentionally left synchronous (it gates the Continue button and isn't on a hot path).

## Tests
`src/test/strength.test.tsx` guards the deferral contract (null on the synchronous render → resolves after paint; resets when cleared). Verifies scoring never runs inline again.

## Verification
typecheck 0 · lint 0 · **60 tests** (58 + 2) · build ok.