### PR TITLE
Site favicons as entry identity (list rows + detail header)

### DIFF
--- a/src-tauri/src/favicon.rs
+++ b/src-tauri/src/favicon.rs
@@ -237,7 +237,10 @@ mod tests {
             <LINK REL="apple-touch-icon" HREF="/touch.png">
             <link rel="shortcut icon" href=favicon.ico >
         </head>"#;
-        assert_eq!(icon_hrefs(html), vec!["/touch.png", "/Icon-32.png", "favicon.ico"]);
+        assert_eq!(
+            icon_hrefs(html),
+            vec!["/touch.png", "/Icon-32.png", "favicon.ico"]
+        );
     }
 
     #[test]
@@ -250,6 +253,9 @@ mod tests {
     fn attr_values_keep_their_case() {
         let tag = r#"<link rel="icon" href="/CaseSensitive.PNG""#;
         let lower = tag.to_ascii_lowercase();
-        assert_eq!(attr_value(tag, &lower, "href").as_deref(), Some("/CaseSensitive.PNG"));
+        assert_eq!(
+            attr_value(tag, &lower, "href").as_deref(),
+            Some("/CaseSensitive.PNG")
+        );
     }
 }

--- a/src-tauri/src/favicon.rs
+++ b/src-tauri/src/favicon.rs
@@ -1,0 +1,255 @@
+//! Website favicon fetch + on-disk cache, for list-row identity.
+//!
+//! Privacy: icons are fetched directly from the host an entry already points
+//! at — never through a third-party favicon service — so the vault's host
+//! list is not shipped anywhere new. Misses are cached with a TTL so offline
+//! launches and dead hosts don't retry on every run.
+//!
+//! The result crosses IPC as a `data:` URI, which keeps the webview CSP's
+//! `img-src 'self' data:` intact. Remote SVG is refused outright — an SVG is
+//! a script container, not an image.
+
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use reqwest::Client;
+use tauri::AppHandle;
+use url::Url;
+
+use crate::error::Result;
+use crate::storage;
+
+const MAX_ICON_BYTES: usize = 256 * 1024;
+const MAX_HTML_BYTES: usize = 512 * 1024;
+const MISS_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const TIMEOUT: Duration = Duration::from_secs(8);
+const USER_AGENT: &str = "Swifty-Password-Manager";
+
+// Raster only (see module docs). Octet-stream is deliberately absent: an icon
+// we can't type is an icon we don't render.
+const SAFE_TYPES: [&str; 6] = [
+    "image/png",
+    "image/x-icon",
+    "image/vnd.microsoft.icon",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+];
+
+// The favicon for `host` as a data: URI, or None when it has none. Disk-cached
+// both ways; safe to call before unlock (touches no vault state).
+#[tauri::command]
+pub async fn fetch_favicon(app: AppHandle, host: String) -> Result<Option<String>> {
+    let Some(host) = safe_host(&host) else {
+        return Ok(None);
+    };
+    let dir = storage::icons_dir(&app)?;
+    fs::create_dir_all(&dir)?;
+
+    let hit = dir.join(format!("{host}.uri"));
+    if let Ok(uri) = fs::read_to_string(&hit) {
+        return Ok(Some(uri));
+    }
+    let miss = dir.join(format!("{host}.miss"));
+    if fresh_miss(&miss) {
+        return Ok(None);
+    }
+
+    match lookup(&host).await {
+        Some(uri) => {
+            let _ = fs::write(&hit, &uri);
+            let _ = fs::remove_file(&miss);
+            Ok(Some(uri))
+        }
+        None => {
+            let _ = fs::write(&miss, b"");
+            Ok(None)
+        }
+    }
+}
+
+// Hostnames double as cache file names, so reject anything that isn't a plain
+// DNS name (no slashes, no traversal, no URL metacharacters).
+fn safe_host(host: &str) -> Option<String> {
+    let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+    let ok = !host.is_empty()
+        && host.len() <= 253
+        && host.contains('.')
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-');
+    ok.then_some(host)
+}
+
+fn fresh_miss(path: &Path) -> bool {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|at| at.elapsed().ok())
+        .is_some_and(|age| age < MISS_TTL)
+}
+
+// Declared icons from the homepage <head> first (usually crisp PNGs), then
+// the conventional /favicon.ico as the fallback.
+async fn lookup(host: &str) -> Option<String> {
+    let client = crate::sync::http_client();
+    let root = Url::parse(&format!("https://{host}/")).ok()?;
+
+    if let Some(html) = fetch_html(&client, root.clone()).await {
+        for href in icon_hrefs(&html) {
+            let Ok(url) = root.join(&href) else { continue };
+            if !matches!(url.scheme(), "http" | "https") {
+                continue;
+            }
+            if let Some(uri) = fetch_icon(&client, url).await {
+                return Some(uri);
+            }
+        }
+    }
+
+    fetch_icon(&client, root.join("favicon.ico").ok()?).await
+}
+
+async fn fetch_icon(client: &Client, url: Url) -> Option<String> {
+    let resp = client
+        .get(url)
+        .timeout(TIMEOUT)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let mime = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .next()?
+        .trim()
+        .to_ascii_lowercase();
+    if !SAFE_TYPES.contains(&mime.as_str()) {
+        return None;
+    }
+    if resp
+        .content_length()
+        .is_some_and(|len| len as usize > MAX_ICON_BYTES)
+    {
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.is_empty() || bytes.len() > MAX_ICON_BYTES {
+        return None;
+    }
+    Some(format!("data:{mime};base64,{}", B64.encode(&bytes)))
+}
+
+async fn fetch_html(client: &Client, url: Url) -> Option<String> {
+    let resp = client
+        .get(url)
+        .timeout(TIMEOUT)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let bytes = resp.bytes().await.ok()?;
+    let cut = bytes.len().min(MAX_HTML_BYTES);
+    Some(String::from_utf8_lossy(&bytes[..cut]).into_owned())
+}
+
+// hrefs of <link> tags whose rel mentions "icon" ("icon", "shortcut icon",
+// "apple-touch-icon"), in document order with apple-touch (largest art)
+// hoisted first. A tolerant ASCII scan, not an HTML parser — good enough for
+// <head> markup in the wild, and every candidate is still mime-checked.
+fn icon_hrefs(html: &str) -> Vec<String> {
+    let lower = html.to_ascii_lowercase(); // ASCII transform: byte offsets align
+    let mut ranked: Vec<(u8, String)> = Vec::new();
+    let mut at = 0;
+    while let Some(found) = lower[at..].find("<link") {
+        let start = at + found;
+        let Some(len) = lower[start..].find('>') else {
+            break;
+        };
+        let end = start + len;
+        let (tag, tag_lower) = (&html[start..end], &lower[start..end]);
+        at = end + 1;
+
+        let rel = attr_value(tag_lower, tag_lower, "rel").unwrap_or_default();
+        if !rel.split_whitespace().any(|word| word.contains("icon")) {
+            continue;
+        }
+        if let Some(href) = attr_value(tag, tag_lower, "href") {
+            let rank = u8::from(!rel.contains("apple-touch"));
+            ranked.push((rank, href));
+        }
+    }
+    ranked.sort_by_key(|(rank, _)| *rank);
+    ranked.into_iter().map(|(_, href)| href).collect()
+}
+
+// The value of `name="..."` in a tag. Matched case-insensitively against
+// `tag_lower`; the value is sliced out of `tag` so its case survives.
+fn attr_value(tag: &str, tag_lower: &str, name: &str) -> Option<String> {
+    let needle = format!("{name}=");
+    let value_at = tag_lower.find(&needle)? + needle.len();
+    let rest = &tag[value_at..];
+    let (rest, quote) = match rest.chars().next()? {
+        q @ ('"' | '\'') => (&rest[1..], Some(q)),
+        _ => (rest, None),
+    };
+    let end = match quote {
+        Some(q) => rest.find(q)?,
+        None => rest
+            .find(|c: char| c.is_whitespace() || c == '>')
+            .unwrap_or(rest.len()),
+    };
+    let value = rest[..end].trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_plain_hosts_and_rejects_everything_else() {
+        assert_eq!(safe_host("Mail.Google.com"), Some("mail.google.com".into()));
+        assert_eq!(safe_host("github.com."), Some("github.com".into()));
+        assert_eq!(safe_host("localhost"), None); // no dot
+        assert_eq!(safe_host("evil.com/../../vault"), None);
+        assert_eq!(safe_host("host with space.com"), None);
+        assert_eq!(safe_host(""), None);
+    }
+
+    #[test]
+    fn finds_declared_icons_apple_touch_first() {
+        let html = r#"<head>
+            <link rel="stylesheet" href="/app.css">
+            <link rel="icon" type="image/png" href="/Icon-32.png">
+            <LINK REL="apple-touch-icon" HREF="/touch.png">
+            <link rel="shortcut icon" href=favicon.ico >
+        </head>"#;
+        assert_eq!(icon_hrefs(html), vec!["/touch.png", "/Icon-32.png", "favicon.ico"]);
+    }
+
+    #[test]
+    fn ignores_links_without_icon_rel_or_href() {
+        let html = r#"<link rel="preload" href="/x.woff2"><link rel="icon">"#;
+        assert!(icon_hrefs(html).is_empty());
+    }
+
+    #[test]
+    fn attr_values_keep_their_case() {
+        let tag = r#"<link rel="icon" href="/CaseSensitive.PNG""#;
+        let lower = tag.to_ascii_lowercase();
+        assert_eq!(attr_value(tag, &lower, "href").as_deref(), Some("/CaseSensitive.PNG"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod biometrics;
 mod commands;
 pub mod crypto;
 mod error;
+mod favicon;
 mod hibp;
 mod import;
 mod models;
@@ -85,6 +86,7 @@ pub fn run() {
             commands::generator::generate_otp,
             commands::generator::verify_otp,
             commands::audit::get_audit,
+            favicon::fetch_favicon,
             commands::clipboard::copy_to_clipboard,
             commands::sync::sync_connect,
             commands::sync::sync_disconnect,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -57,6 +57,11 @@ pub fn db_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(DB_FILE))
 }
 
+// Cached website favicons (list-row identity). Safe to wipe; refetched lazily.
+pub fn icons_dir(app: &AppHandle) -> Result<PathBuf> {
+    Ok(app_dir(app)?.join("icons"))
+}
+
 // Sibling recovery snapshot of the DB (change-master-password rollback point).
 pub fn db_rekey_backup_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(DB_REKEY_BACKUP_FILE))

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -54,14 +54,6 @@ export default function Show({ entry }: Props) {
     <div className="mx-auto w-full max-w-[860px]">
 
       <div className="flex items-start gap-4">
-        {/* Same identity tile as the list row, one size up. */}
-        <div className="grid h-11 w-11 flex-none place-items-center self-center overflow-hidden rounded-lg bg-tile text-text2">
-          {icon ? (
-            <img src={icon} alt="" className="h-full w-full object-cover" />
-          ) : (
-            <Glyph size={20} />
-          )}
-        </div>
         <div className="min-w-0 flex-1">
           <div className={`flex items-center gap-2 whitespace-nowrap ${MONO_LABEL}`}>
             <span className="text-text2">{t(KIND_LABEL[entry.type])}</span>
@@ -72,9 +64,19 @@ export default function Show({ entry }: Props) {
               </>
             )}
           </div>
-          <h1 className="mt-2 text-2xl font-semibold tracking-display text-text">
-            {entry.title}
-          </h1>
+          <div className="mt-2 flex items-center gap-2.5">
+            {/* Same identity tile as the list row, sized to the title line. */}
+            <div className="grid h-7 w-7 flex-none place-items-center overflow-hidden rounded-lg bg-tile text-text2">
+              {icon ? (
+                <img src={icon} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <Glyph size={16} />
+              )}
+            </div>
+            <h1 className="truncate text-2xl font-semibold tracking-display text-text">
+              {entry.title}
+            </h1>
+          </div>
         </div>
         <Actions type={entry.type} revealed={revealed} onDelete={onDelete} />
       </div>

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react'
 import { deleteEntry } from '@/store'
 import type { EntryMeta } from '@/lib/commands'
 import { useRevealed } from '@/hooks/useRevealed'
+import { useFavicon } from '@/hooks/useFavicon'
 import { t } from '@/i18n'
+import { LoginGlyph, NoteGlyph, CardGlyph } from '../../../icons'
 import Details from './Details'
 import Actions from './Actions'
 import { MONO_LABEL } from '../ui'
@@ -17,11 +19,19 @@ const KIND_LABEL: Record<EntryMeta['type'], string> = {
   note: 'Secure note'
 }
 
+const KIND_GLYPH: Record<EntryMeta['type'], typeof LoginGlyph> = {
+  login: LoginGlyph,
+  card: CardGlyph,
+  note: NoteGlyph
+}
+
 const formatDate = (value?: string) =>
   value ? new Date(value).toLocaleString() : '—'
 
 export default function Show({ entry }: Props) {
   const revealed = useRevealed(entry)
+  const icon = useFavicon(entry.urlHost)
+  const Glyph = KIND_GLYPH[entry.type]
   const [deleteError, setDeleteError] = useState<string | null>(null)
 
   // Confirmation is inline in the more-menu (two-press pattern, like the
@@ -44,6 +54,14 @@ export default function Show({ entry }: Props) {
     <div className="mx-auto w-full max-w-[860px]">
 
       <div className="flex items-start gap-4">
+        {/* Same identity tile as the list row, one size up. */}
+        <div className="grid h-11 w-11 flex-none place-items-center self-center overflow-hidden rounded-lg bg-tile text-text2">
+          {icon ? (
+            <img src={icon} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <Glyph size={20} />
+          )}
+        </div>
         <div className="min-w-0 flex-1">
           <div className={`flex items-center gap-2 whitespace-nowrap ${MONO_LABEL}`}>
             <span className="text-text2">{t(KIND_LABEL[entry.type])}</span>

--- a/src/components/Main/Body/List/Item/Login.tsx
+++ b/src/components/Main/Body/List/Item/Login.tsx
@@ -1,8 +1,19 @@
 import { LoginGlyph } from '@/components/Main/icons'
+import { useFavicon } from '@/hooks/useFavicon'
 import Row, { type ContentProps } from './Row'
 
+// A login row leads with the site's own favicon when one exists — real
+// identity beats a generic globe. The glyph stands in while it loads or when
+// the host has none.
 export default function Login({ entry, flag }: ContentProps) {
+  const icon = useFavicon(entry.urlHost)
+
   return (
-    <Row glyph={<LoginGlyph size={16} />} title={entry.title} sub={entry.urlHost} flag={flag} />
+    <Row
+      glyph={icon ? <img src={icon} alt="" className="h-4 w-4" /> : <LoginGlyph size={16} />}
+      title={entry.title}
+      sub={entry.urlHost}
+      flag={flag}
+    />
   )
 }

--- a/src/components/Main/Body/List/Item/Login.tsx
+++ b/src/components/Main/Body/List/Item/Login.tsx
@@ -10,7 +10,7 @@ export default function Login({ entry, flag }: ContentProps) {
 
   return (
     <Row
-      glyph={icon ? <img src={icon} alt="" className="h-4 w-4" /> : <LoginGlyph size={16} />}
+      glyph={icon ? <img src={icon} alt="" className="h-full w-full object-cover" /> : <LoginGlyph size={16} />}
       title={entry.title}
       sub={entry.urlHost}
       flag={flag}

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -22,7 +22,7 @@ interface Props {
 export default function Row({ glyph, title, sub, flag }: Props) {
   return (
     <>
-      <div className="grid h-[30px] w-[30px] flex-none place-items-center rounded-lg bg-tile text-text2">
+      <div className="grid h-[30px] w-[30px] flex-none place-items-center overflow-hidden rounded-lg bg-tile text-text2">
         {glyph}
       </div>
       <div className="min-w-0 flex-1">

--- a/src/hooks/useFavicon.ts
+++ b/src/hooks/useFavicon.ts
@@ -1,0 +1,45 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import { fetchFavicon } from '@/lib/commands'
+
+// Favicons for list rows: one backend call per host per session (the backend
+// caches on disk), fanned out to every row showing that host. Returns the
+// data: URI, or null while loading / after a miss — callers fall back to the
+// type glyph either way.
+const cache = new Map<string, string | null>()
+const pending = new Set<string>()
+const listeners = new Set<() => void>()
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+const lookup = (host: string) => {
+  if (cache.has(host) || pending.has(host)) return
+  pending.add(host)
+  fetchFavicon(host)
+    .catch(() => null)
+    .then(uri => {
+      cache.set(host, uri ?? null)
+      pending.delete(host)
+      listeners.forEach(listener => listener())
+    })
+}
+
+export function useFavicon(host?: string): string | null {
+  const icon = useSyncExternalStore(subscribe, () =>
+    host ? (cache.get(host) ?? null) : null
+  )
+  useEffect(() => {
+    if (host) lookup(host)
+  }, [host])
+  return icon
+}
+
+// Test seam: the cache is module-level so it outlives per-test stores.
+export const resetFavicons = () => {
+  cache.clear()
+  pending.clear()
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -255,6 +255,16 @@ export const getAudit = (checkBreaches: boolean): Promise<Audit> =>
   invoke('get_audit', { checkBreaches })
 
 // ---------------------------------------------------------------------------
+// Favicons
+// ---------------------------------------------------------------------------
+
+// The site's favicon as a data: URI, or null when it has none. The backend
+// fetches straight from the entry's own host (never a third-party favicon
+// service) and caches on disk, so repeat calls are a file read.
+export const fetchFavicon = (host: string): Promise<string | null> =>
+  invoke('fetch_favicon', { host })
+
+// ---------------------------------------------------------------------------
 // Clipboard
 // ---------------------------------------------------------------------------
 

--- a/src/test/list.test.tsx
+++ b/src/test/list.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ListColumn from '@/components/Main/Body/ListColumn'
-import type { Audit } from '@/lib/commands'
+import { fetchFavicon, type Audit } from '@/lib/commands'
 import { makeStore, setSort } from '@/store'
+import { resetFavicons } from '@/hooks/useFavicon'
 import { renderWithStore, withEntries, loginMeta } from './utils'
 
 // A fixed clock (Date only, so userEvent's real timers keep working) makes the
@@ -33,6 +34,8 @@ beforeEach(() => {
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(NOW)
   setSort('recent')
+  resetFavicons()
+  vi.mocked(fetchFavicon).mockClear()
 })
 
 afterEach(() => vi.useRealTimers())
@@ -64,6 +67,26 @@ describe('Entry list', () => {
     expect(screen.getByText('reused')).toBeInTheDocument()
     // Only the two audited entries carry a chip.
     expect(screen.getAllByTestId('entry-item')).toHaveLength(4)
+  })
+
+  it('swaps the glyph for the site favicon once it resolves, one fetch per host', async () => {
+    const uri = 'data:image/png;base64,AAAA'
+    vi.mocked(fetchFavicon).mockResolvedValue(uri)
+    renderWithStore(<ListColumn />, { store: seed() })
+
+    await waitFor(() =>
+      expect(document.querySelectorAll(`img[src="${uri}"]`)).toHaveLength(4)
+    )
+    // All four rows share one host — the lookup is deduped across them.
+    expect(fetchFavicon).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the type glyph when the host has no favicon', async () => {
+    vi.mocked(fetchFavicon).mockResolvedValue(null)
+    renderWithStore(<ListColumn />, { store: seed() })
+
+    await waitFor(() => expect(fetchFavicon).toHaveBeenCalled())
+    expect(document.querySelector('img')).not.toBeInTheDocument()
   })
 
   it('sorts alphabetically', async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -32,6 +32,7 @@ vi.mock('@/lib/commands', () => ({
   generateOtp: vi.fn().mockResolvedValue({ code: '123456', time: 30 }),
   verifyOtp: vi.fn().mockResolvedValue(true),
   getAudit: vi.fn().mockResolvedValue({}),
+  fetchFavicon: vi.fn().mockResolvedValue(null),
   copyToClipboard: vi.fn().mockResolvedValue(undefined),
   syncConnect: vi.fn().mockResolvedValue(undefined),
   syncDisconnect: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Follow-up to #278 — these four commits landed on that branch after it merged, re-based here cleanly.

## What

Login entries now carry their site's real identity instead of a generic globe:
- **List rows**: the favicon fills the 30px `rounded-lg` tile edge to edge; the type glyph stands in while loading or on a miss.
- **Detail header**: the same icon repeats inline beside the h1 title, sized to the title line (28px tile); cards/notes get their type glyph there.

## How

- New Rust command `fetch_favicon(host)` (`src-tauri/src/favicon.rs`): parses the site homepage `<head>` for declared icons (apple-touch-icon first — the crisp large art), falls back to `/favicon.ico`. Disk cache under the dev-isolated data dir (`icons/<host>.uri`), 7-day negative cache for misses.
- **Privacy/hardening**: fetched direct from the entry's own host — never a third-party favicon service, so the vault's host list is not shipped anywhere new. Hostname sanitized before becoming a cache filename; raster mime-types only (remote SVG refused); 256KB cap; 8s timeout. Returned as a `data:` URI so the strict CSP (`img-src 'self' data:`) is untouched.
- `useFavicon(host)` hook with a module-level cache: one backend call per host per session, fanned out to every row and the detail header. Rendering never blocks on the network.

## Verification

- 127/127 vitest (new: favicon swap-in + one-fetch-per-host dedupe; glyph fallback on miss), 4 new Rust unit tests (host sanitizing, `<head>` icon scanning), cargo check / tsc / eslint clean.
- Visual: unlock, watch rows upgrade to real icons; detail header shows the same icon inline with the title; entries with dead hosts keep the glyph.