### PR TITLE
Entry editor in a right slide-in sheet

### DIFF
--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -9,7 +9,8 @@ import Login from './Login'
 import Card from './Card'
 import Note from './Note'
 import Button from '@/components/elements/Button'
-import { MONO_LABEL } from '../ui'
+import Sheet from '@/components/elements/Sheet'
+import { cx } from '@/utils/cx'
 import type { FieldChange } from './helpers'
 
 interface Props {
@@ -26,19 +27,26 @@ export default function Form({ entry }: Props) {
   const scope = useStore(state => state.filters.scope)
   const type: EntryType = scope === 'audit' ? 'login' : scope
 
+  const initial = (): EntryDraft => (entry ? { ...entry } : defaults[type])
   const [validate, setValidate] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
-  const [model, setModel] = useState<EntryDraft>(
-    entry ? { ...entry } : defaults[type]
-  )
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
+  const [model, setModel] = useState<EntryDraft>(initial)
+  // What the model looked like when it was last loaded — the dirty baseline.
+  const [pristine, setPristine] = useState<EntryDraft>(initial)
 
   // When editing, secret fields arrive encrypted; swap in the decrypted values.
   const revealed = useRevealed(entry)
   useEffect(() => {
-    if (revealed) setModel({ ...revealed })
+    if (!revealed) return
+    setModel({ ...revealed })
+    setPristine({ ...revealed })
   }, [revealed])
 
-  const patch = (name: string, value: string | string[]) =>
+  const dirty = JSON.stringify(model) !== JSON.stringify(pristine)
+
+  const patch = (name: string, value: string | string[]) => {
+    setConfirmDiscard(false)
     setModel(current => ({
       ...current,
       [name]: value,
@@ -46,14 +54,22 @@ export default function Form({ entry }: Props) {
         ? { password_updated_at: new Date().toISOString() }
         : {})
     }))
+  }
 
   const onChange = (event: FieldChange) =>
     patch(event.target.name, event.target.value)
   const onTagsChange = (tags: string[]) => patch('tags', tags)
 
-  const onCancel = () => {
+  const close = () => {
     if (model.id) setCurrentEntry(model.id)
     else setNoEntry()
+  }
+
+  // Esc / scrim / Cancel. Unsaved edits arm an inline confirm on the Cancel
+  // button instead of a blocking dialog; the next request discards.
+  const onCancel = () => {
+    if (!dirty || confirmDiscard) return close()
+    setConfirmDiscard(true)
   }
 
   const onSave = () => {
@@ -85,34 +101,40 @@ export default function Form({ entry }: Props) {
     }
   }
 
-  return (
-    <div className="mx-auto max-w-[560px]">
-      <div className={MONO_LABEL}>{t(KIND_LABEL[type])}</div>
-      <h1 className="mt-2 text-2xl font-semibold tracking-display text-text">
-        {entry ? t('Edit') : t('New Secret')}
-      </h1>
+  const footer = (
+    <>
+      <span className="flex-1 font-mono text-xs text-text3">{t(KIND_LABEL[type])}</span>
+      <button
+        type="button"
+        data-testid="cancel-entry-button"
+        onClick={onCancel}
+        className={cx(
+          'h-9 cursor-pointer rounded-sm px-4 text-base transition-colors',
+          confirmDiscard ? 'text-bad hover:brightness-110' : 'text-text2 hover:text-text'
+        )}
+      >
+        {confirmDiscard ? t('Discard changes?') : t('Cancel')}
+      </button>
+      <Button testid="save-entry-button" kbd="⌘⏎" onClick={onSave}>
+        {t('Save')}
+      </Button>
+    </>
+  )
 
-      <div className="mt-6 flex flex-col gap-4">{fields()}</div>
+  return (
+    <Sheet
+      title={entry ? t('Edit entry') : t('New entry')}
+      onClose={onCancel}
+      onSubmit={onSave}
+      footer={footer}
+    >
+      <div className="flex flex-col gap-4">{fields()}</div>
 
       {saveError && (
         <div className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-base text-bad">
           {saveError}
         </div>
       )}
-
-      <div className="mt-6 flex items-center justify-end gap-2">
-        <button
-          type="button"
-          data-testid="cancel-entry-button"
-          onClick={onCancel}
-          className="h-9 cursor-pointer rounded-sm px-4 text-base text-text2 transition-colors hover:text-text"
-        >
-          {t('Cancel')}
-        </button>
-        <Button testid="save-entry-button" onClick={onSave}>
-          {t('Save')}
-        </Button>
-      </div>
-    </div>
+    </Sheet>
   )
 }

--- a/src/components/Main/Body/Aside/index.tsx
+++ b/src/components/Main/Body/Aside/index.tsx
@@ -1,17 +1,14 @@
 import { useStore } from '@/store'
-import Form from './Form'
 import Show from './Show'
 import Empty from './Empty'
 import Audit from './Audit'
 
+// Detail-pane content only. Create/edit no longer replaces it — the Form now
+// renders in a right slide-in sheet over this pane (mounted by Body).
 export default function Aside() {
   const scope = useStore(state => state.filters.scope)
-  const isNew = useStore(state => state.entries.new)
-  const isEditing = useStore(state => state.entries.edit)
   const entry = useStore(state => state.entries.current)
 
-  if (isNew) return <Form />
-  if (isEditing && entry) return <Form entry={entry} />
   if (entry) return <Show entry={entry} />
   if (scope === 'audit') return <Audit />
   return <Empty />

--- a/src/components/Main/Body/index.tsx
+++ b/src/components/Main/Body/index.tsx
@@ -1,12 +1,23 @@
+import { useStore } from '@/store'
 import ListColumn from './ListColumn'
 import DetailPane from './DetailPane'
+import Form from './Aside/Form'
 
 // The two content panes to the right of the rail: list column + detail pane.
+// Creating or editing an entry floats the Form over both in a right slide-in
+// sheet, so the detail pane keeps showing the entry underneath.
 export default function Body() {
+  const isNew = useStore(state => state.entries.new)
+  const isEditing = useStore(state => state.entries.edit)
+  const entry = useStore(state => state.entries.current)
+  const editing = isEditing ? entry : null
+
   return (
     <>
       <ListColumn />
       <DetailPane />
+      {isNew && <Form />}
+      {editing && <Form entry={editing} />}
     </>
   )
 }

--- a/src/components/elements/Sheet.tsx
+++ b/src/components/elements/Sheet.tsx
@@ -1,0 +1,60 @@
+import { useEffect, type ReactNode } from 'react'
+import { t } from '@/i18n'
+import { CloseGlyph } from '../Main/icons'
+import IconButton from './IconButton'
+
+interface Props {
+  title: string
+  // Close *request* — from Esc, the scrim, or the header button. The caller
+  // decides whether to actually close (so it can run a dirty guard first).
+  onClose: () => void
+  // ⌘⏎ / Ctrl+⏎ while the sheet is open.
+  onSubmit?: () => void
+  // Pinned action row at the bottom of the panel.
+  footer?: ReactNode
+  children: ReactNode
+}
+
+// Full-height 520px panel sliding in from the right over a blurred scrim, with
+// a fixed header, a scrollable body and a pinned footer. Sibling of Modal:
+// same overlay language, different anchor.
+export default function Sheet({ title, onClose, onSubmit, footer, children }: Props) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') return onClose()
+      if (onSubmit && event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        onSubmit()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose, onSubmit])
+
+  return (
+    <div
+      className="animate-fade fixed inset-0 z-40 flex justify-end bg-[var(--scrim)] backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="animate-sheet flex h-full w-[520px] flex-col border-l border-line2 bg-detail text-text shadow-[var(--shadow)]"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="flex flex-none items-center gap-3 border-b border-line px-5 py-[17px]">
+          <div className="flex-1 text-lg font-semibold tracking-display">{title}</div>
+          <IconButton title={t('Close')} onClick={onClose}>
+            <CloseGlyph />
+          </IconButton>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 pt-[18px] pb-6">{children}</div>
+
+        {footer && (
+          <div className="flex flex-none items-center gap-2 border-t border-line px-5 py-[13px]">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -126,5 +126,9 @@
   "Automatic Updates": "Automatic Updates",
   "Updates download in the background and apply when you restart.": "Updates download in the background and apply when you restart.",
   "Check for Updates": "Check for Updates",
-  "Checking…": "Checking…"
+  "Checking…": "Checking…",
+  "New entry": "New entry",
+  "Edit entry": "Edit entry",
+  "Discard changes?": "Discard changes?",
+  "Close": "Close"
 }

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -37,6 +37,39 @@ describe('Form', () => {
     expect(saveEntry).not.toHaveBeenCalled()
   })
 
+  it('closes straight away when nothing was typed', async () => {
+    const { store } = renderWithStore(<Form />)
+    store.getState().newEntry()
+    await userEvent.click(screen.getByTestId('cancel-entry-button'))
+    expect(screen.queryByText('Discard changes?')).not.toBeInTheDocument()
+    expect(store.getState().entries.new).toBe(false)
+  })
+
+  it('guards unsaved changes with an inline confirm', async () => {
+    const { store } = renderWithStore(<Form />)
+    store.getState().newEntry()
+    await userEvent.type(document.querySelector('input[name="title"]')!, 'GitHub')
+
+    // First press only arms the confirm; the form stays open.
+    await userEvent.click(screen.getByTestId('cancel-entry-button'))
+    expect(screen.getByText('Discard changes?')).toBeInTheDocument()
+    expect(store.getState().entries.new).toBe(true)
+
+    // Second press discards.
+    await userEvent.click(screen.getByTestId('cancel-entry-button'))
+    expect(store.getState().entries.new).toBe(false)
+  })
+
+  it('saves on ⌘⏎ from anywhere in the sheet', async () => {
+    renderWithStore(<Form />)
+    await userEvent.type(document.querySelector('input[name="title"]')!, 'GitHub')
+    await userEvent.type(document.querySelector('input[name="username"]')!, 'octocat')
+    await userEvent.type(document.querySelector('input[name="password"]')!, 'pw')
+    await userEvent.keyboard('{Meta>}{Enter}{/Meta}')
+
+    expect(saveEntry).toHaveBeenCalledOnce()
+  })
+
   it('generates a password', async () => {
     vi.mocked(generatePassword).mockResolvedValue('Generated123!')
     renderWithStore(<Form />)


### PR DESCRIPTION
PR 5 of the design port — **stacked on #270** (`feat/pixel-port-sweep`); merge that first and this retargets automatically.

## What
- New reusable `elements/Sheet.tsx`: 520px right panel over the blurred scrim (`animate-sheet`/`animate-fade`), pinned header/footer, scrollable body, `z-40` under Modal's `z-50`. Esc/scrim/✕ are close *requests* routed to the caller; optional ⌘⏎ submit
- The entry Form now renders in the sheet, floating over both panes — the detail pane keeps showing Show/Empty behind it. Aside routing simplified to Show/Audit/Empty; no store changes needed (the existing `entries.new`/`entries.edit` flags drive it)
- Sheet footer: entry-type label · Cancel · Save with `⌘⏎` kbd hint
- Dirty guard with **no native dialogs**: first Esc/Cancel on a dirty form arms "Discard changes?" (text-bad), second press discards, any edit disarms. Baseline snapshots the *decrypted* values so editing doesn't false-positive
- Form internals (fields, validation, save thunk) byte-identical — layout wrapper only

## Tests
63 passing (+3: clean close, two-press discard, ⌘⏎ save) · lint/build green · `save-entry-button`/`cancel-entry-button` preserved and the e2e smoke create-flow verified against `tests/e2e/specs/smoke.spec.ts`

Known cosmetic: Show behind the sheet still calls `revealEntry`, so an edit decrypts twice — harmless, noted for the polish pass.