### PR TITLE
UI refinements: rail navigation, quieter detail meta, full-width column, new brand mark

### DIFF
--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -41,7 +41,7 @@ export default function Show({ entry }: Props) {
   ]
 
   return (
-    <div className="mx-auto max-w-[860px]">
+    <div className="mx-auto w-full max-w-[860px]">
 
       <div className="flex items-start gap-4">
         <div className="min-w-0 flex-1">
@@ -61,18 +61,20 @@ export default function Show({ entry }: Props) {
         <Actions type={entry.type} revealed={revealed} onDelete={onDelete} />
       </div>
 
-      <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-line bg-[image:var(--card)]">
+      {/* Reference metadata, not content — no card fill, xs mono values, tight
+          padding, so the block recedes behind the title and details. */}
+      <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-line">
         {ledger.map((cell, i) => (
           <div
             key={cell.k}
             className={
               i < ledger.length - 1
-                ? 'border-r border-line px-3.5 py-[11px]'
-                : 'px-3.5 py-[11px]'
+                ? 'border-r border-line px-3.5 py-2'
+                : 'px-3.5 py-2'
             }
           >
             <div className={MONO_LABEL}>{cell.k}</div>
-            <div className="mt-1.5 truncate font-mono text-base text-text2">
+            <div className="mt-1 truncate font-mono text-xs text-text2">
               {cell.v}
             </div>
           </div>

--- a/src/components/Main/Body/List/Group.tsx
+++ b/src/components/Main/Body/List/Group.tsx
@@ -8,14 +8,14 @@ interface Props {
 }
 
 // A labelled run of entries in either list — an audit severity ("Weak") or a
-// recency bucket ("Today"). A sticky mono header (label + hairline rule +
-// count) over its rows; rendered only when the group has members.
+// recency bucket ("Today"). A mono header (label + hairline rule + count)
+// over its rows; rendered only when the group has members.
 export default function Group({ title, entries }: Props) {
   if (entries.length === 0) return null
 
   return (
     <div>
-      <div className="sticky top-0 z-[1] flex items-center gap-2 bg-list px-4 pb-1.5 pt-3">
+      <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
         <span className="font-mono text-xs uppercase tracking-label text-text3">
           {t(title)}
         </span>

--- a/src/components/Main/Body/List/Manager.tsx
+++ b/src/components/Main/Body/List/Manager.tsx
@@ -1,10 +1,11 @@
 import { useStore } from '@/store'
 import { filterEntries } from '@/services/entries'
 import Item from './Item'
-import Group from './Group'
 import Empty from './Empty'
-import { byTitle, groupByRecency } from './order'
+import { byTitle, byRecency } from './order'
 
+// A flat list in either order — retrieval here is by name or search, so date
+// buckets earn nothing (the audit list keeps its severity groups, which do).
 export default function Manager() {
   const tags = useStore(state => state.filters.tags)
   const scope = useStore(state => state.filters.scope)
@@ -16,20 +17,12 @@ export default function Manager() {
 
   if (entries.length === 0) return <Empty />
 
-  // A–Z is a flat index — grouping it by date would fight the ordering.
-  if (sort === 'alpha')
-    return (
-      <div className="pb-6">
-        {byTitle(entries).map(entry => (
-          <Item entry={entry} key={entry.id} />
-        ))}
-      </div>
-    )
+  const ordered = sort === 'alpha' ? byTitle(entries) : byRecency(entries)
 
   return (
     <div className="pb-6">
-      {groupByRecency(entries).map(group => (
-        <Group title={group.title} entries={group.entries} key={group.title} />
+      {ordered.map(entry => (
+        <Item entry={entry} key={entry.id} />
       ))}
     </div>
   )

--- a/src/components/Main/Body/List/order.ts
+++ b/src/components/Main/Body/List/order.ts
@@ -1,12 +1,8 @@
 import type { EntryMeta } from '@/lib/commands'
-import { recencyBucket, toTime, RECENCY, type Recency } from '@/utils/time'
+import { toTime } from '@/utils/time'
 
-// How the entry list is ordered. "recent" is the working order (newest first,
-// split into recency groups); "alpha" is the flat A–Z index.
-export interface EntryGroup {
-  title: Recency
-  entries: EntryMeta[]
-}
+// How the entry list is ordered. "recent" is the working order (newest
+// first); "alpha" is the flat A–Z index.
 
 // An entry's own clock: when it last changed, falling back to when it was made.
 export const stampOf = (entry: EntryMeta): string | undefined =>
@@ -19,16 +15,3 @@ export const byTitle = (entries: EntryMeta[]): EntryMeta[] =>
 
 export const byRecency = (entries: EntryMeta[]): EntryMeta[] =>
   [...entries].sort((a, b) => timeOf(b) - timeOf(a))
-
-// Newest first, cut into Today / Yesterday / This week / Earlier. Empty buckets
-// drop out, so the headers only ever describe rows that are there.
-export const groupByRecency = (
-  entries: EntryMeta[],
-  now: number = Date.now()
-): EntryGroup[] => {
-  const sorted = byRecency(entries)
-  return RECENCY.map(title => ({
-    title,
-    entries: sorted.filter(entry => recencyBucket(stampOf(entry), now) === title)
-  })).filter(group => group.entries.length > 0)
-}

--- a/src/components/Main/Body/ListColumn.tsx
+++ b/src/components/Main/Body/ListColumn.tsx
@@ -1,11 +1,11 @@
 import { useStore } from '@/store'
-import { scopeEyebrow, scopeTitle } from '../scope'
+import { scopeTitle } from '../scope'
 import Tags from '../Header/Tags'
 import List from './List'
 import SortMenu from './List/SortMenu'
 
-// The middle pane: a scope header (mono eyebrow + large title) with the sort
-// control and the tag filter chips, over the scrollable entry list.
+// The middle pane: a scope header (large title) with the sort control and the
+// tag filter chips, over the scrollable entry list.
 export default function ListColumn() {
   const scope = useStore(state => state.filters.scope)
 
@@ -14,10 +14,7 @@ export default function ListColumn() {
       <div className="flex-none px-4 pt-4 pb-2.5">
         <div className="flex items-end gap-2.5">
           <div className="min-w-0 flex-1">
-            <div className="font-mono text-xs uppercase tracking-label text-text3">
-              {scopeEyebrow(scope)}
-            </div>
-            <div className="mt-1.5 text-xl font-semibold tracking-display text-text">
+            <div className="text-xl font-semibold tracking-display text-text">
               {scopeTitle(scope)}
             </div>
           </div>

--- a/src/components/Main/Sidebar/Add.tsx
+++ b/src/components/Main/Sidebar/Add.tsx
@@ -16,9 +16,9 @@ export default function Add() {
       <div
         data-testid="add-entry-button"
         onClick={onAddEntry}
-        className="grid h-9 w-9 cursor-pointer place-items-center rounded-lg border border-dashed border-accent-line text-accent transition-colors hover:bg-accent-soft"
+        className="grid h-10 w-10 cursor-pointer place-items-center rounded-lg border border-dashed border-accent-line text-accent transition-colors hover:bg-accent-soft"
       >
-        <PlusGlyph />
+        <PlusGlyph size={18} />
       </div>
     </Tooltip>
   )

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -1,24 +1,15 @@
 // Single-vault app: the rail top is just a brand mark (no vault switcher).
 //
 // The mark is "Reveal": a masked-password asterisk with one arm detached as a
-// dot — the one secret in your hand. The asterisk is the native symbol of a
-// secrets app (it's what a masked password looks like), and the dot seeds the
-// lock-screen mascot's eye. Five stadium arms at 60° plus the dot where the
-// sixth would be; arms overlap the center so the union fills solid.
+// dot — the one secret in your hand. Five stadium arms at 60° plus the dot
+// where the sixth would be; arms overlap the center so the union fills solid.
+// Drawn plain in the accent ink, no tile behind it — the mark is the brand.
 const ARM_ANGLES = [0, 60, 180, 240, 300]
 
 export default function Brand() {
   return (
-    <div
-      className="grid h-10 w-10 flex-none place-items-center rounded-lg"
-      style={{
-        background:
-          'linear-gradient(150deg, var(--c-accent), var(--c-accent-deep))',
-        boxShadow: '0 1px 0 rgba(255,255,255,.18) inset'
-      }}
-      title="Swifty"
-    >
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="#fff" aria-label="Swifty">
+    <div className="grid h-10 w-10 flex-none place-items-center text-accent" title="Swifty">
+      <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" aria-label="Swifty">
         {ARM_ANGLES.map(angle => (
           <rect
             key={angle}

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -8,7 +8,7 @@ const ARM_ANGLES = [0, 60, 180, 240, 300]
 
 export default function Brand() {
   return (
-    <div className="grid h-10 w-10 flex-none place-items-center text-text" title="Swifty">
+    <div className="grid h-10 w-10 flex-none place-items-center text-text2" title="Swifty">
       <svg width="30" height="30" viewBox="0 0 24 24" fill="currentColor" aria-label="Swifty">
         {ARM_ANGLES.map(angle => (
           <rect

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -3,13 +3,13 @@
 // The mark is "Reveal": a masked-password asterisk with one arm detached as a
 // dot — the one secret in your hand. Five stadium arms at 60° plus the dot
 // where the sixth would be; arms overlap the center so the union fills solid.
-// Drawn plain in the accent ink, no tile behind it — the mark is the brand.
+// Drawn plain in the graphite ink, no tile behind it — the mark is the brand.
 const ARM_ANGLES = [0, 60, 180, 240, 300]
 
 export default function Brand() {
   return (
-    <div className="grid h-10 w-10 flex-none place-items-center text-accent" title="Swifty">
-      <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" aria-label="Swifty">
+    <div className="grid h-10 w-10 flex-none place-items-center text-text" title="Swifty">
+      <svg width="30" height="30" viewBox="0 0 24 24" fill="currentColor" aria-label="Swifty">
         {ARM_ANGLES.map(angle => (
           <rect
             key={angle}

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -1,10 +1,10 @@
-import logo from '@/assets/images/swifty.png'
-
 // Single-vault app: the rail top is just a brand mark (no vault switcher).
+// The mark is a monoline "S" swept from two arcs with a slight forward slant —
+// same stroke language as the lucide glyphs, so it reads as part of the set.
 export default function Brand() {
   return (
     <div
-      className="grid h-9 w-9 flex-none place-items-center overflow-hidden rounded-lg"
+      className="grid h-10 w-10 flex-none place-items-center rounded-lg"
       style={{
         background:
           'linear-gradient(150deg, var(--c-accent), var(--c-accent-deep))',
@@ -12,7 +12,15 @@ export default function Brand() {
       }}
       title="Swifty"
     >
-      <img src={logo} alt="Swifty" className="h-6 w-6 object-contain" />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-label="Swifty">
+        <path
+          d="M15.3 8.7 A3.3 3.3 0 1 0 12 12 A3.3 3.3 0 1 1 8.7 15.3"
+          stroke="#fff"
+          strokeWidth="2"
+          strokeLinecap="round"
+          transform="rotate(-10 12 12)"
+        />
+      </svg>
     </div>
   )
 }

--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -1,6 +1,12 @@
 // Single-vault app: the rail top is just a brand mark (no vault switcher).
-// The mark is a monoline "S" swept from two arcs with a slight forward slant —
-// same stroke language as the lucide glyphs, so it reads as part of the set.
+//
+// The mark is "Reveal": a masked-password asterisk with one arm detached as a
+// dot — the one secret in your hand. The asterisk is the native symbol of a
+// secrets app (it's what a masked password looks like), and the dot seeds the
+// lock-screen mascot's eye. Five stadium arms at 60° plus the dot where the
+// sixth would be; arms overlap the center so the union fills solid.
+const ARM_ANGLES = [0, 60, 180, 240, 300]
+
 export default function Brand() {
   return (
     <div
@@ -12,14 +18,19 @@ export default function Brand() {
       }}
       title="Swifty"
     >
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-label="Swifty">
-        <path
-          d="M15.3 8.7 A3.3 3.3 0 1 0 12 12 A3.3 3.3 0 1 1 8.7 15.3"
-          stroke="#fff"
-          strokeWidth="2"
-          strokeLinecap="round"
-          transform="rotate(-10 12 12)"
-        />
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="#fff" aria-label="Swifty">
+        {ARM_ANGLES.map(angle => (
+          <rect
+            key={angle}
+            x="10.4"
+            y="3.4"
+            width="3.2"
+            height="9.6"
+            rx="1.6"
+            transform={`rotate(${angle} 12 12)`}
+          />
+        ))}
+        <circle cx="18.06" cy="15.5" r="2.1" />
       </svg>
     </div>
   )

--- a/src/components/Main/Sidebar/Settings/index.tsx
+++ b/src/components/Main/Sidebar/Settings/index.tsx
@@ -23,11 +23,11 @@ export default function Settings() {
     <div className="settings">
       <Tooltip content={t('Settings')}>
         <div
-          className="settings-button grid h-9 w-9 cursor-pointer place-items-center rounded-lg text-text2 transition-colors hover:bg-hover hover:text-text"
+          className="settings-button grid h-10 w-10 cursor-pointer place-items-center rounded-lg text-text2 transition-colors hover:bg-hover hover:text-text"
           data-testid="settings-button"
           onClick={() => (modal ? closeSettings() : openSettings())}
         >
-          <GearGlyph />
+          <GearGlyph size={18} />
         </div>
       </Tooltip>
       {modal && (

--- a/src/components/Main/Sidebar/Switcher.tsx
+++ b/src/components/Main/Sidebar/Switcher.tsx
@@ -17,7 +17,7 @@ export default function Switcher() {
   const scope = useStore(state => state.filters.scope)
 
   return (
-    <div className="switcher flex flex-col items-center gap-[3px]">
+    <div className="switcher flex flex-col items-center gap-2">
       {scopes.map(({ scope: current, label, Icon }) => {
         const selected = scope === current
         return (
@@ -26,7 +26,7 @@ export default function Switcher() {
               className={cx(
                 'item relative grid h-10 w-10 cursor-pointer place-items-center rounded-lg transition-colors',
                 selected
-                  ? 'current bg-accent-soft text-accent'
+                  ? 'current bg-tile text-text'
                   : 'text-text2 hover:bg-hover hover:text-text'
               )}
               onClick={() => setFilterScope(current)}

--- a/src/components/Main/Sidebar/Switcher.tsx
+++ b/src/components/Main/Sidebar/Switcher.tsx
@@ -24,7 +24,7 @@ export default function Switcher() {
           <Tooltip content={t(label)} key={current}>
             <div
               className={cx(
-                'item relative grid h-9 w-9 cursor-pointer place-items-center rounded-lg transition-colors',
+                'item relative grid h-10 w-10 cursor-pointer place-items-center rounded-lg transition-colors',
                 selected
                   ? 'current bg-accent-soft text-accent'
                   : 'text-text2 hover:bg-hover hover:text-text'
@@ -32,9 +32,9 @@ export default function Switcher() {
               onClick={() => setFilterScope(current)}
             >
               {selected && (
-                <span className="absolute -left-2.5 top-2.5 h-4 w-0.5 rounded-full bg-accent" />
+                <span className="absolute -left-3.5 top-3 h-4 w-0.5 rounded-full bg-accent" />
               )}
-              <Icon />
+              <Icon size={18} />
             </div>
           </Tooltip>
         )

--- a/src/components/Main/Sidebar/VaultHealth.tsx
+++ b/src/components/Main/Sidebar/VaultHealth.tsx
@@ -42,13 +42,13 @@ export default function VaultHealth() {
       <div
         onClick={() => setFilterScope('audit')}
         className={cx(
-          'grid h-9 w-9 cursor-pointer place-items-center rounded-lg transition-colors',
+          'grid h-10 w-10 cursor-pointer place-items-center rounded-lg transition-colors',
           selected
             ? 'bg-accent-soft text-accent'
             : 'text-text2 hover:bg-hover hover:text-text'
         )}
       >
-        <svg width="28" height="28" viewBox="0 0 36 36" fill="none">
+        <svg width="30" height="30" viewBox="0 0 36 36" fill="none">
           <circle cx="18" cy="18" r={RADIUS} stroke="var(--c-line2)" strokeWidth="2.5" />
           {score !== null && (
             <circle

--- a/src/components/Main/Sidebar/VaultHealth.tsx
+++ b/src/components/Main/Sidebar/VaultHealth.tsx
@@ -44,7 +44,7 @@ export default function VaultHealth() {
         className={cx(
           'grid h-10 w-10 cursor-pointer place-items-center rounded-lg transition-colors',
           selected
-            ? 'bg-accent-soft text-accent'
+            ? 'bg-tile text-text'
             : 'text-text2 hover:bg-hover hover:text-text'
         )}
       >

--- a/src/components/Main/Sidebar/index.tsx
+++ b/src/components/Main/Sidebar/index.tsx
@@ -5,7 +5,8 @@ import VaultHealth from './VaultHealth'
 import Settings from './Settings'
 
 // The 68px icon rail: brand mark · new-secret · scope filters · spacer ·
-// vault-health · settings.
+// vault-health · settings. Rail tiles are 40px with 18px glyphs — one step up
+// from the in-pane tiers so the rail reads as primary navigation.
 export default function Sidebar() {
   return (
     <nav className="flex w-[68px] flex-none flex-col items-center gap-[3px] border-r border-line bg-rail py-3">

--- a/src/components/Main/Sidebar/index.tsx
+++ b/src/components/Main/Sidebar/index.tsx
@@ -9,7 +9,7 @@ import Settings from './Settings'
 // from the in-pane tiers so the rail reads as primary navigation.
 export default function Sidebar() {
   return (
-    <nav className="flex w-[68px] flex-none flex-col items-center gap-[3px] border-r border-line bg-rail py-3">
+    <nav className="flex w-[68px] flex-none flex-col items-center gap-2 border-r border-line bg-rail py-3">
       <Brand />
       <div className="my-2 h-px w-6 bg-line2" />
       <Add />

--- a/src/components/Main/scope.ts
+++ b/src/components/Main/scope.ts
@@ -1,8 +1,8 @@
 import { t } from '@/i18n'
 import type { Scope } from '@/store/filtersSlice'
 
-// The list-column header shows a mono eyebrow + large title per scope. Kept
-// here so the rail, list header, and any future scope-aware chrome stay in sync.
+// The list-column header shows a large title per scope. Kept here so the
+// rail, list header, and any future scope-aware chrome stay in sync.
 export const scopeTitle = (scope: Scope): string => {
   switch (scope) {
     case 'note':
@@ -15,6 +15,3 @@ export const scopeTitle = (scope: Scope): string => {
       return t('Logins')
   }
 }
-
-export const scopeEyebrow = (scope: Scope): string =>
-  scope === 'audit' ? t('Security') : t('Vault')

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -228,7 +228,7 @@
   --c-detail: #ffffff;
   --c-field: #fafafb;
   --c-tile: rgba(20, 22, 26, 0.065);
-  --c-line: rgba(20, 22, 26, 0.11);
+  --c-line: rgba(20, 22, 26, 0.075);
   --c-line2: rgba(20, 22, 26, 0.19);
   --c-hover: rgba(20, 22, 26, 0.045);
   --c-sel: rgba(59, 91, 219, 0.09);
@@ -264,7 +264,7 @@
   --c-detail: #1b1c1e;
   --c-field: rgba(255, 255, 255, 0.03);
   --c-tile: rgba(255, 255, 255, 0.06);
-  --c-line: rgba(255, 255, 255, 0.07);
+  --c-line: rgba(255, 255, 255, 0.05);
   --c-line2: rgba(255, 255, 255, 0.12);
   --c-hover: rgba(255, 255, 255, 0.045);
   --c-sel: rgba(255, 255, 255, 0.06);

--- a/src/test/list.test.tsx
+++ b/src/test/list.test.tsx
@@ -38,14 +38,12 @@ beforeEach(() => {
 afterEach(() => vi.useRealTimers())
 
 describe('Entry list', () => {
-  it('groups by recency, newest first, skipping empty buckets', () => {
+  it('lists newest first as a flat list, no date headers', () => {
     renderWithStore(<ListColumn />, { store: seed() })
 
-    expect(screen.getByText('Today')).toBeInTheDocument()
-    expect(screen.getByText('Yesterday')).toBeInTheDocument()
-    expect(screen.getByText('This week')).toBeInTheDocument()
-    expect(screen.getByText('Earlier')).toBeInTheDocument()
     expect(titles()).toEqual(['Zebra', 'Airbnb', 'Monzo', 'Basecamp'])
+    expect(screen.queryByText('Today')).not.toBeInTheDocument()
+    expect(screen.queryByText('Earlier')).not.toBeInTheDocument()
   })
 
   it('shows a relative time on every row', () => {
@@ -68,13 +66,12 @@ describe('Entry list', () => {
     expect(screen.getAllByTestId('entry-item')).toHaveLength(4)
   })
 
-  it('sorts alphabetically without group headers', async () => {
+  it('sorts alphabetically', async () => {
     renderWithStore(<ListColumn />, { store: seed() })
 
     await userEvent.click(screen.getByTestId('sort-menu'))
     await userEvent.click(screen.getByText('Alphabetical'))
 
     expect(titles()).toEqual(['Airbnb', 'Basecamp', 'Monzo', 'Zebra'])
-    expect(screen.queryByText('Today')).not.toBeInTheDocument()
   })
 })

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { relativeTime, recencyBucket, toTime } from './time'
+import { relativeTime, toTime } from './time'
 
 // A fixed "now" so every case is deterministic: 2024-03-14, midday local time.
 const now = new Date(2024, 2, 14, 12, 0, 0).getTime()
@@ -35,24 +35,6 @@ describe('relativeTime', () => {
 
   it('keeps the year on dates outside the current one', () => {
     expect(relativeTime(new Date(2023, 0, 12, 9).toISOString(), now)).toBe('Jan 12, 2023')
-  })
-})
-
-describe('recencyBucket', () => {
-  it('buckets by calendar day', () => {
-    expect(recencyBucket(new Date(2024, 2, 14, 1).toISOString(), now)).toBe('Today')
-    expect(recencyBucket(new Date(2024, 2, 13, 23).toISOString(), now)).toBe('Yesterday')
-    expect(recencyBucket(new Date(2024, 2, 10, 12).toISOString(), now)).toBe('This week')
-    expect(recencyBucket(new Date(2024, 1, 20, 12).toISOString(), now)).toBe('Earlier')
-  })
-
-  it('treats an hour-old entry from yesterday as Yesterday', () => {
-    // 13h ago is still the previous calendar day, not a rolling 24h window.
-    expect(recencyBucket(ago(13 * HOUR), now)).toBe('Yesterday')
-  })
-
-  it('sends undated entries to Earlier', () => {
-    expect(recencyBucket(undefined, now)).toBe('Earlier')
   })
 })
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -36,26 +36,3 @@ const shortDate = (at: number, now: number): string => {
     ...(sameYear ? {} : { year: 'numeric' })
   })
 }
-
-export type Recency = 'Today' | 'Yesterday' | 'This week' | 'Earlier'
-
-export const RECENCY: Recency[] = ['Today', 'Yesterday', 'This week', 'Earlier']
-
-// Calendar-day buckets (not rolling 24h windows), so "Yesterday" means the
-// previous day on the clock. Anything undated falls to the bottom bucket.
-export const recencyBucket = (iso?: string, now: number = Date.now()): Recency => {
-  const at = toTime(iso)
-  if (at === null) return 'Earlier'
-
-  const days = Math.round((startOfDay(now) - startOfDay(at)) / DAY)
-  if (days <= 0) return 'Today'
-  if (days === 1) return 'Yesterday'
-  if (days < 7) return 'This week'
-  return 'Earlier'
-}
-
-const startOfDay = (ms: number): number => {
-  const date = new Date(ms)
-  date.setHours(0, 0, 0, 0)
-  return date.getTime()
-}


### PR DESCRIPTION
Four visual refinements from live testing:

## Rail reads as navigation
Rail tiles go 36 → 40px with 18px glyphs — a documented one-step-up icon tier for the rail only (in-pane tiers stay 14/16). Applies to Add, the three scope filters, Vault Health (dial 28 → 30) and Settings. The selected-scope indicator bar moves to hug the rail edge.

## Detail metadata recedes
The Type / Last Modified / Created ledger is reference metadata, not content: card fill removed (hairline border only), values drop to xs mono, padding tightened. It no longer competes with the title and secret fields.

## Detail column is stable
`Show`'s root is a flex-column child, so `mx-auto` alone gave it shrink-to-fit width — the column changed width per entry. Now `w-full max-w-[860px]`: always full width up to the cap.

## New brand mark
Replaces the PNG with an inline SVG: a monoline "S" swept from two arcs with round caps and a slight forward slant (the "swift" motion), white on the existing accent gradient. Same stroke language as the lucide set, so the mark reads as part of the system. Tile aligned to the new 40px rail grid.

## Verification
- 128/128 tests, tsc clean, eslint --max-warnings 0
- Visual: rail tiles/indicator, ledger weight, column width across entries of different content widths, mark at 1x/2x