### PR TITLE
fix(dialog): run native file dialogs off the main thread (fix macOS hang)

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -53,13 +53,18 @@ pub struct ImportReport {
 }
 
 // Open a file picker for a third-party export (JSON / CSV).
+// Async + spawn_blocking so the blocking picker never runs on the main thread
+// (which would deadlock the event loop and hang the window).
 #[tauri::command]
-pub fn pick_import_file(app: AppHandle) -> Result<Option<String>> {
-    let file = app
-        .dialog()
-        .file()
-        .add_filter("Password exports", &["json", "csv"])
-        .blocking_pick_file();
+pub async fn pick_import_file(app: AppHandle) -> Result<Option<String>> {
+    let file = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .add_filter("Password exports", &["json", "csv"])
+            .blocking_pick_file()
+    })
+    .await
+    .map_err(|e| Error::Other(e.to_string()))?;
     Ok(file
         .and_then(|f| f.into_path().ok())
         .map(|p| p.to_string_lossy().into_owned()))
@@ -150,7 +155,7 @@ pub async fn import_entries(
 // Export the open vault to a third-party format. `path` may be supplied directly;
 // when None, a save dialog is shown. `format` is "bitwarden" or "csv".
 #[tauri::command]
-pub fn export_entries(
+pub async fn export_entries(
     path: Option<String>,
     format: String,
     app: AppHandle,
@@ -183,12 +188,16 @@ pub fn export_entries(
     let dest = match path {
         Some(p) => Some(std::path::PathBuf::from(p)),
         None => {
-            let chosen = app
-                .dialog()
-                .file()
-                .set_file_name(format!("swifty-export.{ext}"))
-                .add_filter("Export", &[ext])
-                .blocking_save_file();
+            // Off-main-thread so the blocking save dialog can't hang the window.
+            let chosen = tauri::async_runtime::spawn_blocking(move || {
+                app.dialog()
+                    .file()
+                    .set_file_name(format!("swifty-export.{ext}"))
+                    .add_filter("Export", &[ext])
+                    .blocking_save_file()
+            })
+            .await
+            .map_err(|e| Error::Other(e.to_string()))?;
             chosen.and_then(|f| f.into_path().ok())
         }
     };

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -60,13 +60,20 @@ pub fn delete_entry(id: String, state: State<'_, AppState>) -> Result<()> {
 }
 
 // Open a file picker for a `.swftx` backup. Returns the chosen path, or None if cancelled.
+// The blocking picker must run off the main thread: a sync command runs on the
+// main thread, and blocking there deadlocks the event loop (window hangs) while
+// the modal waits for it. spawn_blocking moves the wait off-main; the plugin
+// still presents the panel on the main thread internally.
 #[tauri::command]
-pub fn pick_backup(app: AppHandle) -> Result<Option<String>> {
-    let file = app
-        .dialog()
-        .file()
-        .add_filter("Swifty backup", &["swftx"])
-        .blocking_pick_file();
+pub async fn pick_backup(app: AppHandle) -> Result<Option<String>> {
+    let file = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .add_filter("Swifty backup", &["swftx"])
+            .blocking_pick_file()
+    })
+    .await
+    .map_err(|e| Error::Other(e.to_string()))?;
     Ok(file
         .and_then(|f| f.into_path().ok())
         .map(|p| p.to_string_lossy().into_owned()))
@@ -159,7 +166,7 @@ pub async fn import_swftx(
 // restorable via import_backup on any install. `password` must be the current
 // master password; a mismatch is rejected so a backup is never unrecoverable.
 #[tauri::command]
-pub fn export_vault(
+pub async fn export_vault(
     password: String,
     app: AppHandle,
     state: State<'_, AppState>,
@@ -181,12 +188,16 @@ pub fn export_vault(
         out.encrypt_data(&VaultData { entries })?
     };
 
-    let dest = app
-        .dialog()
-        .file()
-        .set_file_name("vault.swftx")
-        .add_filter("Swifty backup", &["swftx"])
-        .blocking_save_file();
+    // Off-main-thread so the blocking save dialog can't deadlock the event loop.
+    let dest = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .set_file_name("vault.swftx")
+            .add_filter("Swifty backup", &["swftx"])
+            .blocking_save_file()
+    })
+    .await
+    .map_err(|e| Error::Other(e.to_string()))?;
     let Some(dest) = dest.and_then(|f| f.into_path().ok()) else {
         return Ok(None);
     };


### PR DESCRIPTION
## Symptom
On macOS, opening any native file dialog **hangs the window** — the modal appears but nothing is selectable and the app is frozen. Breaks **Restore from backup**, **third-party Import**, and **Export**.

## Root cause
`pick_backup` (`vault.rs`), `pick_import_file` (`import.rs`), `export_vault` (`vault.rs`), and `export_entries` (`import.rs`) were **synchronous** `#[tauri::command] fn`s calling `.blocking_pick_file()` / `.blocking_save_file()` **directly**. Tauri v2 runs sync commands on the **main thread**, and a blocking modal there runs a nested loop while holding the main thread — the event loop can't pump the dialog, so it deadlocks. (The codebase already routes other heavy work through `spawn_blocking`; the dialog commands were the exception.)

## Fix
Make all four commands `async` and run the blocking dialog inside `tauri::async_runtime::spawn_blocking`. The dialog plugin still presents the panel on the main thread internally; only the *wait* moves off it, so the event loop stays live. Frontend-facing command names and arguments are unchanged.

## Verification
- **Live:** with this build, Restore → Choose file opens normally and imports a `.swftx` into a fresh Argon2 vault (previously a hard hang).
- **Gates:** `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo build --locked`, plus `bun run typecheck` / `lint` — all green.

## Impact
Release blocker for v1.0.0 on macOS — file import/export/restore is unusable without it. Found while diagnosing an unrelated reveal-latency report.