### PR TITLE
Detail header: per-type primary action, more-menu, copy feedback

### DIFF
--- a/src/components/Main/Body/Aside/Show/Actions.tsx
+++ b/src/components/Main/Body/Aside/Show/Actions.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import type { Entry, EntryType } from '@/lib/commands'
+import { editEntry } from '@/store'
+import { t } from '@/i18n'
+import { useCopied } from '@/hooks/useCopied'
+import Button from '@/components/elements/Button'
+import IconButton from '@/components/elements/IconButton'
+import { Dropdown, DropdownItem } from '@/components/elements/Dropdown'
+import { CheckGlyph, MoreGlyph, PencilGlyph, TrashGlyph } from '../../../icons'
+
+interface Props {
+  type: EntryType
+  // The decrypted entry, or null while `revealEntry` is still in flight.
+  revealed: Entry | null
+  onDelete: () => void
+}
+
+// Each type's headline secret — the one value the header offers in a single
+// press. Reads straight off the already-decrypted entry, so copying never
+// touches a row's on-screen reveal state.
+const secretOf = (entry: Entry): string => {
+  switch (entry.type) {
+    case 'login':
+      return entry.password
+    case 'card':
+      return entry.number
+    case 'note':
+      return entry.note
+  }
+}
+
+const PRIMARY_LABEL: Record<EntryType, string> = {
+  login: 'Copy password',
+  card: 'Copy number',
+  note: 'Copy note'
+}
+
+// Enter is the detail pane's accelerator for the primary action, but only as a
+// bare press outside any text field or open dialog — anywhere else the key
+// belongs to whatever the user is typing in.
+const isPlainEnter = (e: KeyboardEvent) =>
+  e.key === 'Enter' &&
+  !e.metaKey &&
+  !e.ctrlKey &&
+  !e.altKey &&
+  !e.shiftKey &&
+  !e.defaultPrevented
+
+const inTextField = (target: EventTarget | null) =>
+  target instanceof Element &&
+  !!target.closest('input, textarea, select, [contenteditable="true"]')
+
+const dialogOpen = () => !!document.querySelector('[role="dialog"], dialog[open]')
+
+// The detail header's action cluster: Edit, an overflow menu and the per-type
+// primary copy action.
+export default function Actions({ type, revealed, onDelete }: Props) {
+  const [menu, setMenu] = useState(false)
+  const { copied, copy } = useCopied()
+  const secret = revealed ? secretOf(revealed) : ''
+
+  useEffect(() => {
+    if (!secret) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!isPlainEnter(e) || inTextField(e.target) || dialogOpen()) return
+      e.preventDefault()
+      copy(secret)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [secret, copy])
+
+  const run = (action: () => void) => () => {
+    setMenu(false)
+    action()
+  }
+
+  return (
+    <div className="flex flex-none items-center gap-1.5">
+      <Button variant="pale" size="md" onClick={() => editEntry()}>
+        {t('Edit')}
+      </Button>
+
+      <div className="relative">
+        <IconButton
+          title={t('More actions')}
+          active={menu}
+          onClick={() => setMenu(!menu)}
+          className="border border-line2 hover:border-accent-line"
+          testid="more-actions-button"
+        >
+          <MoreGlyph />
+        </IconButton>
+        {menu && (
+          <Dropdown className="right-0 top-8" onBlur={() => setMenu(false)}>
+            <DropdownItem onClick={run(editEntry)}>
+              <PencilGlyph />
+              {t('Edit')}
+            </DropdownItem>
+            <DropdownItem separated danger onClick={run(onDelete)}>
+              <TrashGlyph />
+              {t('Delete')}
+            </DropdownItem>
+          </Dropdown>
+        )}
+      </div>
+
+      <Button
+        size="md"
+        kbd="⏎"
+        disabled={!secret}
+        onClick={() => copy(secret)}
+        testid="primary-action-button"
+      >
+        {copied ? (
+          <>
+            <CheckGlyph />
+            {t('Copied')}
+          </>
+        ) : (
+          t(PRIMARY_LABEL[type])
+        )}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
-import { editEntry, deleteEntry } from '@/store'
+import { deleteEntry } from '@/store'
 import type { EntryMeta } from '@/lib/commands'
 import { useRevealed } from '@/hooks/useRevealed'
 import { t } from '@/i18n'
 import Details from './Details'
-import Button from '@/components/elements/Button'
-import { IconButton, MONO_LABEL } from '../ui'
-import { TrashGlyph } from '../../../icons'
+import Actions from './Actions'
+import { MONO_LABEL } from '../ui'
 
 interface Props {
   entry: EntryMeta
@@ -66,16 +65,7 @@ export default function Show({ entry }: Props) {
             {entry.title}
           </h1>
         </div>
-        <div className="flex flex-none items-center gap-1.5">
-          <IconButton
-            title={t('Delete')}
-            onClick={onDelete}
-            className="border border-line2 hover:border-accent-line hover:text-bad"
-          >
-            <TrashGlyph />
-          </IconButton>
-          <Button size="md" onClick={() => editEntry()}>{t('Edit')}</Button>
-        </div>
+        <Actions type={entry.type} revealed={revealed} onDelete={onDelete} />
       </div>
 
       <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-line bg-[image:var(--card)]">

--- a/src/components/Main/Body/Aside/ui.tsx
+++ b/src/components/Main/Body/Aside/ui.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
-import { copy } from '@/services/copy'
+import { useCopied } from '@/hooks/useCopied'
 import { useStrength } from '@/hooks/useStrength'
 import { t } from '@/i18n'
 import IconButton from '@/components/elements/IconButton'
-import { CopyGlyph } from '../../icons'
+import { CheckGlyph, CopyGlyph } from '../../icons'
 
 // Re-export so existing detail-pane imports keep working; the primitive itself
 // now lives in elements/ and is shared with the header and Masterpass.
@@ -45,11 +45,14 @@ export function Panel({
   )
 }
 
-// Copy-to-clipboard affordance wired to the existing clipboard service.
+// Copy-to-clipboard affordance wired to the existing clipboard service. The
+// glyph flips to a check for a beat so the row confirms locally, alongside the
+// global "Copied to Clipboard" toast.
 export function CopyButton({ value, title }: { value: string; title?: string }) {
+  const { copied, copy } = useCopied()
   return (
-    <IconButton title={title} onClick={() => copy(value)}>
-      <CopyGlyph />
+    <IconButton title={copied ? t('Copied') : title} onClick={() => copy(value)}>
+      {copied ? <CheckGlyph className="text-good" /> : <CopyGlyph />}
     </IconButton>
   )
 }

--- a/src/components/Main/icons.tsx
+++ b/src/components/Main/icons.tsx
@@ -10,6 +10,7 @@
 // Components keep the historical `*Glyph` names so this module stays the one
 // place an icon choice lives.
 import {
+  Check,
   ChevronDown,
   Copy,
   CreditCard,
@@ -21,6 +22,7 @@ import {
   Globe,
   Lock,
   Moon,
+  MoreHorizontal,
   Pencil,
   Plus,
   RefreshCw,
@@ -50,6 +52,8 @@ export const LockGlyph = glyph(Lock, 14)
 export const SunGlyph = glyph(Sun, 14)
 export const MoonGlyph = glyph(Moon, 14)
 export const CopyGlyph = glyph(Copy, 14)
+export const CheckGlyph = glyph(Check, 14)
+export const MoreGlyph = glyph(MoreHorizontal, 14)
 export const EyeGlyph = glyph(Eye, 14)
 export const EyeOffGlyph = glyph(EyeOff, 14)
 export const PencilGlyph = glyph(Pencil, 14)

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -3,13 +3,20 @@ import { cx } from '@/utils/cx'
 
 interface DropdownProps {
   onBlur: () => void
+  // Placement against the nearest positioned ancestor (e.g. 'right-0 top-8').
+  className?: string
   children: ReactNode
 }
 
-export function Dropdown({ onBlur, children }: DropdownProps) {
+export function Dropdown({ onBlur, className, children }: DropdownProps) {
   return (
     <>
-      <div className="animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]">
+      <div
+        className={cx(
+          'animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]',
+          className
+        )}
+      >
         {children}
       </div>
       <div className="fixed inset-0 z-10" onClick={onBlur} />
@@ -20,17 +27,20 @@ export function Dropdown({ onBlur, children }: DropdownProps) {
 interface ItemProps {
   id?: string
   separated?: boolean
+  // Destructive entry (delete, disconnect, ...): inked in the `bad` token.
+  danger?: boolean
   onClick?: () => void
   children: ReactNode
 }
 
-export function DropdownItem({ id, separated, onClick, children }: ItemProps) {
+export function DropdownItem({ id, separated, danger, onClick, children }: ItemProps) {
   return (
     <div
       id={id}
       onClick={onClick}
       className={cx(
-        'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-base text-text2 transition-colors hover:bg-hover hover:text-text',
+        'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-base transition-colors hover:bg-hover',
+        danger ? 'text-bad' : 'text-text2 hover:text-text',
         separated && 'mt-1 border-t border-line pt-2.5'
       )}
     >

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -13,6 +13,8 @@ export default function Modal({ onClose, children }: Props) {
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
         className="animate-pop relative flex max-h-[80vh] w-full max-w-[720px] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
         onClick={e => e.stopPropagation()}
       >

--- a/src/hooks/useCopied.test.tsx
+++ b/src/hooks/useCopied.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { copyToClipboard } from '@/lib/commands'
+import { useCopied } from './useCopied'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useCopied', () => {
+  it('copies through the clipboard service and flags the confirmation', () => {
+    const { result } = renderHook(() => useCopied())
+    expect(result.current.copied).toBe(false)
+
+    act(() => result.current.copy('secret'))
+
+    expect(copyToClipboard).toHaveBeenCalledWith('secret', expect.any(Number))
+    expect(result.current.copied).toBe(true)
+  })
+
+  it('drops the confirmation once the beat elapses', () => {
+    const { result } = renderHook(() => useCopied(1200))
+
+    act(() => result.current.copy('secret'))
+    act(() => vi.advanceTimersByTime(1199))
+    expect(result.current.copied).toBe(true)
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('restarts the beat on a re-copy', () => {
+    const { result } = renderHook(() => useCopied(1200))
+
+    act(() => result.current.copy('one'))
+    act(() => vi.advanceTimersByTime(1000))
+    act(() => result.current.copy('two'))
+    act(() => vi.advanceTimersByTime(1000))
+
+    expect(result.current.copied).toBe(true)
+  })
+
+  it('clears its timer on unmount', () => {
+    const { result, unmount } = renderHook(() => useCopied())
+
+    act(() => result.current.copy('secret'))
+    unmount()
+
+    expect(() => vi.runOnlyPendingTimers()).not.toThrow()
+  })
+})

--- a/src/hooks/useCopied.ts
+++ b/src/hooks/useCopied.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { copy } from '@/services/copy'
+
+// How long the confirmation glyph stays up after a copy.
+const FEEDBACK_TIMEOUT = 1200
+
+// Copies a value through the clipboard service and raises `copied` for a short
+// beat, so every copy affordance (row buttons, the detail header's primary
+// action) can flash the same check without owning a timer of its own. The timer
+// restarts on a re-copy and is cleared on unmount.
+export function useCopied(timeout = FEEDBACK_TIMEOUT) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => clearTimeout(timer.current), [])
+
+  const copyValue = useCallback(
+    (value: string) => {
+      copy(value)
+      clearTimeout(timer.current)
+      setCopied(true)
+      timer.current = setTimeout(() => setCopied(false), timeout)
+    },
+    [timeout]
+  )
+
+  return { copied, copy: copyValue }
+}

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Form from '@/components/Main/Body/Aside/Form'
 import Show from '@/components/Main/Body/Aside/Show'
-import { saveEntry, revealEntry, generatePassword, generateOtp, copyToClipboard, toEntryMeta } from '@/lib/commands'
+import { saveEntry, revealEntry, generatePassword, generateOtp, copyToClipboard, deleteEntry, toEntryMeta } from '@/lib/commands'
 import type { LoginEntry } from '@/lib/commands'
 import { renderWithStore, loginEntry, loginMeta } from './utils'
 
@@ -70,5 +70,42 @@ describe('Show', () => {
     await userEvent.click(await screen.findByText('copyme'))
     await userEvent.click(document.querySelector('.item svg')!)
     expect(copyToClipboard).toHaveBeenCalled()
+  })
+
+  it('copies the password from the header without revealing it', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'hunter2' }))
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    const action = await screen.findByTestId('primary-action-button')
+    await waitFor(() => expect(action).toBeEnabled())
+    expect(action).toHaveTextContent('Copy password')
+    await userEvent.click(action)
+
+    expect(copyToClipboard).toHaveBeenCalledWith('hunter2', expect.any(Number))
+    // The password row is still masked: nothing toggled its reveal.
+    expect(screen.getByTitle('Reveal')).toBeInTheDocument()
+  })
+
+  it('runs the primary action on a bare Enter', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'hunter2' }))
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    await waitFor(() => expect(screen.getByTestId('primary-action-button')).toBeEnabled())
+    await userEvent.keyboard('{Enter}')
+
+    expect(copyToClipboard).toHaveBeenCalledWith('hunter2', expect.any(Number))
+  })
+
+  it('deletes from the more menu, keeping the confirmation', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry())
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    await userEvent.click(screen.getByTestId('more-actions-button'))
+    await userEvent.click(screen.getByText('Delete'))
+
+    expect(confirm).toHaveBeenCalled()
+    await waitFor(() => expect(deleteEntry).toHaveBeenCalledWith('l1'))
+    confirm.mockRestore()
   })
 })


### PR DESCRIPTION
PR 4 of the design port — **stacked on #270** (`feat/pixel-port-sweep`).

## What
- Header action cluster per the prototype: **Edit** (pale, 28px) · **⋯ more-menu** (Dropdown, animate-pop; Edit + red Delete) · one accent **primary button with ⏎ kbd**, labeled by type: Copy password / Copy number / Copy note (`data-testid="primary-action-button"`)
- **Copy never reveals**: the plaintext comes from the already-decrypted `useRevealed` entry; on-screen masking is separate presentational state and is never touched (regression test included). Button disabled until decryption resolves or when the field is empty
- **Enter accelerator** scoped to Show's lifetime; ignores modifiers, inputs, and open dialogs (`Modal` gained `role="dialog" aria-modal` — needed for the guard, and correct a11y)
- **Unified copied feedback**: new `useCopied` hook (1.2s check swap, timer-safe); both the header primary and every row `CopyButton` flash a green check; `copy()` service and toast untouched
- `Dropdown` gains additive `className` (placement) and `danger` props

## Deliberate call
Edit was the accent primary before; the prototype's cluster is bordered secondaries + exactly one accent primary, so Edit is now `pale`. Easy to flip back.

## Kept as-is
Delete's existing `window.confirm` guard — replacing it with an inline, design-language confirm is queued for the polish pass.

## Tests
67 passing (+7: copy-without-reveal, Enter guard, delete-confirm kept, useCopied) · lint/build green · all testids preserved