### PR TITLE
Pixel-exact sweep: every component on the ruled scales

### DIFF
--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -47,10 +47,12 @@ export default function Score({ audit }: Props) {
         />
       </svg>
       <div className="text-center">
-        <div className="text-[34px] font-semibold tracking-[-0.03em] text-text">
+        {/* 34px is a documented one-off: the dial numeral sits above the 24px
+            display tier so it fills the ring. */}
+        <div className="text-[34px] font-semibold tracking-display text-text">
           {score}
         </div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-text3">
+        <div className="font-mono text-xs uppercase tracking-label text-text3">
           {t('Overall Score')}
         </div>
       </div>

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -35,8 +35,8 @@ export default function Audit() {
               className="flex items-center gap-3 px-4 py-3 shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none"
             >
               <span className={`h-[7px] w-[7px] flex-none rounded-full ${s.dot}`} />
-              <span className="flex-1 text-[13px] text-text2">{s.label}</span>
-              <span className="font-mono text-[13px] text-text">{s.value}</span>
+              <span className="flex-1 text-base text-text2">{s.label}</span>
+              <span className="font-mono text-base text-text">{s.value}</span>
             </div>
           ))}
       </Panel>

--- a/src/components/Main/Body/Aside/Empty/Actions.tsx
+++ b/src/components/Main/Body/Aside/Empty/Actions.tsx
@@ -21,7 +21,7 @@ export default function Actions() {
       <Button onClick={() => newEntry()}>{t('Create First Entry')}</Button>
       {SYNC_ENABLED && (
         <>
-          <span className="text-[12px] text-text3">{t('or')}</span>
+          <span className="text-base text-text3">{t('or')}</span>
           <Button variant="pale" loading={loading} onClick={onImport}>
             {t('Import from Gdrive')}
           </Button>

--- a/src/components/Main/Body/Aside/Empty/index.tsx
+++ b/src/components/Main/Body/Aside/Empty/index.tsx
@@ -8,10 +8,10 @@ export default function Empty() {
       <div className="grid h-16 w-16 place-items-center rounded-lg bg-accent-soft text-accent">
         <ShieldGlyph size={30} />
       </div>
-      <h2 className="mt-5 text-2xl font-semibold tracking-[-0.025em] text-text">
+      <h2 className="mt-5 text-2xl font-semibold tracking-display text-text">
         Swifty
       </h2>
-      <p className="mt-2 max-w-[320px] text-[13px] text-text2">
+      <p className="mt-2 max-w-[320px] text-base text-text2">
         {t('Keep your passwords safe and organized')}
       </p>
       <Actions />

--- a/src/components/Main/Body/Aside/Form/Field.tsx
+++ b/src/components/Main/Body/Aside/Form/Field.tsx
@@ -1,7 +1,11 @@
 import { cx } from '@/utils/cx'
 import type { EntryDraft } from '@/defaults/entries'
 import { valueOf, type FieldChange } from './helpers'
-import { inputClass, labelClass } from '@/components/elements/formStyles'
+import {
+  inputClass,
+  labelClass,
+  textareaClass
+} from '@/components/elements/formStyles'
 
 interface Props {
   label: string
@@ -24,14 +28,14 @@ export default function Field({
 }: Props) {
   const value = valueOf(entry, name)
   const error = validate && value.trim() === ''
-  const control = cx(inputClass, error && '!border-bad')
+  const invalid = error && '!border-bad'
 
   return (
     <div>
       <label className={labelClass}>{label}</label>
       {rows ? (
         <textarea
-          className={cx(control, 'resize-none')}
+          className={cx(textareaClass, invalid, 'resize-none')}
           name={name}
           rows={rows}
           value={value}
@@ -40,7 +44,7 @@ export default function Field({
         />
       ) : (
         <input
-          className={control}
+          className={cx(inputClass, invalid)}
           name={name}
           type="text"
           value={value}

--- a/src/components/Main/Body/Aside/Form/Login.tsx
+++ b/src/components/Main/Body/Aside/Form/Login.tsx
@@ -35,7 +35,7 @@ export default function Login({
       <Field label={t('Username')} name="username" validate={validate} entry={entry} onChange={onChange} maxLength={40} />
       <SecureField label={t('Password')} name="password" validate={validate} entry={entry} onChange={onChange} maxLength={100}>
         <span
-          className="flex cursor-pointer items-center gap-1.5 text-[12px] text-accent hover:brightness-110"
+          className="flex cursor-pointer items-center gap-1.5 text-base text-accent hover:brightness-110"
           onClick={generate}
         >
           <RefreshGlyph size={13} />

--- a/src/components/Main/Body/Aside/Form/SecureField.tsx
+++ b/src/components/Main/Body/Aside/Form/SecureField.tsx
@@ -2,7 +2,11 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import type { EntryDraft } from '@/defaults/entries'
 import { valueOf, type FieldChange } from './helpers'
-import { inputClass, labelClass } from '@/components/elements/formStyles'
+import {
+  inputClass,
+  labelClass,
+  textareaClass
+} from '@/components/elements/formStyles'
 import { IconButton } from '../ui'
 import { EyeGlyph, EyeOffGlyph } from '../../../icons'
 
@@ -33,7 +37,7 @@ export default function SecureField({
   const mask: CSSProperties = {
     WebkitTextSecurity: show ? 'none' : 'disc'
   } as CSSProperties
-  const control = cx(inputClass, '!pr-10', error && '!border-bad')
+  const control = cx('!pr-10', error && '!border-bad')
 
   return (
     <div>
@@ -41,7 +45,7 @@ export default function SecureField({
       <div className="relative">
         {rows ? (
           <textarea
-            className={cx(control, 'resize-none')}
+            className={cx(textareaClass, control, 'resize-none')}
             name={name}
             rows={rows}
             value={value}
@@ -51,7 +55,7 @@ export default function SecureField({
           />
         ) : (
           <input
-            className={control}
+            className={cx(inputClass, control)}
             name={name}
             type="text"
             value={value}
@@ -61,7 +65,7 @@ export default function SecureField({
           />
         )}
         <IconButton
-          className="absolute right-1.5 top-1.5"
+          className="absolute top-1 right-1"
           active={show}
           onClick={() => setShow(!show)}
         >

--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -88,14 +88,14 @@ export default function Form({ entry }: Props) {
   return (
     <div className="mx-auto max-w-[560px]">
       <div className={MONO_LABEL}>{t(KIND_LABEL[type])}</div>
-      <h1 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-text">
+      <h1 className="mt-2 text-2xl font-semibold tracking-display text-text">
         {entry ? t('Edit') : t('New Secret')}
       </h1>
 
       <div className="mt-6 flex flex-col gap-4">{fields()}</div>
 
       {saveError && (
-        <div className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
+        <div className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-base text-bad">
           {saveError}
         </div>
       )}
@@ -105,7 +105,7 @@ export default function Form({ entry }: Props) {
           type="button"
           data-testid="cancel-entry-button"
           onClick={onCancel}
-          className="h-9 cursor-pointer rounded-sm px-4 text-[13px] text-text2 transition-colors hover:text-text"
+          className="h-9 cursor-pointer rounded-sm px-4 text-base text-text2 transition-colors hover:text-text"
         >
           {t('Cancel')}
         </button>

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -27,6 +27,9 @@ export default function Card({ entry }: Props) {
   return (
     <div className="mt-3">
       <div className="grid grid-cols-[340px_minmax(0,1fr)] items-start gap-3.5">
+        {/* Card art: an always-dark plastic-card visual, deliberately off-system.
+            Its gradient, hex inks, 16/4px radii and face letter-spacings imitate a
+            real card, so they are exempt from the type/radius/tracking scales. */}
         <div className="relative flex h-[208px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-[18px] text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
           <div className="absolute -right-10 -top-16 h-[200px] w-[200px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
           <div className="flex items-start">
@@ -55,7 +58,7 @@ export default function Card({ entry }: Props) {
 
         <Panel>
           <div className="flex items-center gap-3 px-3.5 py-3 shadow-[inset_0_-1px_0_var(--c-line)]">
-            <span className="flex-1 text-[12px] text-text2">
+            <span className="flex-1 text-base text-text2">
               {t('Reveal number & CVC')}
             </span>
             <IconButton

--- a/src/components/Main/Body/Aside/Show/Details/Item/Tags.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/Tags.tsx
@@ -15,7 +15,7 @@ export default function Tags({ entry }: Props) {
       {entry.tags.map(tag => (
         <span
           key={tag}
-          className="grid h-6 place-items-center rounded-sm border border-line2 px-2.5 font-mono text-[11px] text-text2"
+          className="grid h-6 place-items-center rounded-sm border border-line2 px-2.5 font-mono text-xs text-text2"
         >
           {tag}
         </span>

--- a/src/components/Main/Body/Aside/Show/Details/Item/Totp.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/Totp.tsx
@@ -74,17 +74,17 @@ export default function Totp({ name, entry }: Props) {
             strokeDasharray={dash}
           />
         </svg>
-        <div className="font-mono text-[20px] tracking-[0.1em] text-text">
+        <div className="font-mono text-xl tracking-secret text-text">
           {`${code.slice(0, 3)} ${code.slice(3)}`}
         </div>
       </div>
-      <div className="font-mono text-[11px] text-text3">
+      <div className="font-mono text-xs text-text3">
         {t('refreshes in {n}s').replace('{n}', String(time))}
       </div>
       <button
         type="button"
         onClick={() => copy(code)}
-        className="mt-3 grid h-7 w-full cursor-pointer place-items-center rounded-sm border border-line2 text-[12px] text-text2 transition-colors hover:border-accent-line hover:text-text"
+        className="mt-3 grid h-7 w-full cursor-pointer place-items-center rounded-sm border border-line2 text-base text-text2 transition-colors hover:border-accent-line hover:text-text"
       >
         {t('Copy code')}
       </button>

--- a/src/components/Main/Body/Aside/Show/Details/Item/index.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Item/index.tsx
@@ -51,14 +51,12 @@ export default function Item({ entry, name, link, cc, secure, big, children }: P
 
   return (
     <div className="item flex items-center gap-3 px-3.5 py-3 shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none">
-      <span className={`w-[92px] flex-none ${MONO_LABEL} tracking-[0.1em]`}>
-        {t(name)}
-      </span>
+      <span className={`w-24 flex-none ${MONO_LABEL}`}>{t(name)}</span>
       <span
         className={
           big
-            ? 'min-w-0 flex-1 break-all font-mono text-[18px] tracking-[0.04em] text-text'
-            : 'min-w-0 flex-1 break-all font-mono text-[13px] text-text'
+            ? 'min-w-0 flex-1 break-all font-mono text-xl tracking-secret text-text'
+            : 'min-w-0 flex-1 break-all font-mono text-base text-text'
         }
         style={maskStyle}
         data-testid={`entry-value-${name.toLowerCase()}`}

--- a/src/components/Main/Body/Aside/Show/Details/Note.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Note.tsx
@@ -11,7 +11,7 @@ export default function Note({ entry }: Props) {
     <div className="mt-3">
       <Panel>
         <div
-          className="whitespace-pre-wrap break-words px-4 py-4 text-[13px] leading-relaxed text-text2"
+          className="whitespace-pre-wrap break-words px-4 py-4 text-base leading-relaxed text-text2"
           data-testid="entry-value-note"
         >
           {entry.note}

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -42,15 +42,18 @@ export default function Show({ entry }: Props) {
 
   return (
     <div className="mx-auto max-w-[860px]">
+      {/* `copied-notification` + `hidden` are toggled by services/copy.ts; the
+          display flip is what replays `animate-pop`. Centering uses auto margins
+          instead of a translate so the pop's transform doesn't fight it. */}
       <div
-        className="copied-notification hidden fixed left-1/2 top-4 z-50 w-max -translate-x-1/2 rounded-full bg-text px-5 py-2 text-[13px] text-detail shadow-[var(--shadow)]"
+        className="copied-notification hidden animate-pop fixed inset-x-0 top-4 z-50 mx-auto w-max rounded-full bg-text px-5 py-2 text-base text-detail shadow-[var(--shadow)]"
       >
         {t('Copied to Clipboard')}
       </div>
 
       <div className="flex items-start gap-4">
         <div className="min-w-0 flex-1">
-          <div className={`flex items-center gap-2 whitespace-nowrap ${MONO_LABEL} tracking-[0.14em]`}>
+          <div className={`flex items-center gap-2 whitespace-nowrap ${MONO_LABEL}`}>
             <span className="text-text2">{t(KIND_LABEL[entry.type])}</span>
             {entry.urlHost && (
               <>
@@ -59,7 +62,7 @@ export default function Show({ entry }: Props) {
               </>
             )}
           </div>
-          <h1 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-text">
+          <h1 className="mt-2 text-2xl font-semibold tracking-display text-text">
             {entry.title}
           </h1>
         </div>
@@ -79,10 +82,14 @@ export default function Show({ entry }: Props) {
         {ledger.map((cell, i) => (
           <div
             key={cell.k}
-            className={i < ledger.length - 1 ? 'border-r border-line px-3.5 py-3' : 'px-3.5 py-3'}
+            className={
+              i < ledger.length - 1
+                ? 'border-r border-line px-3.5 py-[11px]'
+                : 'px-3.5 py-[11px]'
+            }
           >
             <div className={MONO_LABEL}>{cell.k}</div>
-            <div className="mt-1.5 truncate font-mono text-[12px] text-text2">
+            <div className="mt-1.5 truncate font-mono text-base text-text2">
               {cell.v}
             </div>
           </div>
@@ -91,7 +98,7 @@ export default function Show({ entry }: Props) {
 
       {revealed && <Details entry={revealed} />}
       {deleteError && (
-        <div className="mt-3 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-[13px] text-bad">
+        <div className="mt-3 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-base text-bad">
           {deleteError}
         </div>
       )}

--- a/src/components/Main/Body/DetailPane.tsx
+++ b/src/components/Main/Body/DetailPane.tsx
@@ -5,7 +5,7 @@ import Aside from './Aside'
 // the current content stays functional and readable in both themes.
 export default function DetailPane() {
   return (
-    <div className="flex min-w-0 flex-1 flex-col overflow-y-auto bg-detail p-6 text-text">
+    <div className="flex min-w-0 flex-1 flex-col overflow-y-auto bg-detail pt-[26px] px-[34px] pb-[60px] text-text">
       <Aside />
     </div>
   )

--- a/src/components/Main/Body/List/Audit/Group.tsx
+++ b/src/components/Main/Body/List/Audit/Group.tsx
@@ -15,11 +15,11 @@ export default function Group({ title, entries }: Props) {
   return (
     <div>
       <div className="sticky top-0 z-[1] flex items-center gap-2 bg-list px-4 pb-1.5 pt-3">
-        <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-text3">
+        <span className="font-mono text-xs uppercase tracking-label text-text3">
           {t(title)}
         </span>
         <span className="h-px flex-1 bg-line" />
-        <span className="font-mono text-[11px] text-text3">{entries.length}</span>
+        <span className="font-mono text-xs text-text3">{entries.length}</span>
       </div>
       {entries.map(entry => (
         <Item entry={entry} key={entry.id} />

--- a/src/components/Main/Body/List/Audit/index.tsx
+++ b/src/components/Main/Body/List/Audit/index.tsx
@@ -17,7 +17,7 @@ export default function AuditList() {
 
   if (!audit)
     return (
-      <div className="px-4 py-6 font-mono text-[11px] uppercase tracking-[0.14em] text-text3">
+      <div className="px-4 py-6 font-mono text-xs uppercase tracking-label text-text3">
         {t('Loading Results..')}
       </div>
     )

--- a/src/components/Main/Body/List/Empty.tsx
+++ b/src/components/Main/Body/List/Empty.tsx
@@ -3,7 +3,7 @@ import { t } from '@/i18n'
 export default function Empty() {
   return (
     <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
-      <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-text3">
+      <div className="font-mono text-xs uppercase tracking-label text-text3">
         {t('No Items')}
       </div>
     </div>

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -17,11 +17,11 @@ export default function Row({ glyph, title, sub }: Props) {
         {glyph}
       </div>
       <div className="min-w-0 flex-1">
-        <div className="truncate text-[13px] font-medium tracking-[-0.01em] text-text">
+        <div className="truncate text-base font-medium text-text">
           {title}
         </div>
         {sub && (
-          <div className="mt-0.5 truncate font-mono text-[11px] text-text3">
+          <div className="mt-0.5 truncate font-mono text-xs text-text3">
             {sub}
           </div>
         )}

--- a/src/components/Main/Body/ListColumn.tsx
+++ b/src/components/Main/Body/ListColumn.tsx
@@ -11,10 +11,10 @@ export default function ListColumn() {
   return (
     <div className="flex w-[348px] min-h-0 flex-none flex-col border-r border-line bg-list">
       <div className="flex-none px-4 pt-4 pb-2.5">
-        <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-text3">
+        <div className="font-mono text-xs uppercase tracking-label text-text3">
           {scopeEyebrow(scope)}
         </div>
-        <div className="mt-1.5 text-xl font-semibold tracking-[-0.025em] text-text">
+        <div className="mt-1.5 text-xl font-semibold tracking-display text-text">
           {scopeTitle(scope)}
         </div>
         <Tags />

--- a/src/components/Main/Header/LockButton.tsx
+++ b/src/components/Main/Header/LockButton.tsx
@@ -17,7 +17,6 @@ export default function LockButton() {
       testid="lock-vault-button"
       onClick={onLock}
       title={t('Lock')}
-      className="[-webkit-app-region:no-drag]"
     >
       <LockGlyph />
     </IconButton>

--- a/src/components/Main/Header/Search.tsx
+++ b/src/components/Main/Header/Search.tsx
@@ -9,7 +9,7 @@ export default function Search() {
   const query = useStore(state => state.filters.query)
 
   return (
-    <div className="flex-none [-webkit-app-region:no-drag]">
+    <div className="flex-none">
       <div className="flex h-7 w-[400px] items-center gap-2.5 rounded-sm border border-line2 bg-field pl-[11px] pr-2 text-text3 transition-colors focus-within:border-accent-line">
         <SearchGlyph className="flex-none" />
         <input

--- a/src/components/Main/Header/SyncIndicator.tsx
+++ b/src/components/Main/Header/SyncIndicator.tsx
@@ -28,7 +28,7 @@ export default function SyncIndicator() {
 
   return (
     <Tooltip content={message()}>
-      <div className="flex h-7 items-center gap-[7px] rounded-sm px-2.5 font-mono text-[11px] text-text3">
+      <div className="flex h-7 items-center gap-[7px] rounded-sm px-2.5 font-mono text-xs text-text3">
         <span className={cx('h-[5px] w-[5px] flex-none rounded-full', dot())} />
         {label()}
       </div>

--- a/src/components/Main/Header/Tags/Chip.tsx
+++ b/src/components/Main/Header/Tags/Chip.tsx
@@ -15,14 +15,14 @@ export default function Chip({ label, count, selected, onClick }: Props) {
       type="button"
       onClick={onClick}
       className={cx(
-        'flex h-[25px] flex-none items-center gap-1.5 rounded-sm border px-[9px] text-[11px] whitespace-nowrap',
+        'flex h-6 flex-none items-center gap-1.5 rounded-sm border px-[9px] text-xs whitespace-nowrap',
         selected
           ? 'border-accent-line bg-accent-soft text-accent'
           : 'border-line bg-transparent text-text2 hover:border-line2'
       )}
     >
       <span>{label}</span>
-      <span className="font-mono text-[11px] opacity-60">{count}</span>
+      <span className="font-mono text-xs opacity-60">{count}</span>
     </button>
   )
 }

--- a/src/components/Main/Header/ThemeToggle.tsx
+++ b/src/components/Main/Header/ThemeToggle.tsx
@@ -13,7 +13,6 @@ export default function ThemeToggle() {
     <IconButton
       onClick={() => toggleTheme()}
       title={isDark ? t('Light mode') : t('Dark mode')}
-      className="[-webkit-app-region:no-drag]"
     >
       {isDark ? <SunGlyph /> : <MoonGlyph />}
     </IconButton>

--- a/src/components/Main/Sidebar/Settings/Import/Progress.tsx
+++ b/src/components/Main/Sidebar/Settings/Import/Progress.tsx
@@ -15,7 +15,7 @@ export default function Progress({ done, total }: Props) {
           style={{ width: `${pct(done, total)}%` }}
         />
       </div>
-      <span className="font-mono text-base text-text3">
+      <span className="font-mono text-xs text-text3">
         {done} / {total}
       </span>
     </div>

--- a/src/components/Main/Sidebar/Settings/Import/Progress.tsx
+++ b/src/components/Main/Sidebar/Settings/Import/Progress.tsx
@@ -15,7 +15,7 @@ export default function Progress({ done, total }: Props) {
           style={{ width: `${pct(done, total)}%` }}
         />
       </div>
-      <span className="font-mono text-[12px] text-text3">
+      <span className="font-mono text-base text-text3">
         {done} / {total}
       </span>
     </div>

--- a/src/components/Main/Sidebar/Settings/Import/RowErrors.tsx
+++ b/src/components/Main/Sidebar/Settings/Import/RowErrors.tsx
@@ -11,7 +11,7 @@ export default function RowErrors({ errors }: { errors: RowError[] }) {
   if (errors.length === 0) return null
 
   return (
-    <div className="mt-2 text-[13px]">
+    <div className="mt-2 text-base">
       <span
         className="cursor-pointer select-none text-bad"
         onClick={() => setOpen(!open)}

--- a/src/components/Main/Sidebar/Settings/Import/ThirdParty.tsx
+++ b/src/components/Main/Sidebar/Settings/Import/ThirdParty.tsx
@@ -107,7 +107,7 @@ export default function ThirdParty() {
       </div>
 
       {preview && (
-        <div className="text-[13px] text-text2">
+        <div className="text-base text-text2">
           {t('Ready to import')}: <strong className="text-text">{preview.total}</strong>
           {preview.skipped > 0 && (
             <span className={DANGER}>

--- a/src/components/Main/Sidebar/Settings/Navigation.tsx
+++ b/src/components/Main/Sidebar/Settings/Navigation.tsx
@@ -35,7 +35,7 @@ export default function Navigation({ section, onClick }: Props) {
           key={item.key}
           onClick={() => onClick(item.key)}
           className={cx(
-            'cursor-pointer rounded-sm px-3 py-2 text-[13px] transition-colors',
+            'cursor-pointer rounded-sm px-3 py-2 text-base transition-colors',
             section === item.key
               ? 'bg-accent-soft font-medium text-accent'
               : 'text-text2 hover:bg-hover hover:text-text'

--- a/src/components/Main/Sidebar/Settings/Password.tsx
+++ b/src/components/Main/Sidebar/Settings/Password.tsx
@@ -36,7 +36,7 @@ export default function Password({ section }: Props) {
       <h1 className={H1}>{t('Password Settings')}</h1>
       <Row>
         <strong className={LABEL}>{t('Example')}</strong>
-        <div className="rounded-sm border border-line bg-field px-3 py-2.5 font-mono text-[14px] text-text">
+        <div className="rounded-sm border border-line bg-field px-3 py-2.5 font-mono text-base text-text">
           {example}
         </div>
       </Row>
@@ -52,7 +52,7 @@ export default function Password({ section }: Props) {
             value={options.length}
             onChange={onLength}
           />
-          <div className="grid h-6 min-w-[32px] place-items-center rounded-sm bg-accent-soft px-1.5 font-mono text-[12px] text-accent">
+          <div className="grid h-6 min-w-[32px] place-items-center rounded-sm bg-accent-soft px-1.5 font-mono text-base text-accent">
             {options.length}
           </div>
         </div>

--- a/src/components/Main/Sidebar/Settings/Password.tsx
+++ b/src/components/Main/Sidebar/Settings/Password.tsx
@@ -36,7 +36,7 @@ export default function Password({ section }: Props) {
       <h1 className={H1}>{t('Password Settings')}</h1>
       <Row>
         <strong className={LABEL}>{t('Example')}</strong>
-        <div className="rounded-sm border border-line bg-field px-3 py-2.5 font-mono text-base text-text">
+        <div className="rounded-sm border border-line bg-field px-3 py-2.5 font-mono text-lg text-text">
           {example}
         </div>
       </Row>
@@ -52,7 +52,7 @@ export default function Password({ section }: Props) {
             value={options.length}
             onChange={onLength}
           />
-          <div className="grid h-6 min-w-[32px] place-items-center rounded-sm bg-accent-soft px-1.5 font-mono text-base text-accent">
+          <div className="grid h-6 min-w-[32px] place-items-center rounded-sm bg-accent-soft px-1.5 font-mono text-xs text-accent">
             {options.length}
           </div>
         </div>

--- a/src/components/Main/Sidebar/Settings/ui.tsx
+++ b/src/components/Main/Sidebar/Settings/ui.tsx
@@ -3,12 +3,12 @@ import { cx } from '@/utils/cx'
 
 // Shared token-styled building blocks for the settings panels.
 
-export const H1 = 'mb-5 text-xl font-semibold tracking-[-0.02em] text-text'
-export const LABEL = 'block text-[13px] font-medium text-text'
-export const DESC = 'mt-1 text-[13px] leading-relaxed text-text2'
-export const MUTED = 'text-[12px] leading-relaxed text-text3'
-export const DANGER = 'text-[13px] text-bad'
-export const SUCCESS = 'text-[13px] text-good'
+export const H1 = 'mb-5 text-xl font-semibold tracking-display text-text'
+export const LABEL = 'block text-base font-medium text-text'
+export const DESC = 'mt-1 text-base leading-relaxed text-text2'
+export const MUTED = 'text-base leading-relaxed text-text3'
+export const DANGER = 'text-base text-bad'
+export const SUCCESS = 'text-base text-good'
 
 export function Section({
   children,
@@ -37,7 +37,7 @@ export function Checkbox({
   children: ReactNode
 }) {
   return (
-    <label className="flex cursor-pointer items-center gap-2.5 text-[13px] text-text2">
+    <label className="flex cursor-pointer items-center gap-2.5 text-base text-text2">
       <input
         type="checkbox"
         name={name}

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -9,7 +9,7 @@ interface DropdownProps {
 export function Dropdown({ onBlur, children }: DropdownProps) {
   return (
     <>
-      <div className="absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]">
+      <div className="animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]">
         {children}
       </div>
       <div className="fixed inset-0 z-10" onClick={onBlur} />
@@ -30,7 +30,7 @@ export function DropdownItem({ id, separated, onClick, children }: ItemProps) {
       id={id}
       onClick={onClick}
       className={cx(
-        'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-[13px] text-text2 transition-colors hover:bg-hover hover:text-text',
+        'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-base text-text2 transition-colors hover:bg-hover hover:text-text',
         separated && 'mt-1 border-t border-line pt-2.5'
       )}
     >

--- a/src/components/elements/Error.tsx
+++ b/src/components/elements/Error.tsx
@@ -5,7 +5,7 @@ interface Props {
 export default function Error({ error }: Props) {
   if (!error) return null
   return (
-    <div className="mt-2.5 text-center font-mono text-[11px] tracking-[0.02em] text-bad">
+    <div className="mt-2.5 text-center font-mono text-xs tracking-label text-bad">
       {error}
     </div>
   )

--- a/src/components/elements/Eyebrow.tsx
+++ b/src/components/elements/Eyebrow.tsx
@@ -16,7 +16,7 @@ export default function Eyebrow({ children, tone = 'muted' }: Props) {
   const text = tone === 'bad' ? 'text-bad' : 'text-text3'
 
   return (
-    <div className="flex items-center justify-center gap-2.5 font-mono text-[11px] uppercase tracking-[0.2em]">
+    <div className="flex items-center justify-center gap-2.5 font-mono text-xs uppercase tracking-label">
       <span
         className={cx(
           'h-1 w-1 rounded-full animate-[breathe_3.4s_ease-in-out_infinite]',

--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -88,6 +88,8 @@ export default function Masterpass({
           lock ? 'h-16' : 'h-14'
         )}
       >
+        {/* Deliberately off the type/tracking scales: the passphrase field is a
+            theatrical one-off (26/22px, .3em cuts) that no other surface reuses. */}
         <input
           type={reveal ? 'text' : 'password'}
           className="absolute inset-0 w-full border-0 bg-transparent text-center font-mono tracking-[0.3em] outline-none placeholder:text-[15px] placeholder:tracking-[0em] placeholder:text-text3"

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -9,11 +9,11 @@ interface Props {
 export default function Modal({ onClose, children }: Props) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-[var(--scrim)] p-4 pt-[10vh] backdrop-blur-sm"
+      className="animate-fade fixed inset-0 z-50 flex items-start justify-center bg-[var(--scrim)] p-4 pt-[10vh] backdrop-blur-sm"
       onClick={onClose}
     >
       <div
-        className="relative flex max-h-[80vh] w-full max-w-[720px] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
+        className="animate-pop relative flex max-h-[80vh] w-full max-w-[720px] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
         onClick={e => e.stopPropagation()}
       >
         <button

--- a/src/components/elements/PasswordStrength.tsx
+++ b/src/components/elements/PasswordStrength.tsx
@@ -40,7 +40,7 @@ export default function PasswordStrength({ password }: Props) {
           />
         ))}
       </div>
-      <div className="mt-1.5 flex justify-between gap-2 font-mono text-[11px] text-text3">
+      <div className="mt-1.5 flex justify-between gap-2 font-mono text-xs text-text3">
         <span>{score !== null ? t(LABELS[score]) : ''}</span>
         {hint && <span className="text-right text-text3">{hint}</span>}
       </div>

--- a/src/components/elements/TagsInput.tsx
+++ b/src/components/elements/TagsInput.tsx
@@ -32,14 +32,14 @@ export default function TagsInput({ value, onChange }: Props) {
         <span
           key={tag}
           onClick={() => removeTag(tag)}
-          className="flex cursor-pointer items-center gap-1 rounded-sm bg-accent-soft px-2 py-1 font-mono text-[11px] text-accent hover:brightness-95"
+          className="flex cursor-pointer items-center gap-1 rounded-sm bg-accent-soft px-2 py-1 font-mono text-xs text-accent hover:brightness-95"
         >
           {tag}
           <span className="opacity-60">×</span>
         </span>
       ))}
       <input
-        className="min-w-[80px] flex-1 !border-0 !bg-transparent !p-1 !text-[13px] !text-text !outline-none"
+        className="min-w-[80px] flex-1 !border-0 !bg-transparent !p-1 !text-base !text-text !outline-none"
         value={input}
         onChange={e => setInput(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/components/elements/Tooltip.tsx
+++ b/src/components/elements/Tooltip.tsx
@@ -10,7 +10,10 @@ interface Props {
 export default function Tooltip({ content, className, children }: Props) {
   return (
     <div className={cx('group/tt relative', className)}>
-      <div className="pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-[12px] text-detail opacity-0 shadow-[var(--shadow)] transition-opacity duration-150 group-hover/tt:opacity-100">
+      {/* The panel stays mounted, so `animate-pop` is scoped to the hover state
+          (its `both` fill would otherwise pin opacity to 1 and never hide), and
+          centering uses auto margins rather than a transform the pop would eat. */}
+      <div className="pointer-events-none absolute inset-x-0 top-full z-50 mx-auto mt-2 w-max whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-base text-detail opacity-0 shadow-[var(--shadow)] transition-opacity duration-150 group-hover/tt:animate-pop group-hover/tt:opacity-100">
         {content}
       </div>
       {children}

--- a/src/components/elements/UpdateToast.tsx
+++ b/src/components/elements/UpdateToast.tsx
@@ -17,7 +17,7 @@ export default function UpdateToast() {
 }
 
 const shell =
-  'fixed bottom-5 right-5 z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-[var(--shadow)]'
+  'animate-pop fixed bottom-5 right-5 z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-[var(--shadow)]'
 
 function ReadyToast({ version, notes }: { version: string; notes: string | null }) {
   const dismiss = useStore(state => state.dismissUpdate)
@@ -38,12 +38,12 @@ function ReadyToast({ version, notes }: { version: string; notes: string | null 
     <div className={`${shell} flex gap-3 p-4`} role="alert">
       <DownloadGlyph size={18} className="mt-0.5 flex-none text-accent" />
       <div className="flex flex-col gap-1">
-        <strong className="text-[14px]">{t('Update Ready')}</strong>
-        <span className="text-[13px] text-text2">
+        <strong className="text-base">{t('Update Ready')}</strong>
+        <span className="text-base text-text2">
           {t('Version {v} has been downloaded.').replace('{v}', version)}
         </span>
         {notes && (
-          <p className="mt-1 whitespace-pre-wrap text-[12px] text-text3">{notes}</p>
+          <p className="mt-1 whitespace-pre-wrap text-base text-text3">{notes}</p>
         )}
         <div className="mt-3 flex gap-2">
           <Button
@@ -75,7 +75,7 @@ const STATUS_COPY: Record<'checking' | 'uptodate' | 'error', string> = {
 function StatusToast({ status }: { status: 'checking' | 'uptodate' | 'error' }) {
   return (
     <div className={`${shell} px-4 py-3`} role="status">
-      <span className="text-[13px] text-text2">{t(STATUS_COPY[status])}</span>
+      <span className="text-base text-text2">{t(STATUS_COPY[status])}</span>
     </div>
   )
 }

--- a/src/components/elements/formStyles.ts
+++ b/src/components/elements/formStyles.ts
@@ -1,13 +1,19 @@
 // Shared token-styled form control classes for the redesign.
 
-export const inputClass =
-  'w-full rounded-sm border border-line2 bg-field px-3 py-2.5 text-[13px] leading-[1.4] text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line'
+// Everything a field shares; the per-control classes below only add the sizing.
+const controlBase =
+  'w-full rounded-sm border border-line2 bg-field px-3 text-base text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line'
+
+// 36px — the ruled tier for inputs, CTAs and rail tiles.
+export const inputClass = `${controlBase} h-9`
+
+// Textareas grow with their content, so they swap the fixed height for padding.
+export const textareaClass = `${controlBase} py-2.5`
+
+export const selectClass = `${controlBase} h-9 appearance-none pr-9`
 
 export const labelClass =
-  'mb-[7px] block font-mono text-[11px] uppercase tracking-[0.1em] text-text3'
-
-export const selectClass =
-  'w-full appearance-none rounded-sm border border-line2 bg-field px-3 py-2.5 pr-9 text-[13px] text-text outline-none transition-colors focus:border-accent-line'
+  'mb-[7px] block font-mono text-xs uppercase tracking-label text-text3'
 
 export const checkboxClass =
   'h-4 w-4 flex-none accent-accent'


### PR DESCRIPTION
PR 2 of the design port. Mechanical restyle of 41 files — no behavior, markup, or prop changes.

## What
- All arbitrary text/tracking/height/radius values snapped to the PR-#268 token system: 11/13 type tiers, `tracking-label/display/secret`, 24/28/36 control heights, 8/12/14 radii
- Prototype-exact metrics: detail pane `26/34/60` padding, secret displays 20px mono `.08em`, ledger cell padding, one 96px field-label width, 36px inputs (new shared `textareaClass` so textareas still grow)
- Motion utilities applied: modals/dropdowns/toast/tooltip get `animate-pop`/`animate-fade`; toast re-pops on each copy for free (`hidden` toggle restarts CSS animations)
- Dead `-webkit-app-region:no-drag` classes removed (Tauri never implemented that CSS; #269 owns the real drag mechanism)

## Notable non-mechanical calls (commented in code)
- `animate-pop` ends at `transform:none` with `both` fill, which would break `-translate-x-1/2` centering — copy toast and Tooltip now center via auto margins (`inset-x-0 mx-auto w-max`)
- Tooltip's pop is scoped to `group-hover` (unconditional `both` fill would pin it visible)
- List-row glyph tile stays 30px — decorative square, not an interactive control

## Audits (clean)
`text-[`/`tracking-[`/`rounded-[` greps return only documented one-offs (card art, Masterpass 15px placeholder + .3em input, 34px audit dial) and two items inside `AuthShell.tsx`, which #269 owns — follow-up noted there.

## Tests
`bun run test` 60/60 · lint clean · build green · all testids and the `copied-notification` hook preserved · emitted CSS grepped to confirm every new utility compiled (Tailwind drops off-scale classes silently)

Stacked PRs for list/detail/editor facelifts branch from this.