### PR TITLE
Design-system core: ruled scales, lucide icons, shared primitives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@zxcvbn-ts/language-common": "^4.1.3",
         "@zxcvbn-ts/language-en": "^4.1.1",
         "fuse.js": "^7.5.0",
+        "lucide-react": "^1.38.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "zustand": "^5.0.15",
@@ -47,7 +48,7 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.68.0",
         "vite": "^7.3.6",
-        "vite-plugin-svgr": "^5.2.0",
+        "vite-plugin-svgr": "4.5.0",
         "vitest": "^4.1.11",
         "webdriverio": "^8.46.0",
       },
@@ -1112,6 +1113,8 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
+    "lucide-react": ["lucide-react@1.38.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ=="],
+
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -1470,7 +1473,7 @@
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
-    "vite-plugin-svgr": ["vite-plugin-svgr@5.2.0", "", { "dependencies": { "@rollup/pluginutils": "^5.3.0", "@svgr/core": "^8.1.0", "@svgr/plugin-jsx": "^8.1.0" }, "peerDependencies": { "vite": ">=3.0.0" } }, "sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ=="],
+    "vite-plugin-svgr": ["vite-plugin-svgr@4.5.0", "", { "dependencies": { "@rollup/pluginutils": "^5.2.0", "@svgr/core": "^8.1.0", "@svgr/plugin-jsx": "^8.1.0" }, "peerDependencies": { "vite": ">=2.6.0" } }, "sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA=="],
 
     "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@zxcvbn-ts/language-common": "^4.1.3",
     "@zxcvbn-ts/language-en": "^4.1.1",
     "fuse.js": "^7.5.0",
+    "lucide-react": "^1.38.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "zustand": "^5.0.15"
@@ -66,7 +67,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.68.0",
     "vite": "^7.3.6",
-    "vite-plugin-svgr": "^5.2.0",
+    "vite-plugin-svgr": "4.5.0",
     "vitest": "^4.1.11",
     "webdriverio": "^8.46.0"
   }

--- a/src/components/Main/Body/Aside/Empty/index.tsx
+++ b/src/components/Main/Body/Aside/Empty/index.tsx
@@ -5,7 +5,7 @@ import { ShieldGlyph } from '../../../icons'
 export default function Empty() {
   return (
     <div className="flex min-h-full flex-col items-center justify-center text-center">
-      <div className="grid h-16 w-16 place-items-center rounded-[18px] bg-accent-soft text-accent">
+      <div className="grid h-16 w-16 place-items-center rounded-lg bg-accent-soft text-accent">
         <ShieldGlyph size={30} />
       </div>
       <h2 className="mt-5 text-2xl font-semibold tracking-[-0.025em] text-text">

--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -95,7 +95,7 @@ export default function Form({ entry }: Props) {
       <div className="mt-6 flex flex-col gap-4">{fields()}</div>
 
       {saveError && (
-        <div className="mt-4 rounded-xl border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
+        <div className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
           {saveError}
         </div>
       )}
@@ -105,7 +105,7 @@ export default function Form({ entry }: Props) {
           type="button"
           data-testid="cancel-entry-button"
           onClick={onCancel}
-          className="h-9 cursor-pointer rounded-lg px-4 text-[13px] text-text2 transition-colors hover:text-text"
+          className="h-9 cursor-pointer rounded-sm px-4 text-[13px] text-text2 transition-colors hover:text-text"
         >
           {t('Cancel')}
         </button>

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -27,13 +27,13 @@ export default function Card({ entry }: Props) {
   return (
     <div className="mt-3">
       <div className="grid grid-cols-[340px_minmax(0,1fr)] items-start gap-3.5">
-        <div className="relative flex h-[208px] flex-col overflow-hidden rounded-2xl border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-[18px] text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
+        <div className="relative flex h-[208px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-[18px] text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
           <div className="absolute -right-10 -top-16 h-[200px] w-[200px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
           <div className="flex items-start">
             <div className="flex-1 font-mono text-[11px] uppercase tracking-[0.18em] opacity-60">
               {entry.name || t('Card')}
             </div>
-            <div className="h-6 w-[34px] rounded border border-white/15 bg-white/10" />
+            <div className="h-6 w-[34px] rounded-[4px] border border-white/15 bg-white/10" />
           </div>
           <div className="flex-1" />
           <div className="font-mono text-[20px] tracking-[0.16em]">{number}</div>

--- a/src/components/Main/Body/Aside/Show/Details/Item/Tags.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/Tags.tsx
@@ -15,7 +15,7 @@ export default function Tags({ entry }: Props) {
       {entry.tags.map(tag => (
         <span
           key={tag}
-          className="grid h-6 place-items-center rounded-[7px] border border-line2 px-2.5 font-mono text-[11px] text-text2"
+          className="grid h-6 place-items-center rounded-sm border border-line2 px-2.5 font-mono text-[11px] text-text2"
         >
           {tag}
         </span>

--- a/src/components/Main/Body/Aside/Show/Details/Item/Totp.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/Totp.tsx
@@ -84,7 +84,7 @@ export default function Totp({ name, entry }: Props) {
       <button
         type="button"
         onClick={() => copy(code)}
-        className="mt-3 grid h-7 w-full cursor-pointer place-items-center rounded-lg border border-line2 text-[12px] text-text2 transition-colors hover:border-accent-line hover:text-text"
+        className="mt-3 grid h-7 w-full cursor-pointer place-items-center rounded-sm border border-line2 text-[12px] text-text2 transition-colors hover:border-accent-line hover:text-text"
       >
         {t('Copy code')}
       </button>

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -71,11 +71,11 @@ export default function Show({ entry }: Props) {
           >
             <TrashGlyph />
           </IconButton>
-          <Button size="sm" onClick={() => editEntry()}>{t('Edit')}</Button>
+          <Button size="md" onClick={() => editEntry()}>{t('Edit')}</Button>
         </div>
       </div>
 
-      <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-xl border border-line bg-[image:var(--card)]">
+      <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-line bg-[image:var(--card)]">
         {ledger.map((cell, i) => (
           <div
             key={cell.k}
@@ -91,7 +91,7 @@ export default function Show({ entry }: Props) {
 
       {revealed && <Details entry={revealed} />}
       {deleteError && (
-        <div className="mt-3 rounded-xl border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
+        <div className="mt-3 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
           {deleteError}
         </div>
       )}

--- a/src/components/Main/Body/Aside/ui.tsx
+++ b/src/components/Main/Body/Aside/ui.tsx
@@ -3,7 +3,12 @@ import { cx } from '@/utils/cx'
 import { copy } from '@/services/copy'
 import { useStrength } from '@/hooks/useStrength'
 import { t } from '@/i18n'
+import IconButton from '@/components/elements/IconButton'
 import { CopyGlyph } from '../../icons'
+
+// Re-export so existing detail-pane imports keep working; the primitive itself
+// now lives in elements/ and is shared with the header and Masterpass.
+export { IconButton }
 
 const STRENGTH_LABELS = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 const STRENGTH_COLOR = [
@@ -18,8 +23,7 @@ const STRENGTH_COLOR = [
 // mono label and copy affordance in Show / Form / Audit routes through these so
 // the token styling lives in one place.
 
-export const MONO_LABEL =
-  'font-mono text-[11px] uppercase tracking-[0.12em] text-text3'
+export const MONO_LABEL = 'font-mono text-xs uppercase tracking-label text-text3'
 
 // A bordered card surface on the gradient `--card` background.
 export function Panel({
@@ -32,44 +36,12 @@ export function Panel({
   return (
     <div
       className={cx(
-        'overflow-hidden rounded-xl border border-line bg-[image:var(--card)]',
+        'overflow-hidden rounded-lg border border-line bg-[image:var(--card)]',
         className
       )}
     >
       {children}
     </div>
-  )
-}
-
-// A 28px square icon button used for reveal/copy/edit affordances.
-export function IconButton({
-  onClick,
-  title,
-  active,
-  className,
-  children
-}: {
-  onClick?: () => void
-  title?: string
-  active?: boolean
-  className?: string
-  children: ReactNode
-}) {
-  return (
-    <button
-      type="button"
-      title={title}
-      onClick={onClick}
-      className={cx(
-        'grid h-7 w-7 flex-none cursor-pointer place-items-center rounded-[7px] transition-colors',
-        active
-          ? 'bg-accent-soft text-accent'
-          : 'text-text2 hover:bg-hover hover:text-text',
-        className
-      )}
-    >
-      {children}
-    </button>
   )
 }
 
@@ -102,7 +74,7 @@ export function StrengthBar({ password }: { password: string }) {
           />
         ))}
       </span>
-      <span className="font-mono text-[11px] text-text3">
+      <span className="font-mono text-xs text-text3">
         {score !== null ? t(STRENGTH_LABELS[score]) : ''}
       </span>
     </div>

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -13,7 +13,7 @@ interface Props {
 export default function Row({ glyph, title, sub }: Props) {
   return (
     <>
-      <div className="grid h-[30px] w-[30px] flex-none place-items-center rounded-[9px] bg-tile text-text2">
+      <div className="grid h-[30px] w-[30px] flex-none place-items-center rounded-lg bg-tile text-text2">
         {glyph}
       </div>
       <div className="min-w-0 flex-1">

--- a/src/components/Main/Header/LockButton.tsx
+++ b/src/components/Main/Header/LockButton.tsx
@@ -1,6 +1,7 @@
 import { flowAuth } from '@/store'
 import { lock } from '@/lib/commands'
 import { t } from '@/i18n'
+import IconButton from '@/components/elements/IconButton'
 import { LockGlyph } from '../icons'
 
 // Locks the vault straight from the top chrome (previously only reachable via
@@ -12,14 +13,13 @@ export default function LockButton() {
   }
 
   return (
-    <button
-      type="button"
-      data-testid="lock-vault-button"
+    <IconButton
+      testid="lock-vault-button"
       onClick={onLock}
       title={t('Lock')}
-      className="grid h-7 w-7 place-items-center rounded-[7px] text-text2 transition-colors hover:bg-hover hover:text-text [-webkit-app-region:no-drag]"
+      className="[-webkit-app-region:no-drag]"
     >
       <LockGlyph />
-    </button>
+    </IconButton>
   )
 }

--- a/src/components/Main/Header/Search.tsx
+++ b/src/components/Main/Header/Search.tsx
@@ -1,6 +1,7 @@
 import { useStore, setFilterQuery } from '@/store'
 import { t } from '@/i18n'
-import { SearchGlyph } from '../icons'
+import Kbd from '@/components/elements/Kbd'
+import { CloseGlyph, SearchGlyph } from '../icons'
 
 // Command-bar style search entry: search glyph, input, and a mono ⌘K chip that
 // swaps to a clear button once there's a query.
@@ -9,7 +10,7 @@ export default function Search() {
 
   return (
     <div className="flex-none [-webkit-app-region:no-drag]">
-      <div className="flex h-[30px] w-[400px] items-center gap-2.5 rounded-lg border border-line2 bg-field pl-[11px] pr-2 text-text3 transition-colors focus-within:border-accent-line">
+      <div className="flex h-7 w-[400px] items-center gap-2.5 rounded-sm border border-line2 bg-field pl-[11px] pr-2 text-text3 transition-colors focus-within:border-accent-line">
         <SearchGlyph className="flex-none" />
         <input
           type="search"
@@ -17,12 +18,10 @@ export default function Search() {
           placeholder={t('Search')}
           value={query}
           onChange={e => setFilterQuery(e.target.value)}
-          className="min-w-0 flex-1 border-0 bg-transparent text-xs text-text outline-none placeholder:text-text3 [&::-webkit-search-cancel-button]:hidden"
+          className="min-w-0 flex-1 border-0 bg-transparent text-base text-text outline-none placeholder:text-text3 [&::-webkit-search-cancel-button]:hidden"
         />
         {query === '' ? (
-          <span className="flex-none rounded-[5px] border border-line px-[5px] py-px font-mono text-[11px] text-text3">
-            ⌘K
-          </span>
+          <Kbd>⌘K</Kbd>
         ) : (
           <button
             type="button"
@@ -30,9 +29,7 @@ export default function Search() {
             aria-label={t('Clear')}
             className="grid h-4 w-4 flex-none place-items-center rounded-full text-text3 hover:text-text"
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
-              <path d="M6 6l12 12M18 6 6 18" />
-            </svg>
+            <CloseGlyph size={12} />
           </button>
         )}
       </div>

--- a/src/components/Main/Header/SyncIndicator.tsx
+++ b/src/components/Main/Header/SyncIndicator.tsx
@@ -28,7 +28,7 @@ export default function SyncIndicator() {
 
   return (
     <Tooltip content={message()}>
-      <div className="flex h-7 items-center gap-[7px] rounded-[7px] px-2.5 font-mono text-[11px] text-text3">
+      <div className="flex h-7 items-center gap-[7px] rounded-sm px-2.5 font-mono text-[11px] text-text3">
         <span className={cx('h-[5px] w-[5px] flex-none rounded-full', dot())} />
         {label()}
       </div>

--- a/src/components/Main/Header/Tags/Chip.tsx
+++ b/src/components/Main/Header/Tags/Chip.tsx
@@ -15,7 +15,7 @@ export default function Chip({ label, count, selected, onClick }: Props) {
       type="button"
       onClick={onClick}
       className={cx(
-        'flex h-[25px] flex-none items-center gap-1.5 rounded-[7px] border px-[9px] text-[11px] whitespace-nowrap',
+        'flex h-[25px] flex-none items-center gap-1.5 rounded-sm border px-[9px] text-[11px] whitespace-nowrap',
         selected
           ? 'border-accent-line bg-accent-soft text-accent'
           : 'border-line bg-transparent text-text2 hover:border-line2'

--- a/src/components/Main/Header/ThemeToggle.tsx
+++ b/src/components/Main/Header/ThemeToggle.tsx
@@ -1,5 +1,6 @@
 import { useStore, toggleTheme } from '@/store'
 import { t } from '@/i18n'
+import IconButton from '@/components/elements/IconButton'
 import { SunGlyph, MoonGlyph } from '../icons'
 
 // Light/dark toggle wired to the theme slice. Shows the icon for the theme it
@@ -9,13 +10,12 @@ export default function ThemeToggle() {
   const isDark = theme === 'dark'
 
   return (
-    <button
-      type="button"
+    <IconButton
       onClick={() => toggleTheme()}
       title={isDark ? t('Light mode') : t('Dark mode')}
-      className="grid h-7 w-7 place-items-center rounded-[7px] text-text2 transition-colors hover:bg-hover hover:text-text [-webkit-app-region:no-drag]"
+      className="[-webkit-app-region:no-drag]"
     >
       {isDark ? <SunGlyph /> : <MoonGlyph />}
-    </button>
+    </IconButton>
   )
 }

--- a/src/components/Main/Sidebar/Add.tsx
+++ b/src/components/Main/Sidebar/Add.tsx
@@ -16,7 +16,7 @@ export default function Add() {
       <div
         data-testid="add-entry-button"
         onClick={onAddEntry}
-        className="grid h-9 w-9 cursor-pointer place-items-center rounded-[11px] border border-dashed border-accent-line text-accent transition-colors hover:bg-accent-soft"
+        className="grid h-9 w-9 cursor-pointer place-items-center rounded-lg border border-dashed border-accent-line text-accent transition-colors hover:bg-accent-soft"
       >
         <PlusGlyph />
       </div>

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -4,9 +4,10 @@ import logo from '@/assets/images/swifty.png'
 export default function Brand() {
   return (
     <div
-      className="grid h-9 w-9 flex-none place-items-center overflow-hidden rounded-[11px]"
+      className="grid h-9 w-9 flex-none place-items-center overflow-hidden rounded-lg"
       style={{
-        background: 'linear-gradient(150deg, var(--c-accent), #2b3a8f)',
+        background:
+          'linear-gradient(150deg, var(--c-accent), var(--c-accent-deep))',
         boxShadow: '0 1px 0 rgba(255,255,255,.18) inset'
       }}
       title="Swifty"

--- a/src/components/Main/Sidebar/Settings/Navigation.tsx
+++ b/src/components/Main/Sidebar/Settings/Navigation.tsx
@@ -35,7 +35,7 @@ export default function Navigation({ section, onClick }: Props) {
           key={item.key}
           onClick={() => onClick(item.key)}
           className={cx(
-            'cursor-pointer rounded-lg px-3 py-2 text-[13px] transition-colors',
+            'cursor-pointer rounded-sm px-3 py-2 text-[13px] transition-colors',
             section === item.key
               ? 'bg-accent-soft font-medium text-accent'
               : 'text-text2 hover:bg-hover hover:text-text'

--- a/src/components/Main/Sidebar/Settings/Password.tsx
+++ b/src/components/Main/Sidebar/Settings/Password.tsx
@@ -36,7 +36,7 @@ export default function Password({ section }: Props) {
       <h1 className={H1}>{t('Password Settings')}</h1>
       <Row>
         <strong className={LABEL}>{t('Example')}</strong>
-        <div className="rounded-lg border border-line bg-field px-3 py-2.5 font-mono text-[14px] text-text">
+        <div className="rounded-sm border border-line bg-field px-3 py-2.5 font-mono text-[14px] text-text">
           {example}
         </div>
       </Row>
@@ -52,7 +52,7 @@ export default function Password({ section }: Props) {
             value={options.length}
             onChange={onLength}
           />
-          <div className="grid h-6 min-w-[32px] place-items-center rounded-md bg-accent-soft px-1.5 font-mono text-[12px] text-accent">
+          <div className="grid h-6 min-w-[32px] place-items-center rounded-sm bg-accent-soft px-1.5 font-mono text-[12px] text-accent">
             {options.length}
           </div>
         </div>

--- a/src/components/Main/Sidebar/Settings/index.tsx
+++ b/src/components/Main/Sidebar/Settings/index.tsx
@@ -21,7 +21,7 @@ export default function Settings() {
     <div className="settings">
       <Tooltip content={t('Settings')}>
         <div
-          className="settings-button grid h-9 w-9 cursor-pointer place-items-center rounded-[11px] text-text2 transition-colors hover:bg-hover hover:text-text"
+          className="settings-button grid h-9 w-9 cursor-pointer place-items-center rounded-lg text-text2 transition-colors hover:bg-hover hover:text-text"
           data-testid="settings-button"
           onClick={() => setModal(!modal)}
         >

--- a/src/components/Main/Sidebar/Switcher.tsx
+++ b/src/components/Main/Sidebar/Switcher.tsx
@@ -24,7 +24,7 @@ export default function Switcher() {
           <Tooltip content={t(label)} key={current}>
             <div
               className={cx(
-                'item relative grid h-9 w-9 cursor-pointer place-items-center rounded-[11px] transition-colors',
+                'item relative grid h-9 w-9 cursor-pointer place-items-center rounded-lg transition-colors',
                 selected
                   ? 'current bg-accent-soft text-accent'
                   : 'text-text2 hover:bg-hover hover:text-text'

--- a/src/components/Main/Sidebar/VaultHealth.tsx
+++ b/src/components/Main/Sidebar/VaultHealth.tsx
@@ -42,7 +42,7 @@ export default function VaultHealth() {
       <div
         onClick={() => setFilterScope('audit')}
         className={cx(
-          'grid h-9 w-9 cursor-pointer place-items-center rounded-[11px] transition-colors',
+          'grid h-9 w-9 cursor-pointer place-items-center rounded-lg transition-colors',
           selected
             ? 'bg-accent-soft text-accent'
             : 'text-text2 hover:bg-hover hover:text-text'

--- a/src/components/Main/icons.tsx
+++ b/src/components/Main/icons.tsx
@@ -1,141 +1,69 @@
-// Inline, single-colour stroke icons for the app shell (rail + top chrome).
-// They paint with `currentColor` so a `text-*` token themes them in both light
-// and dark — unlike the legacy filled SVG assets, which hard-code black.
+// The app's icon set: lucide, themed through `currentColor` so a `text-*`
+// token colors every glyph in both themes.
+//
+// System rules (from the Keyring design system):
+//   · stroke 1.75 — tracks the prototype's 1.7 hairline look (lucide's
+//     default 2 reads too heavy at our sizes)
+//   · two sizes — 14 inside 24–28px controls, 16 everywhere else
+//     (rows, tiles, rail); call sites may override for hero surfaces
+//
+// Components keep the historical `*Glyph` names so this module stays the one
+// place an icon choice lives.
+import {
+  ChevronDown,
+  Copy,
+  CreditCard,
+  Download,
+  Eye,
+  EyeOff,
+  FileText,
+  Fingerprint,
+  Globe,
+  Lock,
+  Moon,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  Settings,
+  ShieldCheck,
+  Sun,
+  Trash2,
+  X,
+  type LucideIcon
+} from 'lucide-react'
 
 interface IconProps {
   size?: number
   className?: string
 }
 
-const stroke = (size: number, className: string | undefined, children: React.ReactNode) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.7}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className}
-  >
-    {children}
-  </svg>
-)
+const glyph =
+  (Icon: LucideIcon, defaultSize: 14 | 16) =>
+  ({ size = defaultSize, className }: IconProps) => (
+    <Icon size={size} strokeWidth={1.75} className={className} />
+  )
 
-export const SearchGlyph = ({ size = 14, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <circle cx="11" cy="11" r="7" />
-      <path d="M16.5 16.5 21 21" />
-    </>
-  ))
+// Control tier (24–28px hit areas)
+export const SearchGlyph = glyph(Search, 14)
+export const LockGlyph = glyph(Lock, 14)
+export const SunGlyph = glyph(Sun, 14)
+export const MoonGlyph = glyph(Moon, 14)
+export const CopyGlyph = glyph(Copy, 14)
+export const EyeGlyph = glyph(Eye, 14)
+export const EyeOffGlyph = glyph(EyeOff, 14)
+export const PencilGlyph = glyph(Pencil, 14)
+export const TrashGlyph = glyph(Trash2, 14)
+export const RefreshGlyph = glyph(RefreshCw, 14)
+export const DownloadGlyph = glyph(Download, 14)
+export const CloseGlyph = glyph(X, 14)
+export const ChevronDownGlyph = glyph(ChevronDown, 14)
+export const FingerprintGlyph = glyph(Fingerprint, 14)
 
-export const PlusGlyph = ({ size = 16, className }: IconProps) =>
-  stroke(size, className, <path d="M12 5v14M5 12h14" />)
-
-export const LockGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <rect x="4.5" y="10.5" width="15" height="10" rx="2.5" />
-      <path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" />
-    </>
-  ))
-
-export const SunGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <circle cx="12" cy="12" r="4" />
-      <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
-    </>
-  ))
-
-export const MoonGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />)
-
-export const GearGlyph = ({ size = 17, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <circle cx="12" cy="12" r="3.2" />
-      <path d="M12 3v2.6M12 18.4V21M3 12h2.6M18.4 12H21M5.6 5.6l1.9 1.9M16.5 16.5l1.9 1.9M18.4 5.6l-1.9 1.9M7.5 16.5l-1.9 1.9" />
-    </>
-  ))
-
-export const LoginGlyph = ({ size = 17, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
-    </>
-  ))
-
-export const NoteGlyph = ({ size = 17, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <rect x="5" y="3" width="14" height="18" rx="2" />
-      <path d="M9 8h6M9 12h6M9 16h4" />
-    </>
-  ))
-
-export const CardGlyph = ({ size = 17, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <rect x="3" y="6" width="18" height="12" rx="2" />
-      <path d="M3 10h18" />
-    </>
-  ))
-
-export const CopyGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <rect x="9" y="9" width="11" height="11" rx="2.5" />
-      <path d="M15.5 5.5H6.5a2 2 0 0 0-2 2v9" />
-    </>
-  ))
-
-export const EyeGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <path d="M2.5 12S6 6.5 12 6.5 21.5 12 21.5 12 18 17.5 12 17.5 2.5 12 2.5 12Z" />
-      <circle cx="12" cy="12" r="2.6" />
-    </>
-  ))
-
-export const EyeOffGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <path d="M2.5 12S6 6.5 12 6.5c1.6 0 3 .4 4.2 1M21.5 12S18 17.5 12 17.5c-1.6 0-3-.4-4.2-1" />
-      <path d="M9.9 9.9a2.6 2.6 0 0 0 3.7 3.7M4 4l16 16" />
-    </>
-  ))
-
-export const PencilGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.8-2.8L5 17v3Z" />
-      <path d="M13.5 6.5l4 4" />
-    </>
-  ))
-
-export const TrashGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M5 7h14M9 7V5h6v2M7 7l1 12h8l1-12" />)
-
-export const RefreshGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M19 12a7 7 0 1 1-2.6-5.4M19 4v4h-4" />)
-
-export const DownloadGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M12 4v11m0 0-4-4m4 4 4-4M5 19h14" />)
-
-export const CloseGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M6 6l12 12M18 6 6 18" />)
-
-export const ChevronDownGlyph = ({ size = 15, className }: IconProps) =>
-  stroke(size, className, <path d="M6 9l6 6 6-6" />)
-
-export const ShieldGlyph = ({ size = 17, className }: IconProps) =>
-  stroke(size, className, (
-    <>
-      <path d="M12 3.5 5.5 6v6c0 4 2.8 6.8 6.5 8.5 3.7-1.7 6.5-4.5 6.5-8.5V6Z" />
-      <path d="M9 12l2 2 4-4" />
-    </>
-  ))
+// Row / tile / rail tier
+export const PlusGlyph = glyph(Plus, 16)
+export const GearGlyph = glyph(Settings, 16)
+export const LoginGlyph = glyph(Globe, 16)
+export const NoteGlyph = glyph(FileText, 16)
+export const CardGlyph = glyph(CreditCard, 16)
+export const ShieldGlyph = glyph(ShieldCheck, 16)

--- a/src/components/Start/Choice.tsx
+++ b/src/components/Start/Choice.tsx
@@ -11,10 +11,10 @@ export default function Choice({ onSelect }: Props) {
   return (
     <AuthShell meta={`${t('offline')} · aes-256-gcm`}>
       <Eyebrow>{t('Welcome to Swifty')}</Eyebrow>
-      <h1 className="mt-8 text-center text-2xl font-medium tracking-tight text-text">
+      <h1 className="mt-8 text-center text-2xl font-medium tracking-display text-text">
         {t('Set up your vault')}
       </h1>
-      <p className="mx-auto mt-3 max-w-sm text-center text-sm leading-relaxed text-text2">
+      <p className="mx-auto mt-3 max-w-sm text-center text-base leading-relaxed text-text2">
         {t('Create a new vault or restore from an existing backup.')}
       </p>
       <div className="mx-auto mt-9 flex w-72 max-w-full flex-col gap-3">

--- a/src/components/Start/Restore/index.tsx
+++ b/src/components/Start/Restore/index.tsx
@@ -16,10 +16,10 @@ export default function Restore({ goBack }: Props) {
   return (
     <AuthShell meta={`${t('offline')} · aes-256-gcm`} onBack={goBack}>
       <Eyebrow tone="accent">{t('Restore')}</Eyebrow>
-      <h1 className="mt-8 text-center text-2xl font-medium tracking-tight text-text">
+      <h1 className="mt-8 text-center text-2xl font-medium tracking-display text-text">
         {t('Restore Backup')}
       </h1>
-      <p className="mx-auto mt-3 max-w-md text-center text-sm leading-relaxed text-text2">
+      <p className="mx-auto mt-3 max-w-md text-center text-base leading-relaxed text-text2">
         {chosen ? t('Enter the Master Password for this backup') : t('Restore Instructions')}
       </p>
 

--- a/src/components/Start/Setup/index.tsx
+++ b/src/components/Start/Setup/index.tsx
@@ -16,10 +16,10 @@ export default function Setup({ goBack }: Props) {
   return (
     <AuthShell meta={`${t('offline')} · aes-256-gcm`} onBack={goBack}>
       <Eyebrow tone="accent">{t('New vault')}</Eyebrow>
-      <h1 className="mt-8 text-center text-2xl font-medium tracking-tight text-text">
+      <h1 className="mt-8 text-center text-2xl font-medium tracking-display text-text">
         {t('Account Setup')}
       </h1>
-      <p className="mx-auto mt-3 max-w-md text-center text-sm leading-relaxed text-text2">
+      <p className="mx-auto mt-3 max-w-md text-center text-base leading-relaxed text-text2">
         {confirming ? t('Confirm your Master Password') : t('Setup Instructions')}
       </p>
 

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 
 type Variant = 'primary' | 'ghost' | 'pale' | 'danger'
-type Size = 'sm' | 'md'
+// Two control heights, per the design system: md 28px (inline actions, pairs
+// with 28px icon buttons) and lg 36px (form/CTA tier, pairs with 36px inputs).
+type Size = 'md' | 'lg'
 
 interface Props {
   variant?: Variant
@@ -10,6 +12,8 @@ interface Props {
   // Full-width auth call-to-action treatment (taller, mono uppercase) used by the
   // lock/setup/restore flows. Overrides `size`.
   block?: boolean
+  // Borderless keyboard hint rendered after the label (e.g. '⏎', '⌘⏎').
+  kbd?: string
   loading?: boolean
   disabled?: boolean
   onClick?: () => void
@@ -19,30 +23,31 @@ interface Props {
 }
 
 const base =
-  'relative inline-flex items-center justify-center gap-2 rounded-lg font-medium cursor-pointer select-none transition-[filter,background,opacity,color] disabled:cursor-default'
+  'relative inline-flex items-center justify-center gap-2 rounded-sm text-base font-medium cursor-pointer select-none transition-[filter,background,opacity,color] disabled:cursor-default'
 
 const sizes: Record<Size, string> = {
-  sm: 'h-8 px-3.5 text-[12px]',
-  md: 'h-9 px-4 text-[13px]'
+  md: 'h-7 px-3',
+  lg: 'h-9 px-4'
 }
 
-const blockStyle = 'w-full px-5 py-3 font-mono text-[13px] uppercase tracking-[0.12em]'
+const blockStyle = 'w-full px-5 py-3 font-mono uppercase tracking-label'
 
 const variants: Record<Variant, string> = {
-  primary: 'bg-accent text-accent-fg hover:brightness-110',
+  primary:
+    'bg-accent text-accent-fg shadow-[inset_0_1px_0_rgba(255,255,255,0.16)] hover:brightness-[1.09]',
   ghost: 'border border-line bg-tile text-text hover:bg-hover',
   pale: 'border border-line2 bg-field text-text2 hover:border-accent-line hover:text-text',
-  danger: 'bg-bad text-white hover:brightness-110'
+  danger:
+    'bg-bad text-accent-fg shadow-[inset_0_1px_0_rgba(255,255,255,0.16)] hover:brightness-[1.09]'
 }
 
 // Shared token-styled button. Serves both the full-width auth CTAs (`block`) and
-// the inline settings/form actions (`size`, `loading`, `disabled`). Replaces the
-// legacy `.button` SASS and unifies the two buttons that were introduced in
-// parallel during the redesign.
+// the inline settings/form actions (`size`, `loading`, `disabled`).
 export default function Button({
   variant = 'primary',
-  size = 'md',
+  size = 'lg',
   block,
+  kbd,
   loading,
   disabled,
   onClick,
@@ -67,6 +72,7 @@ export default function Button({
       )}
     >
       {children}
+      {kbd && <span className="font-mono text-xs opacity-75">{kbd}</span>}
       {loading && (
         <span className="absolute right-3 h-3.5 w-3.5 animate-spin rounded-full border-2 border-transparent border-t-current" />
       )}

--- a/src/components/elements/IconButton.tsx
+++ b/src/components/elements/IconButton.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+
+// THE 28px square icon affordance (reveal, copy, lock, theme, close, ...).
+// One idle ink (text2), one hover (bg-hover + text), one active treatment
+// (accent-soft wash) — the hover/active language for every naked icon control.
+export default function IconButton({
+  onClick,
+  title,
+  label,
+  active,
+  className,
+  testid,
+  children
+}: {
+  onClick?: () => void
+  title?: string
+  // Accessible name; falls back to `title`.
+  label?: string
+  active?: boolean
+  className?: string
+  testid?: string
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={label ?? title}
+      data-testid={testid}
+      onClick={onClick}
+      className={cx(
+        'grid h-7 w-7 flex-none cursor-pointer place-items-center rounded-sm transition-colors',
+        active
+          ? 'bg-accent-soft text-accent'
+          : 'text-text2 hover:bg-hover hover:text-text',
+        className
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/elements/Kbd.tsx
+++ b/src/components/elements/Kbd.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+// Keyboard-hint chip (⌘K, ⏎, esc). Bordered mono micro text on any surface;
+// inside a filled primary Button use its `kbd` prop instead (borderless).
+export default function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex-none rounded-sm border border-line px-[5px] py-px font-mono text-xs text-text3">
+      {children}
+    </span>
+  )
+}

--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -1,7 +1,13 @@
-import { useState, type ChangeEvent, type KeyboardEvent, type ReactNode } from 'react'
+import { useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { cx } from '@/utils/cx'
 import { t } from '@/i18n'
 import Error from '../Error'
+import IconButton from '../IconButton'
+import {
+  EyeGlyph,
+  FingerprintGlyph,
+  LockGlyph
+} from '@/components/Main/icons'
 import Dots from './Dots'
 import KeyCuts from './KeyCuts'
 
@@ -22,55 +28,9 @@ interface Props {
   onTouchID?: () => void
 }
 
-function IconButton({
-  children,
-  label,
-  className,
-  active,
-  onClick
-}: {
-  children: ReactNode
-  label: string
-  className?: string
-  active?: boolean
-  onClick?: () => void
-}) {
-  return (
-    <button
-      type="button"
-      title={label}
-      aria-label={label}
-      onClick={onClick}
-      className={cx(
-        'grid h-[30px] w-[30px] place-items-center rounded-lg border-0 bg-transparent transition-colors hover:bg-hover',
-        active ? 'text-accent' : 'text-text3 hover:text-text',
-        className
-      )}
-    >
-      {children}
-    </button>
-  )
-}
-
-const EyeIcon = (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M2.9 12S6.7 6 12 6s9.1 6 9.1 6-3.8 6-9.1 6-9.1-6-9.1-6Z" />
-    <circle cx="12" cy="12" r="2.8" />
-  </svg>
-)
-
-const FingerprintIcon = (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
-    <path d="M12 4.6c-3.6 0-6.5 2.7-6.5 6v3.1M12 4.6c3.6 0 6.5 2.7 6.5 6v5.1M9 12.3c0-1.6 1.3-2.8 3-2.8s3 1.2 3 2.8v5.5M12 13v6.4M5.9 17.6v1.8M18.4 18.7v.9" />
-  </svg>
-)
-
-const LockIcon = (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="4.8" y="11" width="14.4" height="9.2" rx="2.4" />
-    <path d="M7.7 11V8.2a4.3 4.3 0 0 1 8.6 0V11" />
-  </svg>
-)
+const EyeIcon = <EyeGlyph size={16} />
+const FingerprintIcon = <FingerprintGlyph size={16} />
+const LockIcon = <LockGlyph size={16} />
 
 // Shared master-passphrase field. The real value lives in the (uncontrolled)
 // input; a mirrored copy drives the dot overlay and key-cut count. Masking is
@@ -130,7 +90,7 @@ export default function Masterpass({
       >
         <input
           type={reveal ? 'text' : 'password'}
-          className="absolute inset-0 w-full border-0 bg-transparent text-center font-mono tracking-[0.3em] outline-none placeholder:text-base placeholder:tracking-normal placeholder:text-text3"
+          className="absolute inset-0 w-full border-0 bg-transparent text-center font-mono tracking-[0.3em] outline-none placeholder:text-[15px] placeholder:tracking-[0em] placeholder:text-text3"
           style={{
             fontSize: lock ? 26 : 22,
             color: reveal ? 'var(--c-text)' : 'transparent',
@@ -166,7 +126,7 @@ export default function Masterpass({
           <div className="mt-5 flex items-center justify-between gap-4">
             <span
               className={cx(
-                'font-mono text-[11px] uppercase tracking-[0.14em] transition-colors',
+                'font-mono text-xs uppercase tracking-label transition-colors',
                 bad ? 'text-bad' : 'text-text3'
               )}
             >

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -13,13 +13,13 @@ export default function Modal({ onClose, children }: Props) {
       onClick={onClose}
     >
       <div
-        className="relative flex max-h-[80vh] w-full max-w-[720px] overflow-hidden rounded-2xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
+        className="relative flex max-h-[80vh] w-full max-w-[720px] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
         onClick={e => e.stopPropagation()}
       >
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-3 top-3 z-10 grid h-7 w-7 cursor-pointer place-items-center rounded-[7px] text-text3 transition-colors hover:bg-hover hover:text-text"
+          className="absolute right-3 top-3 z-10 grid h-7 w-7 cursor-pointer place-items-center rounded-sm text-text3 transition-colors hover:bg-hover hover:text-text"
         >
           <CloseGlyph />
         </button>

--- a/src/components/elements/TagsInput.tsx
+++ b/src/components/elements/TagsInput.tsx
@@ -27,12 +27,12 @@ export default function TagsInput({ value, onChange }: Props) {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5 rounded-[9px] border border-line2 bg-field px-2 py-1.5 transition-colors focus-within:border-accent-line">
+    <div className="flex flex-wrap items-center gap-1.5 rounded-sm border border-line2 bg-field px-2 py-1.5 transition-colors focus-within:border-accent-line">
       {value.map(tag => (
         <span
           key={tag}
           onClick={() => removeTag(tag)}
-          className="flex cursor-pointer items-center gap-1 rounded-[6px] bg-accent-soft px-2 py-1 font-mono text-[11px] text-accent hover:brightness-95"
+          className="flex cursor-pointer items-center gap-1 rounded-sm bg-accent-soft px-2 py-1 font-mono text-[11px] text-accent hover:brightness-95"
         >
           {tag}
           <span className="opacity-60">×</span>

--- a/src/components/elements/Tooltip.tsx
+++ b/src/components/elements/Tooltip.tsx
@@ -10,7 +10,7 @@ interface Props {
 export default function Tooltip({ content, className, children }: Props) {
   return (
     <div className={cx('group/tt relative', className)}>
-      <div className="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-text px-2.5 py-1 text-[12px] text-detail opacity-0 shadow-[var(--shadow)] transition-opacity duration-150 group-hover/tt:opacity-100">
+      <div className="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-[12px] text-detail opacity-0 shadow-[var(--shadow)] transition-opacity duration-150 group-hover/tt:opacity-100">
         {content}
       </div>
       {children}

--- a/src/components/elements/UpdateToast.tsx
+++ b/src/components/elements/UpdateToast.tsx
@@ -48,13 +48,13 @@ function ReadyToast({ version, notes }: { version: string; notes: string | null 
         <div className="mt-3 flex gap-2">
           <Button
             variant="pale"
-            size="sm"
+            size="md"
             onClick={restarting ? undefined : dismiss}
           >
             {t('Later')}
           </Button>
           <Button
-            size="sm"
+            size="md"
             loading={restarting}
             onClick={restarting ? undefined : onRestart}
           >

--- a/src/components/elements/formStyles.ts
+++ b/src/components/elements/formStyles.ts
@@ -1,13 +1,13 @@
 // Shared token-styled form control classes for the redesign.
 
 export const inputClass =
-  'w-full rounded-[9px] border border-line2 bg-field px-3 py-2.5 text-[13px] leading-[1.4] text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line'
+  'w-full rounded-sm border border-line2 bg-field px-3 py-2.5 text-[13px] leading-[1.4] text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line'
 
 export const labelClass =
   'mb-[7px] block font-mono text-[11px] uppercase tracking-[0.1em] text-text3'
 
 export const selectClass =
-  'w-full appearance-none rounded-[9px] border border-line2 bg-field px-3 py-2.5 pr-9 text-[13px] text-text outline-none transition-colors focus:border-accent-line'
+  'w-full appearance-none rounded-sm border border-line2 bg-field px-3 py-2.5 pr-9 text-[13px] text-text outline-none transition-colors focus:border-accent-line'
 
 export const checkboxClass =
   'h-4 w-4 flex-none accent-accent'

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -33,6 +33,34 @@
     opacity: 0.9;
   }
 }
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes pop {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes sheet {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
 
 /*
  * App-wide base (replaces the old base.sass / typography.sass). Preflight
@@ -51,8 +79,57 @@
     background: var(--c-app);
     color: var(--c-text);
     font-family: var(--font-sans);
-    font-size: 14px;
+    font-size: 13px; /* the design's base tier; see --text-base below */
     -webkit-font-smoothing: antialiased;
+  }
+
+  ::selection {
+    background: var(--c-accent-soft);
+  }
+
+  /* Padded-thumb scrollbars from the Keyring prototype (`.kr-scroll`), global. */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--thumb);
+    border: 3px solid transparent;
+    background-clip: padding-box;
+    border-radius: 99px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  /*
+   * Keyboard-visible focus, everywhere (the prototype has none — deliberate
+   * facelift). Text fields opt out: they signal focus via border-accent-line.
+   */
+  :focus-visible {
+    outline: 2px solid var(--c-accent-line);
+    outline-offset: 2px;
+  }
+  textarea:focus-visible,
+  input:where(
+      [type='text'],
+      [type='password'],
+      [type='search'],
+      [type='email'],
+      [type='number'],
+      :not([type])
+    ):focus-visible {
+    outline: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    ::before,
+    ::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
   }
 }
 
@@ -88,6 +165,52 @@
   --color-good: var(--c-good);
   --color-warn: var(--c-warn);
   --color-bad: var(--c-bad);
+  --color-accent-deep: var(--c-accent-deep);
+}
+
+/*
+ * Scale tokens — the deliberately tiny design system distilled from the
+ * Keyring prototype. Each namespace is reset first so only the ruled values
+ * exist: an off-scale class (`text-sm`, `rounded-md`, `tracking-wide`, ...)
+ * simply doesn't compile, which keeps the system honest.
+ *
+ *   Type      xs 11px mono micro (labels/meta/counts/kbd)
+ *             base 13px everything readable — hierarchy via weight + ink
+ *             lg 16 / xl 20 / 2xl 24 display tiers
+ *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
+ *             secret .08em (revealed secrets, card numbers, TOTP)
+ *   Radius    sm 8 controls · lg 12 tiles & cards · xl 14 overlays
+ *   Motion    one duration (160ms), one easing, three shapes (fade/pop/sheet)
+ */
+@theme {
+  --text-*: initial;
+  --text-xs: 11px;
+  --text-xs--line-height: 1.35;
+  --text-base: 13px;
+  --text-base--line-height: 1.45;
+  --text-lg: 16px;
+  --text-lg--line-height: 1.3;
+  --text-xl: 20px;
+  --text-xl--line-height: 1.25;
+  --text-2xl: 24px;
+  --text-2xl--line-height: 1.2;
+
+  --tracking-*: initial;
+  --tracking-label: 0.12em;
+  --tracking-display: -0.02em;
+  --tracking-secret: 0.08em;
+
+  --radius-*: initial;
+  --radius-sm: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 14px;
+
+  --default-transition-duration: 160ms;
+  --default-transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  --animate-fade: fade 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  --animate-pop: pop 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  --animate-sheet: sheet 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 /*
@@ -119,6 +242,9 @@
   --c-good: #1e9c6e;
   --c-warn: #b7761a;
   --c-bad: #c9453a;
+  /* Deep end of the brand gradient; same in both themes (it sits under the
+   * accent, which does adapt). */
+  --c-accent-deep: #2b3a8f;
 
   /* Design vars that aren't color utilities (gradients/shadows/scrims). */
   --card: linear-gradient(180deg, #ffffff, #fbfbfc);


### PR DESCRIPTION
First slice of the Keyring design port + facelift plan.

## What
Distills the prototype into a deliberately tiny, enforced token system (Tailwind v4 namespaces are **reset**, so off-scale classes don't compile):

| Scale | Values |
|---|---|
| Type | xs 11px (mono micro) · base 13px (all readable text) · 16 / 20 / 24 display |
| Tracking | label .12em · display −.02em · secret .08em |
| Radius | sm 8 (controls) · lg 12 (tiles/cards) · xl 14 (overlays) |
| Heights | 24 · 28 · 36 |
| Motion | one duration (160ms), one easing; fade/pop/sheet keyframes; reduced-motion guard |

- **Icons → lucide-react** behind the existing `*Glyph` API (stroke 1.75, sizes 14/16); inline SVGs in Masterpass/Search removed
- Global polish never ported from the prototype: styled scrollbars (`--thumb` finally used), `::selection`, and a `:focus-visible` ring (facelift — the prototype has none)
- `Button`: md 28 / lg 36, primary inset top-light + `kbd` hint prop, danger uses `accent-fg`
- New shared `IconButton` (unifies 3 divergent copies) + `Kbd`; Brand gradient tokenized (`--c-accent-deep`)

## Fix
`vite-plugin-svgr` pinned to 4.5.0: v5.2 takes the oxc transform path under vitest 4's rolldown meta, but plain vite 7 exports no `transformWithOxc` — broke on any clean install (stale node_modules was masking it).

## Tests
- `bun run test`: 60/60 green
- `bun run build`: green
- All e2e testids untouched

Part of the redesign plan; next: pixel-exact sweep of remaining components.