### PR TITLE
⌘K command palette

### DIFF
--- a/src/components/Main/Palette/CommandRow.tsx
+++ b/src/components/Main/Palette/CommandRow.tsx
@@ -1,0 +1,30 @@
+import Row from './Row'
+import type { Command } from './commands'
+
+interface Props {
+  command: Command
+  focused: boolean
+  onRun: () => void
+  onHover: () => void
+}
+
+export default function CommandRow({ command, focused, onRun, onHover }: Props) {
+  const Glyph = command.glyph
+
+  return (
+    <Row
+      focused={focused}
+      onClick={onRun}
+      onHover={onHover}
+      className="rounded-sm px-2.5 py-[9px]"
+    >
+      <span className="grid w-5 flex-none place-items-center text-text3">
+        <Glyph size={14} />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-base text-text2">{command.label}</span>
+      {command.shortcut && (
+        <span className="flex-none font-mono text-xs text-text3">{command.shortcut}</span>
+      )}
+    </Row>
+  )
+}

--- a/src/components/Main/Palette/EntryRow.tsx
+++ b/src/components/Main/Palette/EntryRow.tsx
@@ -1,0 +1,49 @@
+import type { EntryMeta } from '@/lib/commands'
+import { t } from '@/i18n'
+import Kbd from '@/components/elements/Kbd'
+import { CardGlyph, LoginGlyph, NoteGlyph } from '../icons'
+import Row from './Row'
+
+interface Props {
+  entry: EntryMeta
+  focused: boolean
+  onOpen: () => void
+  onHover: () => void
+}
+
+const GLYPH = {
+  login: LoginGlyph,
+  card: CardGlyph,
+  note: NoteGlyph
+} as const
+
+// Same secondary line as the list column: the site host for a login, a masked
+// pattern for a card (the real number is a secret), tags otherwise.
+const subtitle = (entry: EntryMeta): string => {
+  if (entry.type === 'card') return '•••• •••• •••• ••••'
+  if (entry.type === 'login' && entry.urlHost) return entry.urlHost
+  return entry.tags.join(' · ')
+}
+
+export default function EntryRow({ entry, focused, onOpen, onHover }: Props) {
+  const Glyph = GLYPH[entry.type]
+  const sub = subtitle(entry)
+
+  return (
+    <Row focused={focused} onClick={onOpen} onHover={onHover} className="rounded-lg p-2.5">
+      <div className="grid h-7 w-7 flex-none place-items-center rounded-sm bg-tile text-text2">
+        <Glyph size={16} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-base font-medium text-text">{entry.title}</div>
+        {sub && <div className="mt-[3px] truncate font-mono text-xs text-text3">{sub}</div>}
+      </div>
+      {focused && (
+        <div className="flex flex-none gap-[5px]">
+          <Kbd>⏎ {t('open')}</Kbd>
+          <Kbd>⌘⏎ {t('copy')}</Kbd>
+        </div>
+      )}
+    </Row>
+  )
+}

--- a/src/components/Main/Palette/Input.tsx
+++ b/src/components/Main/Palette/Input.tsx
@@ -1,0 +1,33 @@
+import type { KeyboardEvent } from 'react'
+import { t } from '@/i18n'
+import Kbd from '@/components/elements/Kbd'
+import { SearchGlyph } from '../icons'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void
+}
+
+// The palette's only focusable control: a borderless field on a hairline,
+// flanked by the search glyph and an `esc` hint.
+export default function Input({ value, onChange, onKeyDown }: Props) {
+  return (
+    <div className="flex items-center gap-[11px] px-4 py-3.5 shadow-[inset_0_-1px_0_var(--c-line)]">
+      <SearchGlyph className="flex-none text-text3" />
+      <input
+        // The palette is mounted only while open, so this focuses on every open.
+        autoFocus
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={t('Search or run a command')}
+        aria-label={t('Search or run a command')}
+        data-testid="command-palette-input"
+        className="min-w-0 flex-1 border-0 bg-transparent text-lg text-text caret-accent outline-none placeholder:text-text3"
+      />
+      <Kbd>esc</Kbd>
+    </div>
+  )
+}

--- a/src/components/Main/Palette/Panel.tsx
+++ b/src/components/Main/Palette/Panel.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState, type KeyboardEvent } from 'react'
+import { closePalette } from '@/store'
+import { t } from '@/i18n'
+import Input from './Input'
+import Section from './Section'
+import EntryRow from './EntryRow'
+import CommandRow from './CommandRow'
+import { useResults, type Item } from './useResults'
+import { copySecret, openEntry } from './actions'
+
+// The palette itself. Mounted only while open, so the query, the focused row,
+// and the input focus all reset on every ⌘K.
+export default function Panel() {
+  const [query, setQuery] = useState('')
+  const [focus, setFocus] = useState(0)
+
+  const groups = useResults(query)
+  const items = useMemo(() => groups.flatMap(group => group.items), [groups])
+  const indexes = useMemo(() => new Map(items.map((item, i) => [item.key, i])), [items])
+
+  // Results shrink as the query narrows; clamp rather than reset so the focus
+  // survives a backspace.
+  const focused = Math.min(focus, Math.max(items.length - 1, 0))
+
+  const move = (step: number) =>
+    setFocus(items.length === 0 ? 0 : (focused + step + items.length) % items.length)
+
+  // ⏎ takes the primary action, ⌘⏎ the secondary one (entries only).
+  const run = (item: Item, secondary: boolean) => {
+    if (item.kind === 'command') item.command.run()
+    else if (secondary) copySecret(item.entry)
+    else openEntry(item.entry)
+    closePalette()
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Escape':
+        closePalette()
+        break
+      case 'ArrowDown':
+        move(1)
+        break
+      case 'ArrowUp':
+        move(-1)
+        break
+      case 'Enter':
+        if (items[focused]) run(items[focused], e.metaKey || e.ctrlKey)
+        break
+      // Focus stays in the field: there is nothing else to tab to.
+      case 'Tab':
+        break
+      default:
+        return
+    }
+    e.preventDefault()
+  }
+
+  return (
+    <div
+      onClick={closePalette}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-[var(--scrim)] pt-[92px] backdrop-blur-[4px] animate-fade"
+    >
+      <div
+        data-testid="command-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('Search or run a command')}
+        onClick={e => e.stopPropagation()}
+        className="w-[620px] overflow-hidden rounded-xl border border-line2 bg-detail shadow-[var(--shadow)] animate-pop"
+      >
+        <Input value={query} onChange={setQuery} onKeyDown={onKeyDown} />
+
+        <div
+          role="listbox"
+          // Clicking a row must not pull focus out of the input.
+          onMouseDown={e => e.preventDefault()}
+          className="max-h-[52vh] overflow-y-auto p-2"
+        >
+          {items.length === 0 && (
+            <div className="px-2.5 py-6 text-center text-base text-text3">{t('No results')}</div>
+          )}
+
+          {groups.map((group, i) => (
+            <div key={group.label}>
+              <Section label={group.label} first={i === 0} />
+              {group.items.map(item => {
+                const index = indexes.get(item.key) ?? 0
+                const props = {
+                  focused: index === focused,
+                  onHover: () => setFocus(index)
+                }
+
+                return item.kind === 'entry' ? (
+                  <EntryRow
+                    key={item.key}
+                    entry={item.entry}
+                    onOpen={() => run(item, false)}
+                    {...props}
+                  />
+                ) : (
+                  <CommandRow
+                    key={item.key}
+                    command={item.command}
+                    onRun={() => run(item, false)}
+                    {...props}
+                  />
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Main/Palette/Row.tsx
+++ b/src/components/Main/Palette/Row.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+
+interface Props {
+  focused: boolean
+  onClick: () => void
+  onHover: () => void
+  // Rows come in two densities (entry vs command); the caller supplies its own
+  // radius and padding.
+  className?: string
+  children: ReactNode
+}
+
+// Shared interaction shell for every palette row: one focus treatment (the
+// prototype's best-match wash) and one hover. The border is always present so
+// focusing a row never shifts the layout.
+export default function Row({ focused, onClick, onHover, className, children }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Keep the keyboard-focused row visible when arrowing past the fold.
+  useEffect(() => {
+    if (focused) ref.current?.scrollIntoView({ block: 'nearest' })
+  }, [focused])
+
+  return (
+    <div
+      ref={ref}
+      role="option"
+      aria-selected={focused}
+      onClick={onClick}
+      // mousemove, not mouseenter: a row sliding under a still cursor while the
+      // list scrolls shouldn't steal focus from the arrow keys.
+      onMouseMove={() => !focused && onHover()}
+      className={cx(
+        'flex cursor-pointer items-center gap-3 border',
+        focused ? 'border-line2 bg-sel' : 'border-transparent hover:bg-hover',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/Main/Palette/Section.tsx
+++ b/src/components/Main/Palette/Section.tsx
@@ -1,0 +1,16 @@
+import { cx } from '@/utils/cx'
+
+// Mono uppercase eyebrow above each group of results ("Best match", "Entries",
+// "Commands"). The first one sits tighter to the input hairline.
+export default function Section({ label, first }: { label: string; first?: boolean }) {
+  return (
+    <div
+      className={cx(
+        'px-2.5 pb-1.5 font-mono text-xs uppercase tracking-label text-text3',
+        first ? 'pt-2' : 'pt-3.5'
+      )}
+    >
+      {label}
+    </div>
+  )
+}

--- a/src/components/Main/Palette/actions.ts
+++ b/src/components/Main/Palette/actions.ts
@@ -1,0 +1,33 @@
+import { revealEntry, type Entry, type EntryMeta } from '@/lib/commands'
+import { useStore, setCurrentEntry, setFilterScope } from '@/store'
+import { copy } from '@/services/copy'
+
+// Selects an entry in the list column, switching scope first when it lives
+// under a different tab (`setFilterScope` clears the selection, so it has to
+// run before `setCurrentEntry`).
+export const openEntry = (entry: EntryMeta) => {
+  if (useStore.getState().filters.scope !== entry.type) setFilterScope(entry.type)
+  setCurrentEntry(entry.id)
+}
+
+// The one secret worth a shortcut per entry type.
+export const primarySecret = (entry: Entry): string => {
+  switch (entry.type) {
+    case 'login':
+      return entry.password
+    case 'card':
+      return entry.number
+    case 'note':
+      return entry.note
+  }
+}
+
+// Decrypts just this entry (secrets never live in the list metadata) and puts
+// its primary secret on the clipboard, with the usual auto-clear timeout.
+export const copySecret = (entry: EntryMeta): Promise<void> =>
+  revealEntry(entry.id)
+    .then(revealed => {
+      const value = primarySecret(revealed)
+      if (value) copy(value)
+    })
+    .catch(() => {})

--- a/src/components/Main/Palette/commands.ts
+++ b/src/components/Main/Palette/commands.ts
@@ -1,0 +1,62 @@
+import { lock } from '@/lib/commands'
+import {
+  useStore,
+  flowAuth,
+  newEntry,
+  openSettings,
+  setFilterScope,
+  toggleTheme
+} from '@/store'
+import { t } from '@/i18n'
+import { GearGlyph, LockGlyph, MoonGlyph, PlusGlyph, SunGlyph } from '../icons'
+
+type Glyph = typeof LockGlyph
+
+export interface Command {
+  id: string
+  label: string
+  // Displayed hint only; the binding itself lives in `useShortcuts`.
+  shortcut?: string
+  glyph: Glyph
+  run: () => void
+}
+
+// Locks the vault and drops back to the auth flow — the same path as the
+// header's lock button.
+export const lockVault = () => {
+  lock().finally(() => flowAuth(false))
+}
+
+// Starts a new entry, leaving the audit scope first (it has no editor) — the
+// same path as the rail's add button.
+export const startNewEntry = () => {
+  if (useStore.getState().filters.scope === 'audit') setFilterScope('login')
+  newEntry()
+}
+
+// The palette's fixed command list. Order here is the order shown for an empty
+// query, and the tie-break when several commands score the same.
+// Rebuilt on every render rather than memoized: four objects is cheaper than
+// the dependency bookkeeping, and `t` reads a module-level locale that a
+// dependency array can't see.
+export const useCommands = (): Command[] => {
+  const theme = useStore(state => state.theme)
+
+  return [
+    { id: 'new-entry', label: t('New entry'), glyph: PlusGlyph, run: startNewEntry },
+    {
+      id: 'lock-vault',
+      label: t('Lock vault'),
+      shortcut: '⌘L',
+      glyph: LockGlyph,
+      run: lockVault
+    },
+    {
+      id: 'toggle-theme',
+      label: t('Toggle theme'),
+      glyph: theme === 'dark' ? SunGlyph : MoonGlyph,
+      run: toggleTheme
+    },
+    { id: 'settings', label: t('Settings'), glyph: GearGlyph, run: openSettings }
+  ]
+}

--- a/src/components/Main/Palette/index.tsx
+++ b/src/components/Main/Palette/index.tsx
@@ -1,0 +1,10 @@
+import { useStore } from '@/store'
+import Panel from './Panel'
+
+// The ⌘K command palette. Mount it once inside the unlocked shell; it renders
+// nothing until `ui.palette` is set (⌘K, or any other control calling
+// `openPalette`).
+export default function Palette() {
+  const open = useStore(state => state.ui.palette)
+  return open ? <Panel /> : null
+}

--- a/src/components/Main/Palette/search.test.ts
+++ b/src/components/Main/Palette/search.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { scoreText, scoreFields, rank, searchEntries } from './search'
+import type { EntryMeta } from '@/lib/commands'
+
+const login = (title: string, urlHost = '', tags: string[] = []): EntryMeta => ({
+  id: title,
+  type: 'login',
+  title,
+  tags,
+  urlHost
+})
+
+describe('scoreText', () => {
+  it('matches everything on an empty query', () => {
+    expect(scoreText('GitHub', '')).toBe(0)
+  })
+
+  it('returns null when the query is absent', () => {
+    expect(scoreText('GitHub', 'zzz')).toBeNull()
+    expect(scoreText('', 'g')).toBeNull()
+  })
+
+  it('is case-insensitive', () => {
+    expect(scoreText('GitHub', 'github')).toBe(scoreText('github', 'GITHUB'))
+  })
+
+  it('ranks a prefix above a substring above a subsequence', () => {
+    const prefix = scoreText('bastion-prod', 'bast')!
+    const substring = scoreText('prod-bastion', 'bast')!
+    const subsequence = scoreText('backup station', 'bast')!
+
+    expect(prefix).toBeGreaterThan(substring)
+    expect(substring).toBeGreaterThan(subsequence)
+  })
+
+  it('prefers an earlier substring', () => {
+    expect(scoreText('a-key', 'key')!).toBeGreaterThan(scoreText('a-long-key', 'key')!)
+  })
+
+  it('prefers a tighter subsequence span', () => {
+    expect(scoreText('abc', 'ac')!).toBeGreaterThan(scoreText('a-------c', 'ac')!)
+  })
+
+  it('requires subsequence characters in order', () => {
+    expect(scoreText('abc', 'ca')).toBeNull()
+  })
+})
+
+describe('scoreFields', () => {
+  it('takes the best field', () => {
+    const fields = [{ text: 'nope' }, { text: 'github' }]
+    expect(scoreFields(fields, 'git')).toBe(scoreText('github', 'git'))
+  })
+
+  it('returns null when no field matches', () => {
+    expect(scoreFields([{ text: 'a' }, { text: 'b' }], 'z')).toBeNull()
+  })
+
+  it('weights fields', () => {
+    const heavy = scoreFields([{ text: 'git', weight: 3 }], 'git')!
+    const light = scoreFields([{ text: 'git', weight: 1 }], 'git')!
+    expect(heavy).toBe(light * 3)
+  })
+})
+
+describe('rank', () => {
+  const labels = (items: { label: string }[]) => items.map(item => item.label)
+  const fieldsOf = (item: { label: string }) => [{ text: item.label }]
+
+  it('drops non-matches and orders by score', () => {
+    const items = [{ label: 'Toggle theme' }, { label: 'Lock vault' }, { label: 'New entry' }]
+    expect(labels(rank(items, 'lock', fieldsOf))).toEqual(['Lock vault'])
+  })
+
+  it('keeps the input order for equal scores', () => {
+    const items = [{ label: 'Lock vault' }, { label: 'Lock screen' }]
+    expect(labels(rank(items, 'lock', fieldsOf))).toEqual(['Lock vault', 'Lock screen'])
+  })
+
+  it('returns everything for an empty query', () => {
+    const items = [{ label: 'b' }, { label: 'a' }]
+    expect(labels(rank(items, '', fieldsOf))).toEqual(['b', 'a'])
+  })
+})
+
+describe('searchEntries', () => {
+  const entries = [
+    login('Google', 'google.com'),
+    login('Airbnb', 'airbnb.com', ['travel']),
+    login('GitHub', 'github.com', ['work'])
+  ]
+
+  it('sorts alphabetically with no query', () => {
+    expect(searchEntries(entries, '').map(e => e.title)).toEqual(['Airbnb', 'GitHub', 'Google'])
+  })
+
+  it('matches the title', () => {
+    expect(searchEntries(entries, 'git').map(e => e.title)).toEqual(['GitHub'])
+  })
+
+  it('matches the site host and tags', () => {
+    expect(searchEntries(entries, 'airbnb.com').map(e => e.title)).toEqual(['Airbnb'])
+    expect(searchEntries(entries, 'travel').map(e => e.title)).toEqual(['Airbnb'])
+  })
+
+  it('ranks a title hit above a tag hit', () => {
+    const items = [login('Bank', 'bank.example', ['work']), login('Work log', '')]
+    expect(searchEntries(items, 'work').map(e => e.title)).toEqual(['Work log', 'Bank'])
+  })
+
+  it('tolerates gaps (subsequence)', () => {
+    expect(searchEntries(entries, 'ggl').map(e => e.title)).toEqual(['Google'])
+  })
+
+  it('does not mutate the input', () => {
+    const items = [login('B'), login('A')]
+    searchEntries(items, '')
+    expect(items.map(e => e.title)).toEqual(['B', 'A'])
+  })
+})

--- a/src/components/Main/Palette/search.ts
+++ b/src/components/Main/Palette/search.ts
@@ -1,0 +1,96 @@
+import type { EntryMeta } from '@/lib/commands'
+
+/**
+ * Matching for the ⌘K palette.
+ *
+ * The list column already has its own search (`services/entries.filterEntries`,
+ * Fuse over one scope). The palette needs something different: it ranks across
+ * every scope *and* across non-entry items (commands) in one pass, so it scores
+ * plain weighted fields instead. Deliberately dependency-free and synchronous —
+ * it re-runs on every keystroke.
+ *
+ * Three tiers, best first: prefix > substring (earlier is better) > subsequence
+ * (tighter span is better). A field's weight multiplies its score, so a title
+ * hit outranks a tag hit.
+ */
+
+const PREFIX = 1000
+const SUBSTRING = 500
+const SUBSEQUENCE = 100
+
+// Caps the positional penalty so a very long field can never score below the
+// tier beneath it.
+const MAX_PENALTY = 99
+
+export interface Field {
+  text: string
+  // Relative importance; defaults to 1.
+  weight?: number
+}
+
+// Score of `query` against one string, or null when it doesn't match at all.
+// An empty query matches everything with a neutral score.
+export const scoreText = (text: string, query: string): number | null => {
+  if (query === '') return 0
+  if (text === '') return null
+
+  const haystack = text.toLowerCase()
+  const needle = query.toLowerCase()
+
+  const index = haystack.indexOf(needle)
+  if (index === 0) return PREFIX
+  if (index > 0) return SUBSTRING - Math.min(index, MAX_PENALTY)
+
+  const span = subsequenceSpan(haystack, needle)
+  return span === null ? null : SUBSEQUENCE - Math.min(span, MAX_PENALTY)
+}
+
+// Distance between the first and last character of a greedy left-to-right
+// subsequence match, or null when the needle isn't a subsequence at all.
+const subsequenceSpan = (haystack: string, needle: string): number | null => {
+  let first = -1
+  let cursor = 0
+
+  for (const char of needle) {
+    const found = haystack.indexOf(char, cursor)
+    if (found === -1) return null
+    if (first === -1) first = found
+    cursor = found + 1
+  }
+
+  return cursor - 1 - first
+}
+
+// Best score across an item's fields, or null when none of them match.
+export const scoreFields = (fields: Field[], query: string): number | null =>
+  fields.reduce<number | null>((best, field) => {
+    const score = scoreText(field.text, query)
+    if (score === null) return best
+    const weighted = score * (field.weight ?? 1)
+    return best === null || weighted > best ? weighted : best
+  }, null)
+
+// Ranks items best-first, dropping non-matches. Ties keep the input order
+// (Array#sort is stable), so callers control the fallback ordering.
+export const rank = <T>(
+  items: T[],
+  query: string,
+  fieldsOf: (item: T) => Field[]
+): T[] =>
+  items
+    .map(item => ({ item, score: scoreFields(fieldsOf(item), query) }))
+    .filter((scored): scored is { item: T; score: number } => scored.score !== null)
+    .sort((a, b) => b.score - a.score)
+    .map(scored => scored.item)
+
+// Only non-secret list metadata is searchable — secrets live in the encrypted
+// payload and are never held in the entry list (see `lib/commands.EntryMeta`).
+export const entryFields = (entry: EntryMeta): Field[] => [
+  { text: entry.title, weight: 3 },
+  { text: entry.urlHost, weight: 2 },
+  ...entry.tags.map(tag => ({ text: tag, weight: 1 }))
+]
+
+// Entries matching `query`, best first, alphabetical within a tie.
+export const searchEntries = (entries: EntryMeta[], query: string): EntryMeta[] =>
+  rank([...entries].sort((a, b) => a.title.localeCompare(b.title)), query, entryFields)

--- a/src/components/Main/Palette/useResults.ts
+++ b/src/components/Main/Palette/useResults.ts
@@ -1,0 +1,62 @@
+import { useMemo } from 'react'
+import type { EntryMeta } from '@/lib/commands'
+import { useStore } from '@/store'
+import { t } from '@/i18n'
+import { rank, searchEntries } from './search'
+import { useCommands, type Command } from './commands'
+
+export type Item =
+  | { kind: 'entry'; key: string; entry: EntryMeta }
+  | { kind: 'command'; key: string; command: Command }
+
+export interface Group {
+  label: string
+  items: Item[]
+}
+
+// The palette is a shortcut, not a browser — a long entry list belongs in the
+// list column, so only the strongest handful surface here.
+const MAX_ENTRIES = 6
+
+const entryItem = (entry: EntryMeta): Item => ({ kind: 'entry', key: `entry:${entry.id}`, entry })
+
+const commandItem = (command: Command): Item => ({
+  kind: 'command',
+  key: `command:${command.id}`,
+  command
+})
+
+const group = (label: string, items: Item[]): Group[] =>
+  items.length === 0 ? [] : [{ label, items }]
+
+// Splits the results into the prototype's sections: the top entry on its own,
+// the runners-up, then the matching commands.
+export const buildGroups = (
+  entries: EntryMeta[],
+  commands: Command[],
+  query: string
+): Group[] => {
+  const matched = rank(commands, query, command => [{ text: command.label }])
+  const [best, ...rest] = entries
+
+  return [
+    ...group(t('Best match'), best ? [entryItem(best)] : []),
+    ...group(t('Entries'), rest.map(entryItem)),
+    ...group(t('Commands'), matched.map(commandItem))
+  ]
+}
+
+export const useResults = (query: string): Group[] => {
+  const entries = useStore(state => state.entries.items)
+  const commands = useCommands()
+
+  // The only costly step (a sort plus a score per entry), so it is the only one
+  // worth memoizing. With no query there is nothing to rank entries by, so the
+  // palette opens on the command list alone.
+  const matched = useMemo(
+    () => (query.trim() === '' ? [] : searchEntries(entries, query).slice(0, MAX_ENTRIES)),
+    [entries, query]
+  )
+
+  return buildGroups(matched, commands, query)
+}

--- a/src/components/Main/Sidebar/Settings/index.tsx
+++ b/src/components/Main/Sidebar/Settings/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useStore, openSettings, closeSettings } from '@/store'
 import { t } from '@/i18n'
 import Modal from '@/components/elements/Modal'
 import Tooltip from '@/components/elements/Tooltip'
@@ -14,7 +15,8 @@ import Updates from './Updates'
 import { GearGlyph } from '../../icons'
 
 export default function Settings() {
-  const [modal, setModal] = useState(false)
+  // Open state lives in the store so the ⌘K palette can open Settings too.
+  const modal = useStore(state => state.ui.settings)
   const [section, setSection] = useState<Section>('vault')
 
   return (
@@ -23,13 +25,13 @@ export default function Settings() {
         <div
           className="settings-button grid h-9 w-9 cursor-pointer place-items-center rounded-lg text-text2 transition-colors hover:bg-hover hover:text-text"
           data-testid="settings-button"
-          onClick={() => setModal(!modal)}
+          onClick={() => (modal ? closeSettings() : openSettings())}
         >
           <GearGlyph />
         </div>
       </Tooltip>
       {modal && (
-        <Modal onClose={() => setModal(false)}>
+        <Modal onClose={closeSettings}>
           <div className="preferences flex max-h-[80vh] min-h-[560px] w-full text-text">
             <Navigation section={section} onClick={setSection} />
             <div className="body flex-1 overflow-y-auto p-7">

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,10 +1,14 @@
 import Sidebar from './Sidebar'
 import Header from './Header'
 import Body from './Body'
+import Palette from './Palette'
+import { useShortcuts } from './useShortcuts'
 
 // Three-pane shell: a full-width top chrome bar over a row of
 // rail (68px) · list column (348px) · detail pane (flex).
 export function Main() {
+  useShortcuts()
+
   return (
     <div
       data-testid="main-view"
@@ -15,6 +19,7 @@ export function Main() {
         <Sidebar />
         <Body />
       </div>
+      <Palette />
     </div>
   )
 }

--- a/src/components/Main/useShortcuts.ts
+++ b/src/components/Main/useShortcuts.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { openPalette } from '@/store'
+import { lockVault } from './Palette/commands'
+
+// App-wide chords for the unlocked vault. Mounted once from `Main`, so they are
+// live only while the vault is open and die with it.
+//
+// Deliberately one small effect with one `switch`: adding a chord is a case,
+// not a new listener, and two branches touching this file merge cleanly.
+const BINDINGS: Record<string, () => void> = {
+  k: openPalette,
+  l: lockVault
+}
+
+export const useShortcuts = () => {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return
+      const run = BINDINGS[e.key.toLowerCase()]
+      if (!run) return
+      e.preventDefault()
+      run()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -126,5 +126,15 @@
   "Automatic Updates": "Automatic Updates",
   "Updates download in the background and apply when you restart.": "Updates download in the background and apply when you restart.",
   "Check for Updates": "Check for Updates",
+  "Search or run a command": "Search or run a command",
+  "Best match": "Best match",
+  "Entries": "Entries",
+  "Commands": "Commands",
+  "No results": "No results",
+  "New entry": "New entry",
+  "Lock vault": "Lock vault",
+  "Toggle theme": "Toggle theme",
+  "open": "open",
+  "copy": "copy",
   "Checking…": "Checking…"
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ import { createSyncSlice, type SyncSlice } from './syncSlice'
 import { createI18nSlice, type I18nSlice } from './i18nSlice'
 import { createThemeSlice, type ThemeSlice } from './themeSlice'
 import { createUpdateSlice, type UpdateSlice } from './updateSlice'
+import { createUiSlice, type UiSlice } from './uiSlice'
 import { createAsyncSlice, type AsyncSlice } from './thunks'
 
 export type StoreState = FlowSlice &
@@ -18,6 +19,7 @@ export type StoreState = FlowSlice &
   I18nSlice &
   ThemeSlice &
   UpdateSlice &
+  UiSlice &
   AsyncSlice
 
 export const useStore = create<StoreState>()((...a) => ({
@@ -29,6 +31,7 @@ export const useStore = create<StoreState>()((...a) => ({
   ...createI18nSlice(...a),
   ...createThemeSlice(...a),
   ...createUpdateSlice(...a),
+  ...createUiSlice(...a),
   ...createAsyncSlice(...a)
 }))
 
@@ -40,7 +43,8 @@ const pickData = (s: StoreState) => ({
   breachCheck: s.breachCheck,
   sync: s.sync,
   i18n: s.i18n,
-  update: s.update
+  update: s.update,
+  ui: s.ui
 })
 
 const initialData = pickData(useStore.getState())
@@ -81,6 +85,10 @@ export const {
   toggleTheme,
   setUpdateReady,
   dismissUpdate,
+  openPalette,
+  closePalette,
+  openSettings,
+  closeSettings,
   runUpdateCheck,
   saveEntry,
   deleteEntry,

--- a/src/store/uiSlice.ts
+++ b/src/store/uiSlice.ts
@@ -1,0 +1,23 @@
+import type { StateCreator } from 'zustand'
+import type { StoreState } from './index'
+
+// Chrome-level UI surfaces that more than one component needs to open: the ⌘K
+// command palette and the Settings modal. Keeping them here means any control
+// (rail button, header field, palette command) can open one with a bound action
+// instead of prop-drilling or lifting state through the three-pane shell.
+export interface UiSlice {
+  ui: { palette: boolean; settings: boolean }
+  openPalette: () => void
+  closePalette: () => void
+  openSettings: () => void
+  closeSettings: () => void
+}
+
+export const createUiSlice: StateCreator<StoreState, [], [], UiSlice> = set => ({
+  ui: { palette: false, settings: false },
+  openPalette: () => set(s => ({ ui: { ...s.ui, palette: true } })),
+  closePalette: () => set(s => ({ ui: { ...s.ui, palette: false } })),
+  // Opening Settings dismisses the palette, so a palette command can hand off.
+  openSettings: () => set(() => ({ ui: { palette: false, settings: true } })),
+  closeSettings: () => set(s => ({ ui: { ...s.ui, settings: false } }))
+})

--- a/src/test/palette.test.tsx
+++ b/src/test/palette.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Main from '@/components/Main'
+import { copyToClipboard, revealEntry } from '@/lib/commands'
+import { makeStore, useStore } from '@/store'
+import { renderWithStore, withEntries, loginEntry, loginMeta } from './utils'
+
+const open = () => userEvent.keyboard('{Meta>}k{/Meta}')
+
+const seed = () => {
+  const store = makeStore()
+  withEntries(store, [
+    loginMeta({ id: 'l1', title: 'Google', urlHost: 'google.com' }),
+    loginMeta({ id: 'l2', title: 'Airbnb', urlHost: 'airbnb.com' }),
+    { id: 'c1', type: 'card', title: 'Visa', tags: [], urlHost: '' }
+  ])
+  return store
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('command palette', () => {
+  it('opens on ⌘K and closes on Escape', async () => {
+    renderWithStore(<Main />, { store: seed() })
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+
+    await open()
+    expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+  })
+
+  it('lists commands before anything is typed', async () => {
+    renderWithStore(<Main />, { store: seed() })
+    await open()
+
+    expect(screen.getByText('Commands')).toBeInTheDocument()
+    expect(screen.getByText('Lock vault')).toBeInTheDocument()
+    expect(screen.queryByText('Best match')).not.toBeInTheDocument()
+  })
+
+  it('filters entries as you type, best match first', async () => {
+    renderWithStore(<Main />, { store: seed() })
+    await open()
+    await userEvent.keyboard('goo')
+
+    // The list column behind the palette shows entries too, so scope the query.
+    const palette = within(screen.getByTestId('command-palette'))
+    expect(palette.getByText('Best match')).toBeInTheDocument()
+    expect(palette.getByText('Google')).toBeInTheDocument()
+    expect(palette.queryByText('Airbnb')).not.toBeInTheDocument()
+  })
+
+  it('opens the focused entry on ⏎, switching scope when needed', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ id: 'c1', title: 'Visa' }))
+    renderWithStore(<Main />, { store: seed() })
+
+    await open()
+    await userEvent.keyboard('visa{Enter}')
+
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+    expect(useStore.getState().filters.scope).toBe('card')
+    expect(useStore.getState().entries.current?.id).toBe('c1')
+  })
+
+  it('copies the primary secret on ⌘⏎', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(
+      loginEntry({ id: 'l1', title: 'Google', password: 's3cret' })
+    )
+    renderWithStore(<Main />, { store: seed() })
+
+    await open()
+    await userEvent.keyboard('google{Meta>}{Enter}{/Meta}')
+
+    expect(revealEntry).toHaveBeenCalledWith('l1')
+    await vi.waitFor(() => expect(copyToClipboard).toHaveBeenCalledWith('s3cret', expect.anything()))
+    // The entry is copied, not selected.
+    expect(useStore.getState().entries.current).toBeNull()
+  })
+
+  it('moves focus with the arrow keys and runs the focused command', async () => {
+    renderWithStore(<Main />, { store: seed() })
+    await open()
+    // Commands: new entry · lock vault · toggle theme · settings
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{Enter}')
+
+    expect(useStore.getState().ui.settings).toBe(true)
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+  })
+
+  it('runs a command on click', async () => {
+    const store = seed()
+    renderWithStore(<Main />, { store })
+    const before = useStore.getState().theme
+
+    await open()
+    await userEvent.click(screen.getByText('Toggle theme'))
+
+    expect(useStore.getState().theme).not.toBe(before)
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
+// jsdom implements no layout, so it ships no scrollIntoView.
+Element.prototype.scrollIntoView = vi.fn()
+
 // The Rust backend is built in parallel; mock the whole command/event layer so
 // screens render without a live backend. Individual tests override as needed.
 vi.mock('@/lib/commands', () => ({


### PR DESCRIPTION
PR 7 of the design port — the prototype's command palette, built as a new module.

## What
- `Main/Palette/` (620px panel, animate-pop over the scrim): typed query ranks entries and commands in one pass; ↑/↓/⏎ navigation, focus trapped in the input
- Entry actions: ⏎ selects (flipping scope first if needed), ⌘⏎ reveals + copies the primary secret (login→password, card→number, note→note) via the existing `copy` service
- Commands reuse the exact functions the existing controls call: New entry, Lock vault (⌘L), Toggle theme, Settings
- `useShortcuts` hook in `Main/index.tsx` — first app-level shortcut surface (`BINDINGS` record: ⌘K, ⌘L; siblings add one line). Live only while unlocked
- New `uiSlice` (`palette`, `settings`); the Settings modal's open flag moved from local state to the store so the palette can open it (testid intact)
- Dependency-free weighted scorer (prefix > substring > subsequence; title×3, host×2, tags×1) with tests — the store's Fuse search and `filters.query` untouched

## Follow-up (one line, tracked for the polish pass)
`Header/Search.tsx` gets `onClick={openPalette}` once that file settles across the open stack — the ⌘K chip it already shows then tells the truth.

## Tests
86 passing (+26 new) · lint clean · build green · testids preserved