### PR TITLE
Card network marks (Visa/Mastercard/Maestro/Amex/Discover)

### DIFF
--- a/src-tauri/src/cards.rs
+++ b/src-tauri/src/cards.rs
@@ -1,0 +1,74 @@
+//! Card network detection from the leading digits (IIN/BIN ranges).
+//!
+//! The network is not a secret — every physical card wears its logo — so the
+//! derived slug lives in the plaintext metadata column, letting the list show
+//! brand marks without ever decrypting a payload. Mirrored in TypeScript at
+//! `src/utils/cardBrand.ts` for the revealed detail view; keep the two in sync.
+
+// Longest/most-specific ranges are tested before the broad ones (e.g. the
+// 2221–2720 Mastercard block before UnionPay's bare 62, Discover's 6011
+// before Maestro's 60x).
+pub fn card_brand(number: &str) -> Option<&'static str> {
+    let digits: String = number.chars().filter(|c| c.is_ascii_digit()).collect();
+    if digits.len() < 4 {
+        return None;
+    }
+    let p2: u32 = digits[..2].parse().ok()?;
+    let p3: u32 = digits[..3].parse().ok()?;
+    let p4: u32 = digits[..4].parse().ok()?;
+
+    let brand = if digits.starts_with('4') {
+        "visa"
+    } else if (51..=55).contains(&p2) || (2221..=2720).contains(&p4) {
+        "mastercard"
+    } else if p2 == 34 || p2 == 37 {
+        "amex"
+    } else if p4 == 6011 || p2 == 65 || (644..=649).contains(&p3) {
+        "discover"
+    } else if (3528..=3589).contains(&p4) {
+        "jcb"
+    } else if (300..=305).contains(&p3) || p2 == 36 || p2 == 38 || p2 == 39 {
+        "diners"
+    } else if p2 == 62 {
+        "unionpay"
+    } else if p2 == 50 || (56..=58).contains(&p2) || p2 == 67 || p2 == 63 {
+        "maestro"
+    } else {
+        return None;
+    };
+    Some(brand)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_the_major_networks() {
+        assert_eq!(card_brand("4111 1111 1111 1111"), Some("visa"));
+        assert_eq!(card_brand("5500-0000-0000-0004"), Some("mastercard"));
+        assert_eq!(card_brand("2221000000000009"), Some("mastercard")); // 2-series
+        assert_eq!(card_brand("340000000000009"), Some("amex"));
+        assert_eq!(card_brand("370000000000002"), Some("amex"));
+        assert_eq!(card_brand("6011000000000004"), Some("discover"));
+        assert_eq!(card_brand("6759649826438453"), Some("maestro"));
+        assert_eq!(card_brand("3530111333300000"), Some("jcb"));
+        assert_eq!(card_brand("36700102000000"), Some("diners"));
+        assert_eq!(card_brand("6212345678901265"), Some("unionpay"));
+    }
+
+    #[test]
+    fn specific_ranges_win_over_broad_ones() {
+        // 6011 is Discover, not Maestro's 60x; 62 is UnionPay, not Maestro.
+        assert_eq!(card_brand("6011 0000"), Some("discover"));
+        assert_eq!(card_brand("6200 0000"), Some("unionpay"));
+    }
+
+    #[test]
+    fn unknown_or_short_input_is_none() {
+        assert_eq!(card_brand(""), None);
+        assert_eq!(card_brand("411"), None); // too short to trust
+        assert_eq!(card_brand("9999 9999"), None);
+        assert_eq!(card_brand("no digits"), None);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -39,8 +39,32 @@ pub fn derive_key(app: &AppHandle, password: &str) -> Result<VaultKey> {
 pub fn open_with_key(app: &AppHandle, key: &VaultKey) -> Result<(SqliteStore, Vec<EntryMetaDto>)> {
     let store = SqliteStore::open(&storage::db_path(app)?, &key.sqlcipher_key())
         .map_err(|_| Error::InvalidPassword)?;
+    backfill_card_brands(&store, key);
     let metas = list_metas(&store)?;
     Ok((store, metas))
+}
+
+// One-time derivation for cards saved before the card_brand column existed
+// (NULL there): unseal each once, store the slug ("none" when unrecognized),
+// and it's plain metadata from then on. Best-effort — a failure just leaves
+// the row NULL for the next unlock.
+fn backfill_card_brands(store: &SqliteStore, key: &VaultKey) {
+    let Ok(metas) = store.list() else { return };
+    let cipher = key.payload_cipher();
+    for meta in metas {
+        if meta.kind != "card" || meta.card_brand.is_some() {
+            continue;
+        }
+        let Ok(Some(record)) = store.get(&meta.id) else {
+            continue;
+        };
+        let Ok(entry) = cipher.unseal(&record.payload) else {
+            continue;
+        };
+        if let Some(brand) = crate::store::migrate::derived_card_brand(&entry) {
+            let _ = store.set_card_brand(&meta.id, &brand);
+        }
+    }
 }
 
 // Password unlock (run inside spawn_blocking): derive the key, then open + list.
@@ -96,6 +120,7 @@ pub fn meta_dto(m: &EntryMeta) -> EntryMetaDto {
         m.title.clone(),
         &m.tags,
         m.url_host.clone(),
+        m.card_brand.clone(),
         m.created_at,
         m.updated_at,
     )
@@ -109,6 +134,7 @@ pub fn record_meta_dto(r: &Record) -> EntryMetaDto {
         r.title.clone(),
         &r.tags,
         r.url_host.clone(),
+        r.card_brand.clone(),
         r.created_at,
         r.updated_at,
     )

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod autolock;
 mod biometrics;
+mod cards;
 mod commands;
 pub mod crypto;
 mod error;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -71,6 +71,9 @@ pub struct EntryMetaDto {
 
 impl EntryMetaDto {
     // Build from the shared metadata columns (timestamps are ms → RFC3339).
+    // One positional arg per DB column, mirrored by both callers — grouping
+    // them into a struct would just restate the column list a third time.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_parts(
         id: String,
         kind: String,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -63,6 +63,8 @@ pub struct EntryMetaDto {
     pub title: String,
     pub tags: Vec<String>,
     pub url_host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_brand: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -75,6 +77,7 @@ impl EntryMetaDto {
         title: String,
         tags: &str,
         url_host: String,
+        card_brand: Option<String>,
         created_at: i64,
         updated_at: i64,
     ) -> Self {
@@ -84,6 +87,8 @@ impl EntryMetaDto {
             title,
             tags: serde_json::from_str(tags).unwrap_or_default(),
             url_host,
+            // "none" marks a completed derivation with no match — internal only.
+            card_brand: card_brand.filter(|b| b != "none"),
             created_at: iso(created_at),
             updated_at: iso(updated_at),
         }

--- a/src-tauri/src/store/migrate.rs
+++ b/src-tauri/src/store/migrate.rs
@@ -21,6 +21,17 @@ pub fn build_record(entry: &Entry, payload: Vec<u8>) -> Result<Record> {
         updated_at: to_ms(&entry.updated_at),
         deleted_at: None,
         payload,
+        card_brand: derived_card_brand(entry),
+    })
+}
+
+// The stored slug for a card entry: its detected network, or "none" so a
+// completed derivation is distinguishable from a pre-column NULL.
+pub fn derived_card_brand(entry: &Entry) -> Option<String> {
+    (entry.kind == "card").then(|| {
+        crate::cards::card_brand(entry.number.as_deref().unwrap_or_default())
+            .unwrap_or("none")
+            .to_string()
     })
 }
 

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -47,6 +47,9 @@ pub struct Record {
     pub updated_at: i64,
     pub deleted_at: Option<i64>,
     pub payload: Vec<u8>,
+    /// Card network slug derived from the number at save time ("visa", …);
+    /// None for non-cards and for rows saved before the column existed.
+    pub card_brand: Option<String>,
 }
 
 /// A row's metadata without its payload (what listings need).
@@ -60,6 +63,7 @@ pub struct EntryMeta {
     pub created_at: i64,
     pub updated_at: i64,
     pub deleted_at: Option<i64>,
+    pub card_brand: Option<String>,
 }
 
 /// The swappable storage contract. Any backend behind this interface is a drop-in.

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -15,8 +15,9 @@ use super::{now_ms, EntryMeta, Record, Result, StoreError, VaultStore};
 // change (Phase 2 KDF columns, Phase 3 sync columns). The `meta` k/v table holds
 // APP data (KDF descriptor, biometric flag, settings), not schema versioning.
 fn migrations() -> Migrations<'static> {
-    Migrations::new(vec![M::up(
-        "CREATE TABLE meta (
+    Migrations::new(vec![
+        M::up(
+            "CREATE TABLE meta (
            key   TEXT PRIMARY KEY,
            value TEXT
          );
@@ -31,11 +32,19 @@ fn migrations() -> Migrations<'static> {
            deleted_at INTEGER,
            payload    BLOB
          );",
-    )])
+        ),
+        // Card network slug ("visa", …), derived from the number at save time
+        // so listings show brand marks without touching the payload. NULL =
+        // not yet derived (backfilled once on unlock).
+        M::up("ALTER TABLE entries ADD COLUMN card_brand TEXT;"),
+    ])
 }
 
-const COLS: &str = "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, payload";
-const META_COLS: &str = "id, kind, title, tags, url_host, created_at, updated_at, deleted_at";
+// card_brand is appended last so pre-existing column indexes stay put.
+const COLS: &str =
+    "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, payload, card_brand";
+const META_COLS: &str =
+    "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, card_brand";
 
 pub struct SqliteStore {
     conn: Mutex<Connection>,
@@ -119,6 +128,16 @@ impl SqliteStore {
             .execute_batch(&format!("PRAGMA rekey = \"x'{}'\";", hex(new_key)))?;
         Ok(())
     }
+
+    /// Set the derived card-network slug without stamping `updated_at` — it is
+    /// derived metadata, not a user edit (used by the one-time unlock backfill).
+    pub fn set_card_brand(&self, id: &str, brand: &str) -> Result<()> {
+        self.lock().execute(
+            "UPDATE entries SET card_brand = ?1 WHERE id = ?2",
+            params![brand, id],
+        )?;
+        Ok(())
+    }
 }
 
 impl VaultStore for SqliteStore {
@@ -161,11 +180,12 @@ impl VaultStore for SqliteStore {
         // created_at is set only on insert; updated_at is always stamped to now.
         self.lock().execute(
             &format!(
-                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
                  ON CONFLICT(id) DO UPDATE SET
                    kind=excluded.kind, title=excluded.title, tags=excluded.tags,
                    url_host=excluded.url_host, updated_at=excluded.updated_at,
-                   deleted_at=excluded.deleted_at, payload=excluded.payload"
+                   deleted_at=excluded.deleted_at, payload=excluded.payload,
+                   card_brand=excluded.card_brand"
             ),
             params![
                 rec.id,
@@ -181,6 +201,7 @@ impl VaultStore for SqliteStore {
                 now,
                 rec.deleted_at,
                 rec.payload,
+                rec.card_brand,
             ],
         )?;
         Ok(())
@@ -209,12 +230,12 @@ impl VaultStore for SqliteStore {
         {
             // Bulk sync-in: timestamps are preserved verbatim (no stamping).
             let mut stmt = tx.prepare(&format!(
-                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
                  ON CONFLICT(id) DO UPDATE SET
                    kind=excluded.kind, title=excluded.title, tags=excluded.tags,
                    url_host=excluded.url_host, created_at=excluded.created_at,
                    updated_at=excluded.updated_at, deleted_at=excluded.deleted_at,
-                   payload=excluded.payload"
+                   payload=excluded.payload, card_brand=excluded.card_brand"
             ))?;
             for r in recs {
                 stmt.execute(params![
@@ -227,6 +248,7 @@ impl VaultStore for SqliteStore {
                     r.updated_at,
                     r.deleted_at,
                     r.payload,
+                    r.card_brand,
                 ])?;
             }
         }
@@ -246,6 +268,7 @@ fn row_to_record(row: &Row) -> rusqlite::Result<Record> {
         updated_at: row.get(6)?,
         deleted_at: row.get(7)?,
         payload: row.get(8)?,
+        card_brand: row.get(9)?,
     })
 }
 
@@ -259,6 +282,7 @@ fn row_to_meta(row: &Row) -> rusqlite::Result<EntryMeta> {
         created_at: row.get(5)?,
         updated_at: row.get(6)?,
         deleted_at: row.get(7)?,
+        card_brand: row.get(8)?,
     })
 }
 

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -51,6 +51,7 @@ fn rec(id: &str, payload: &[u8]) -> Record {
         updated_at: 0,
         deleted_at: None,
         payload: payload.to_vec(),
+        card_brand: None,
     }
 }
 

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -17,6 +17,15 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 // (the 1Password pattern — no per-field buttons, so the face stays a card,
 // not a toolbar), with inline "Copied" feedback at the pointer. Copy always
 // copies the true value, masked or not. No value renders an inert dash.
+// "Copied" is an overlay chip, never a value swap — the face never reflows.
+function CopiedOverlay() {
+  return (
+    <span className="absolute inset-0 grid place-items-center rounded-sm bg-[#101216]/90 text-[10px] uppercase tracking-[0.12em] text-white">
+      {t('Copied')}
+    </span>
+  )
+}
+
 function Face({
   label,
   value,
@@ -34,7 +43,7 @@ function Face({
     <>
       <div className="text-[11px] uppercase tracking-[0.12em] opacity-50">{label}</div>
       <div className="mt-1 text-[13px]" data-testid={testid}>
-        {copied ? t('Copied') : copyValue ? value : '—'}
+        {copyValue ? value : '—'}
       </div>
     </>
   )
@@ -45,9 +54,10 @@ function Face({
       type="button"
       onClick={() => copy(copyValue)}
       title={t('Copy')}
-      className="cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
+      className="relative cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
     >
       {body}
+      {copied && <CopiedOverlay />}
     </button>
   )
 }
@@ -58,6 +68,7 @@ function Face({
 export default function Card({ entry }: Props) {
   const [show, setShow] = useState(false)
   const { copied: numberCopied, copy: copyNumber } = useCopied()
+  const { copied: nameCopied, copy: copyName } = useCopied()
   // Derived live from the revealed number (the list's stored slug isn't in
   // scope here, and this also tracks unsaved-but-revealed data correctly).
   const brand = cardBrandOf(entry.number)
@@ -77,10 +88,25 @@ export default function Card({ entry }: Props) {
           real card, so they are exempt from the type/radius/tracking scales. */}
       <div className="relative flex h-[288px] w-[460px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
         <div className="absolute -right-10 -top-16 h-[240px] w-[240px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
-        <div className="relative flex items-start">
-          <div className="flex-1 pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
-            {entry.name || t('Card')}
-          </div>
+        <div className="relative flex items-start justify-between gap-4">
+          {entry.name ? (
+            <button
+              type="button"
+              onClick={() => copyName(entry.name)}
+              title={t('Copy')}
+              className="relative -mx-1.5 -my-1 min-w-0 cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
+              data-testid="entry-value-name"
+            >
+              <span className="block truncate pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
+                {entry.name}
+              </span>
+              {nameCopied && <CopiedOverlay />}
+            </button>
+          ) : (
+            <div className="pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
+              {t('Card')}
+            </div>
+          )}
           {hasBrandMark(brand) ? (
             <CardBrandMark brand={brand} size={22} tone="light" />
           ) : (
@@ -93,10 +119,11 @@ export default function Card({ entry }: Props) {
             type="button"
             onClick={() => copyNumber(entry.number)}
             title={t('Copy')}
-            className="-mx-2 cursor-pointer self-start rounded-sm px-2 py-1 text-left text-[24px] tracking-[0.14em] transition-colors hover:bg-white/10"
+            className="relative -mx-2 cursor-pointer self-start rounded-sm px-2 py-1 text-left text-[24px] tracking-[0.14em] transition-colors hover:bg-white/10"
             data-testid="entry-value-number"
           >
-            {numberCopied ? t('Copied') : number}
+            {number}
+            {numberCopied && <CopiedOverlay />}
           </button>
         ) : (
           <div className="px-0 py-1 text-[24px] tracking-[0.14em] opacity-50">
@@ -105,12 +132,6 @@ export default function Card({ entry }: Props) {
         )}
         <div className="relative mt-5 flex items-end gap-5">
           <div className="-mx-1.5 flex min-w-0 flex-1 gap-3.5">
-            <Face
-              label={t('Holder')}
-              value={entry.name}
-              copyValue={entry.name || undefined}
-              testid="entry-value-name"
-            />
             <Face
               label={t('Expires')}
               value={expires}
@@ -123,13 +144,13 @@ export default function Card({ entry }: Props) {
               copyValue={entry.cvc || undefined}
               testid="entry-value-cvc"
             />
-            <Face
-              label={t('Pin')}
-              value={show ? entry.pin : '••••'}
-              copyValue={entry.pin || undefined}
-              testid="entry-value-pin"
-            />
           </div>
+          <Face
+            label={t('Pin')}
+            value={show ? entry.pin : '••••'}
+            copyValue={entry.pin || undefined}
+            testid="entry-value-pin"
+          />
           <button
             type="button"
             onClick={() => setShow(!show)}

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import type { CardEntry } from '@/lib/commands'
+import { cardBrandOf, hasBrandMark } from '@/utils/cardBrand'
+import CardBrandMark from '@/components/elements/CardBrandMark'
 import { t } from '@/i18n'
 import Item from './Item'
 import Tags from './Item/Tags'
@@ -14,6 +16,9 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 
 export default function Card({ entry }: Props) {
   const [show, setShow] = useState(false)
+  // Derived live from the revealed number (the list's stored slug isn't in
+  // scope here, and this also tracks unsaved-but-revealed data correctly).
+  const brand = cardBrandOf(entry.number)
 
   const number = entry.number
     ? show
@@ -36,7 +41,11 @@ export default function Card({ entry }: Props) {
             <div className="flex-1 font-mono text-[11px] uppercase tracking-[0.18em] opacity-60">
               {entry.name || t('Card')}
             </div>
-            <div className="h-6 w-[34px] rounded-[4px] border border-white/15 bg-white/10" />
+            {hasBrandMark(brand) ? (
+              <CardBrandMark brand={brand} size={20} tone="light" />
+            ) : (
+              <div className="h-6 w-[34px] rounded-[4px] border border-white/15 bg-white/10" />
+            )}
           </div>
           <div className="flex-1" />
           <div className="font-mono text-[20px] tracking-[0.16em]">{number}</div>

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -22,11 +22,12 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 // the app-level "Copied to Clipboard" toast already says what happened, so
 // the face just confirms *which* value, without a second wordy label. The
 // overlay never swaps the text out, so nothing reflows.
-// Same wash as the fields' hover state, so a click doesn't shift the ground —
-// only the check appears over the value.
+// Opaque version of the hover wash (white/10 composited over the card's dark
+// ground), so a click doesn't visibly shift the ground but the value is fully
+// hidden under the check — no text/icon overlap.
 function CopiedMark() {
   return (
-    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-white/10 text-white">
+    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-[#2B2D31] text-white">
       <CheckGlyph size={12} />
     </span>
   )

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -2,10 +2,9 @@ import { useState } from 'react'
 import type { CardEntry } from '@/lib/commands'
 import { cardBrandOf, hasBrandMark } from '@/utils/cardBrand'
 import CardBrandMark from '@/components/elements/CardBrandMark'
+import { useCopied } from '@/hooks/useCopied'
 import { t } from '@/i18n'
-import Item from './Item'
 import Tags from './Item/Tags'
-import { Panel, IconButton } from '../../ui'
 import { EyeGlyph, EyeOffGlyph } from '../../../../icons'
 
 interface Props {
@@ -14,8 +13,51 @@ interface Props {
 
 const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 
+// One data point on the card face. The whole field is a click-to-copy target
+// (the 1Password pattern — no per-field buttons, so the face stays a card,
+// not a toolbar), with inline "Copied" feedback at the pointer. Copy always
+// copies the true value, masked or not. No value renders an inert dash.
+function Face({
+  label,
+  value,
+  copyValue,
+  testid
+}: {
+  label: string
+  value: string
+  copyValue?: string
+  testid: string
+}) {
+  const { copied, copy } = useCopied()
+
+  const body = (
+    <>
+      <div className="text-[11px] uppercase tracking-[0.12em] opacity-50">{label}</div>
+      <div className="mt-1 text-[13px]" data-testid={testid}>
+        {copied ? t('Copied') : copyValue ? value : '—'}
+      </div>
+    </>
+  )
+  if (!copyValue) return <div className="px-1.5 py-1">{body}</div>
+
+  return (
+    <button
+      type="button"
+      onClick={() => copy(copyValue)}
+      title={t('Copy')}
+      className="cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
+    >
+      {body}
+    </button>
+  )
+}
+
+// The card IS the data surface: every value on it copies on click, and one
+// eye reveals number/CVC/PIN together (the Apple Card "show details" model) —
+// two interactions total, nothing else competing for attention.
 export default function Card({ entry }: Props) {
   const [show, setShow] = useState(false)
+  const { copied: numberCopied, copy: copyNumber } = useCopied()
   // Derived live from the revealed number (the list's stored slug isn't in
   // scope here, and this also tracks unsaved-but-revealed data correctly).
   const brand = cardBrandOf(entry.number)
@@ -24,67 +66,80 @@ export default function Card({ entry }: Props) {
     ? show
       ? group(entry.number)
       : `•••• •••• •••• ${entry.number.slice(-4)}`
-    : '•••• •••• •••• ••••'
-  const cvv = entry.cvc ? (show ? entry.cvc : '•••') : '—'
+    : ''
   const expires =
-    entry.month || entry.year ? `${entry.month || '••'}/${(entry.year || '••').slice(-2)}` : '—'
+    entry.month || entry.year ? `${entry.month || '••'}/${(entry.year || '••').slice(-2)}` : ''
 
   return (
     <div className="mt-3">
-      <div className="grid grid-cols-[340px_minmax(0,1fr)] items-start gap-3.5">
-        {/* Card art: an always-dark plastic-card visual, deliberately off-system.
-            Its gradient, hex inks, 16/4px radii and face letter-spacings imitate a
-            real card, so they are exempt from the type/radius/tracking scales. */}
-        <div className="relative flex h-[208px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-[18px] text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
-          <div className="absolute -right-10 -top-16 h-[200px] w-[200px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
-          <div className="flex items-start">
-            <div className="flex-1 font-mono text-[11px] uppercase tracking-[0.18em] opacity-60">
-              {entry.name || t('Card')}
-            </div>
-            {hasBrandMark(brand) ? (
-              <CardBrandMark brand={brand} size={20} tone="light" />
-            ) : (
-              <div className="h-6 w-[34px] rounded-[4px] border border-white/15 bg-white/10" />
-            )}
+      {/* Card art: an always-dark plastic-card visual, deliberately off-system.
+          Its gradient, hex inks, 16/4px radii and face letter-spacings imitate a
+          real card, so they are exempt from the type/radius/tracking scales. */}
+      <div className="relative flex h-[288px] w-[460px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_18px_40px_rgba(0,0,0,0.32)]">
+        <div className="absolute -right-10 -top-16 h-[240px] w-[240px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
+        <div className="relative flex items-start">
+          <div className="flex-1 pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
+            {entry.name || t('Card')}
           </div>
-          <div className="flex-1" />
-          <div className="font-mono text-[20px] tracking-[0.16em]">{number}</div>
-          <div className="mt-4 flex gap-6 font-mono text-[11px]">
-            <div>
-              <div className="uppercase tracking-[0.12em] opacity-50">{t('Holder')}</div>
-              <div className="mt-1 text-[12px]">{entry.name || '—'}</div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.12em] opacity-50">{t('Expires')}</div>
-              <div className="mt-1 text-[12px]">{expires}</div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.12em] opacity-50">{t('CVC')}</div>
-              <div className="mt-1 text-[12px]">{cvv}</div>
-            </div>
-          </div>
+          {hasBrandMark(brand) ? (
+            <CardBrandMark brand={brand} size={22} tone="light" />
+          ) : (
+            <div className="h-7 w-[40px] rounded-[4px] border border-white/15 bg-white/10" />
+          )}
         </div>
-
-        <Panel>
-          <div className="flex items-center gap-3 px-3.5 py-3 shadow-[inset_0_-1px_0_var(--c-line)]">
-            <span className="flex-1 text-base text-text2">
-              {t('Reveal number & CVC')}
-            </span>
-            <IconButton
-              title={show ? t('Hide') : t('Reveal')}
-              active={show}
-              onClick={() => setShow(!show)}
-            >
-              {show ? <EyeOffGlyph /> : <EyeGlyph />}
-            </IconButton>
+        <div className="flex-1" />
+        {entry.number ? (
+          <button
+            type="button"
+            onClick={() => copyNumber(entry.number)}
+            title={t('Copy')}
+            className="-mx-2 cursor-pointer self-start rounded-sm px-2 py-1 text-left text-[24px] tracking-[0.14em] transition-colors hover:bg-white/10"
+            data-testid="entry-value-number"
+          >
+            {numberCopied ? t('Copied') : number}
+          </button>
+        ) : (
+          <div className="px-0 py-1 text-[24px] tracking-[0.14em] opacity-50">
+            •••• •••• •••• ••••
           </div>
-          <Item name="Number" entry={entry} cc secure />
-          <Item name="Month" entry={entry} />
-          <Item name="Year" entry={entry} />
-          <Item name="CVC" entry={entry} secure />
-          <Item name="Pin" entry={entry} secure />
-          <Item name="Name" entry={entry} />
-        </Panel>
+        )}
+        <div className="relative mt-5 flex items-end gap-5">
+          <div className="-mx-1.5 flex min-w-0 flex-1 gap-3.5">
+            <Face
+              label={t('Holder')}
+              value={entry.name}
+              copyValue={entry.name || undefined}
+              testid="entry-value-name"
+            />
+            <Face
+              label={t('Expires')}
+              value={expires}
+              copyValue={expires || undefined}
+              testid="entry-value-expires"
+            />
+            <Face
+              label={t('CVC')}
+              value={show ? entry.cvc : '•••'}
+              copyValue={entry.cvc || undefined}
+              testid="entry-value-cvc"
+            />
+            <Face
+              label={t('Pin')}
+              value={show ? entry.pin : '••••'}
+              copyValue={entry.pin || undefined}
+              testid="entry-value-pin"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => setShow(!show)}
+            title={show ? t('Hide') : t('Reveal')}
+            data-testid="card-reveal-button"
+            className="grid h-7 w-7 flex-none cursor-pointer place-items-center rounded-sm text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            {show ? <EyeOffGlyph /> : <EyeGlyph />}
+          </button>
+        </div>
       </div>
       <Tags entry={entry} />
     </div>

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -22,9 +22,11 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 // the app-level "Copied to Clipboard" toast already says what happened, so
 // the face just confirms *which* value, without a second wordy label. The
 // overlay never swaps the text out, so nothing reflows.
+// Same wash as the fields' hover state, so a click doesn't shift the ground —
+// only the check appears over the value.
 function CopiedMark() {
   return (
-    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-[#14161A]/70 text-white">
+    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-white/10 text-white">
       <CheckGlyph size={12} />
     </span>
   )

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -22,12 +22,18 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 // the app-level "Copied to Clipboard" toast already says what happened, so
 // the face just confirms *which* value, without a second wordy label. The
 // overlay never swaps the text out, so nothing reflows.
-// Opaque version of the hover wash (white/10 composited over the card's dark
+// Opaque version of the hover wash (white/10 composited over the card's
 // ground), so a click doesn't visibly shift the ground but the value is fully
-// hidden under the check — no text/icon overlap.
-function CopiedMark() {
+// hidden under the check — no text/icon overlap. The card face is a gradient,
+// so the composite differs per zone: 'top' matches the lighter head of the
+// card (the name), 'base' the dark body (number and bottom row).
+function CopiedMark({ zone = 'base' }: { zone?: 'top' | 'base' }) {
   return (
-    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-[#2B2D31] text-white">
+    <span
+      className={`absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] text-white ${
+        zone === 'top' ? 'bg-[#3F4247]' : 'bg-[#2B2D31]'
+      }`}
+    >
       <CheckGlyph size={12} />
     </span>
   )
@@ -108,7 +114,7 @@ export default function Card({ entry }: Props) {
                 <span className="block truncate text-[12px] uppercase tracking-[0.18em] opacity-60">
                   {entry.name}
                 </span>
-                {nameCopied && <CopiedMark />}
+                {nameCopied && <CopiedMark zone="top" />}
               </span>
             </button>
           ) : (

--- a/src/components/Main/Body/Aside/Show/Details/Card.tsx
+++ b/src/components/Main/Body/Aside/Show/Details/Card.tsx
@@ -5,7 +5,7 @@ import CardBrandMark from '@/components/elements/CardBrandMark'
 import { useCopied } from '@/hooks/useCopied'
 import { t } from '@/i18n'
 import Tags from './Item/Tags'
-import { EyeGlyph, EyeOffGlyph } from '../../../../icons'
+import { CheckGlyph, EyeGlyph, EyeOffGlyph } from '../../../../icons'
 
 interface Props {
   entry: CardEntry
@@ -15,13 +15,17 @@ const group = (value: string) => value.match(/.{1,4}/g)?.join(' ') ?? value
 
 // One data point on the card face. The whole field is a click-to-copy target
 // (the 1Password pattern — no per-field buttons, so the face stays a card,
-// not a toolbar), with inline "Copied" feedback at the pointer. Copy always
-// copies the true value, masked or not. No value renders an inert dash.
-// "Copied" is an overlay chip, never a value swap — the face never reflows.
-function CopiedOverlay() {
+// not a toolbar). Copy always copies the true value, masked or not. No value
+// renders an inert dash.
+//
+// Copy feedback is deliberately quiet here: a check over the value only —
+// the app-level "Copied to Clipboard" toast already says what happened, so
+// the face just confirms *which* value, without a second wordy label. The
+// overlay never swaps the text out, so nothing reflows.
+function CopiedMark() {
   return (
-    <span className="absolute inset-0 grid place-items-center rounded-sm bg-[#101216]/90 text-[10px] uppercase tracking-[0.12em] text-white">
-      {t('Copied')}
+    <span className="absolute -inset-x-1 inset-y-0 grid place-items-center rounded-[3px] bg-[#14161A]/70 text-white">
+      <CheckGlyph size={12} />
     </span>
   )
 }
@@ -42,8 +46,9 @@ function Face({
   const body = (
     <>
       <div className="text-[11px] uppercase tracking-[0.12em] opacity-50">{label}</div>
-      <div className="mt-1 text-[13px]" data-testid={testid}>
+      <div className="relative mt-1 text-[13px]" data-testid={testid}>
         {copyValue ? value : '—'}
+        {copied && <CopiedMark />}
       </div>
     </>
   )
@@ -54,10 +59,9 @@ function Face({
       type="button"
       onClick={() => copy(copyValue)}
       title={t('Copy')}
-      className="relative cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
+      className="cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
     >
       {body}
-      {copied && <CopiedOverlay />}
     </button>
   )
 }
@@ -94,13 +98,15 @@ export default function Card({ entry }: Props) {
               type="button"
               onClick={() => copyName(entry.name)}
               title={t('Copy')}
-              className="relative -mx-1.5 -my-1 min-w-0 cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
+              className="-mx-1.5 -my-1 min-w-0 cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-white/10"
               data-testid="entry-value-name"
             >
-              <span className="block truncate pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
-                {entry.name}
+              <span className="relative block pt-1">
+                <span className="block truncate text-[12px] uppercase tracking-[0.18em] opacity-60">
+                  {entry.name}
+                </span>
+                {nameCopied && <CopiedMark />}
               </span>
-              {nameCopied && <CopiedOverlay />}
             </button>
           ) : (
             <div className="pt-1 text-[12px] uppercase tracking-[0.18em] opacity-60">
@@ -119,11 +125,13 @@ export default function Card({ entry }: Props) {
             type="button"
             onClick={() => copyNumber(entry.number)}
             title={t('Copy')}
-            className="relative -mx-2 cursor-pointer self-start rounded-sm px-2 py-1 text-left text-[24px] tracking-[0.14em] transition-colors hover:bg-white/10"
+            className="-mx-2 cursor-pointer self-start rounded-sm px-2 py-1 text-left text-[24px] tracking-[0.14em] transition-colors hover:bg-white/10"
             data-testid="entry-value-number"
           >
-            {number}
-            {numberCopied && <CopiedOverlay />}
+            <span className="relative block">
+              {number}
+              {numberCopied && <CopiedMark />}
+            </span>
           </button>
         ) : (
           <div className="px-0 py-1 text-[24px] tracking-[0.14em] opacity-50">

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -3,6 +3,8 @@ import { deleteEntry } from '@/store'
 import type { EntryMeta } from '@/lib/commands'
 import { useRevealed } from '@/hooks/useRevealed'
 import { useFavicon } from '@/hooks/useFavicon'
+import CardBrandMark from '@/components/elements/CardBrandMark'
+import { hasBrandMark } from '@/utils/cardBrand'
 import { t } from '@/i18n'
 import { LoginGlyph, NoteGlyph, CardGlyph } from '../../../icons'
 import Details from './Details'
@@ -69,6 +71,8 @@ export default function Show({ entry }: Props) {
             <div className="grid h-7 w-7 flex-none place-items-center overflow-hidden rounded-lg bg-tile text-text2">
               {icon ? (
                 <img src={icon} alt="" className="h-full w-full object-cover" />
+              ) : hasBrandMark(entry.cardBrand) ? (
+                <CardBrandMark brand={entry.cardBrand} size={12} />
               ) : (
                 <Glyph size={16} />
               )}

--- a/src/components/Main/Body/List/Item/Card.tsx
+++ b/src/components/Main/Body/List/Item/Card.tsx
@@ -1,12 +1,21 @@
 import { CardGlyph } from '@/components/Main/icons'
+import CardBrandMark from '@/components/elements/CardBrandMark'
+import { hasBrandMark } from '@/utils/cardBrand'
 import Row, { type ContentProps } from './Row'
 
 // The card number is a secret (in the encrypted payload), so the list shows a
-// static masked pattern rather than any real digits until the entry is revealed.
+// static masked pattern rather than any real digits until the entry is
+// revealed. The network mark comes from metadata derived at save time.
 export default function Card({ entry, flag }: ContentProps) {
   return (
     <Row
-      glyph={<CardGlyph size={16} />}
+      glyph={
+        hasBrandMark(entry.cardBrand) ? (
+          <CardBrandMark brand={entry.cardBrand} size={13} />
+        ) : (
+          <CardGlyph size={16} />
+        )
+      }
       title={entry.title}
       sub="•••• •••• •••• ••••"
       flag={flag}

--- a/src/components/elements/CardBrandMark.tsx
+++ b/src/components/elements/CardBrandMark.tsx
@@ -19,6 +19,8 @@ export default function CardBrandMark({ brand, size = 16, tone = 'color' }: Prop
     width: (size * 3) / 2,
     height: size,
     viewBox: '0 0 24 16',
+    // Never overflow a tight tile — scale down, keeping the aspect ratio.
+    style: { maxWidth: '100%', height: 'auto' },
     'aria-label': brand ?? undefined
   }
 
@@ -74,14 +76,15 @@ export default function CardBrandMark({ brand, size = 16, tone = 'color' }: Prop
         </svg>
       )
     case 'discover':
+      // The wordmark is wide; it gets its own 5:2 box so it never clips.
       return (
-        <svg {...shared}>
+        <svg {...shared} width={(size * 5) / 2} viewBox="0 0 40 16">
           <text
-            x="10.5"
-            y="11"
+            x="20"
+            y="10.6"
             textAnchor="middle"
             fontFamily={TEXT_FONT}
-            fontSize="5.6"
+            fontSize="7"
             fontWeight="800"
             fill={tone === 'light' ? '#fff' : '#231F20'}
           >

--- a/src/components/elements/CardBrandMark.tsx
+++ b/src/components/elements/CardBrandMark.tsx
@@ -1,0 +1,97 @@
+// Card network marks, drawn inline so they scale crisply from list tiles to
+// the card art. Circle pairs are the real geometry; wordmark networks are set
+// as bold type in the network's ink (white in `light` tone for dark surfaces).
+// Networks without a distinctive mark here return null — callers fall back to
+// the generic card glyph.
+
+interface Props {
+  brand?: string | null
+  // Height in px; width follows the 3:2 mark box.
+  size?: number
+  // 'light' renders wordmarks in white for dark grounds (the card art).
+  tone?: 'color' | 'light'
+}
+
+const TEXT_FONT = 'ui-sans-serif, system-ui, sans-serif'
+
+export default function CardBrandMark({ brand, size = 16, tone = 'color' }: Props) {
+  const shared = {
+    width: (size * 3) / 2,
+    height: size,
+    viewBox: '0 0 24 16',
+    'aria-label': brand ?? undefined
+  }
+
+  switch (brand) {
+    case 'mastercard':
+      return (
+        <svg {...shared}>
+          <circle cx="9" cy="8" r="5.4" fill="#EB001B" />
+          <circle cx="15" cy="8" r="5.4" fill="#F79E1B" />
+          <path d="M12 3.7 A5.4 5.4 0 0 0 12 12.3 A5.4 5.4 0 0 0 12 3.7 Z" fill="#FF5F00" />
+        </svg>
+      )
+    case 'maestro':
+      return (
+        <svg {...shared}>
+          <circle cx="9" cy="8" r="5.4" fill="#ED0006" />
+          <circle cx="15" cy="8" r="5.4" fill="#0099DF" />
+          <path d="M12 3.7 A5.4 5.4 0 0 0 12 12.3 A5.4 5.4 0 0 0 12 3.7 Z" fill="#6C6BBD" />
+        </svg>
+      )
+    case 'visa':
+      return (
+        <svg {...shared}>
+          <text
+            x="12"
+            y="12.2"
+            textAnchor="middle"
+            fontFamily={TEXT_FONT}
+            fontSize="10.5"
+            fontWeight="800"
+            fontStyle="italic"
+            fill={tone === 'light' ? '#fff' : '#1A1F71'}
+          >
+            VISA
+          </text>
+        </svg>
+      )
+    case 'amex':
+      return (
+        <svg {...shared}>
+          <rect width="24" height="16" rx="2.5" fill="#016FD0" />
+          <text
+            x="12"
+            y="10.6"
+            textAnchor="middle"
+            fontFamily={TEXT_FONT}
+            fontSize="6.4"
+            fontWeight="800"
+            fill="#fff"
+          >
+            AMEX
+          </text>
+        </svg>
+      )
+    case 'discover':
+      return (
+        <svg {...shared}>
+          <text
+            x="10.5"
+            y="11"
+            textAnchor="middle"
+            fontFamily={TEXT_FONT}
+            fontSize="5.6"
+            fontWeight="800"
+            fill={tone === 'light' ? '#fff' : '#231F20'}
+          >
+            DISC
+            <tspan fill="#F27712">O</tspan>
+            VER
+          </text>
+        </svg>
+      )
+    default:
+      return null
+  }
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core'
+import { cardBrandOf } from '@/utils/cardBrand'
 
 /**
  * Frozen command contract for the Swifty backend.
@@ -65,6 +66,9 @@ export interface EntryMeta {
   title: string
   tags: string[]
   urlHost: string
+  // Card network slug ("visa", …) derived from the number at save time;
+  // absent for non-cards and unrecognized numbers.
+  cardBrand?: string
   createdAt?: string
   updatedAt?: string
 }
@@ -76,6 +80,7 @@ export const toEntryMeta = (entry: Entry): EntryMeta => ({
   title: entry.title,
   tags: entry.tags ?? [],
   urlHost: entry.type === 'login' ? hostOf(entry.website) : '',
+  cardBrand: entry.type === 'card' ? cardBrandOf(entry.number) : undefined,
   createdAt: entry.createdAt ?? entry.created_at,
   updatedAt: entry.updatedAt ?? entry.updated_at
 })

--- a/src/test/list.test.tsx
+++ b/src/test/list.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ListColumn from '@/components/Main/Body/ListColumn'
 import { fetchFavicon, type Audit } from '@/lib/commands'
-import { makeStore, setSort } from '@/store'
+import { makeStore, setSort, setFilterScope } from '@/store'
 import { resetFavicons } from '@/hooks/useFavicon'
 import { renderWithStore, withEntries, loginMeta } from './utils'
 
@@ -87,6 +87,21 @@ describe('Entry list', () => {
 
     await waitFor(() => expect(fetchFavicon).toHaveBeenCalled())
     expect(document.querySelector('img')).not.toBeInTheDocument()
+  })
+
+  it('shows the network mark on card rows that carry a brand', () => {
+    const store = makeStore()
+    withEntries(store, [
+      loginMeta({ id: 'c1', type: 'card', title: 'Company Visa', cardBrand: 'visa', urlHost: '' }),
+      loginMeta({ id: 'c2', type: 'card', title: 'Mystery Card', urlHost: '' })
+    ])
+    setFilterScope('card')
+    renderWithStore(<ListColumn />, { store })
+
+    expect(document.querySelector('svg[aria-label="visa"]')).toBeInTheDocument()
+    // The brandless card falls back to the generic glyph, not an empty tile.
+    expect(document.querySelectorAll('svg[aria-label]')).toHaveLength(1)
+    setFilterScope('login')
   })
 
   it('sorts alphabetically', async () => {

--- a/src/utils/cardBrand.test.ts
+++ b/src/utils/cardBrand.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { cardBrandOf } from './cardBrand'
+
+// Mirror of the Rust tests in src-tauri/src/cards.rs — the two detectors must
+// agree (backend stores the slug at save time; this serves revealed views).
+describe('cardBrandOf', () => {
+  it('detects the major networks', () => {
+    expect(cardBrandOf('4111 1111 1111 1111')).toBe('visa')
+    expect(cardBrandOf('5500-0000-0000-0004')).toBe('mastercard')
+    expect(cardBrandOf('2221000000000009')).toBe('mastercard') // 2-series
+    expect(cardBrandOf('340000000000009')).toBe('amex')
+    expect(cardBrandOf('6011000000000004')).toBe('discover')
+    expect(cardBrandOf('6759649826438453')).toBe('maestro')
+    expect(cardBrandOf('3530111333300000')).toBe('jcb')
+    expect(cardBrandOf('36700102000000')).toBe('diners')
+    expect(cardBrandOf('6212345678901265')).toBe('unionpay')
+  })
+
+  it('lets specific ranges win over broad ones', () => {
+    expect(cardBrandOf('6011 0000')).toBe('discover') // not maestro's 60x
+    expect(cardBrandOf('6200 0000')).toBe('unionpay') // not maestro
+  })
+
+  it('returns undefined for unknown or short input', () => {
+    expect(cardBrandOf('')).toBeUndefined()
+    expect(cardBrandOf('411')).toBeUndefined()
+    expect(cardBrandOf('9999 9999')).toBeUndefined()
+    expect(cardBrandOf(undefined)).toBeUndefined()
+  })
+})

--- a/src/utils/cardBrand.ts
+++ b/src/utils/cardBrand.ts
@@ -1,0 +1,39 @@
+// Card network detection from the leading digits (IIN/BIN ranges).
+// TypeScript mirror of `src-tauri/src/cards.rs` — the backend derives and
+// stores the slug at save time for list metadata; this mirror serves views
+// that already hold the revealed number. Keep the two in sync.
+
+export type CardBrand =
+  | 'visa'
+  | 'mastercard'
+  | 'amex'
+  | 'discover'
+  | 'jcb'
+  | 'diners'
+  | 'unionpay'
+  | 'maestro'
+
+const MARKED = new Set(['mastercard', 'maestro', 'visa', 'amex', 'discover'])
+
+// Whether `brand` has a drawn mark in <CardBrandMark> — callers use this to
+// pick a fallback glyph, since the component renders null for the rest.
+export const hasBrandMark = (brand?: string | null): boolean =>
+  !!brand && MARKED.has(brand)
+
+export const cardBrandOf = (number?: string): CardBrand | undefined => {
+  const digits = (number ?? '').replace(/\D/g, '')
+  if (digits.length < 4) return undefined
+  const p2 = Number(digits.slice(0, 2))
+  const p3 = Number(digits.slice(0, 3))
+  const p4 = Number(digits.slice(0, 4))
+
+  if (digits.startsWith('4')) return 'visa'
+  if ((p2 >= 51 && p2 <= 55) || (p4 >= 2221 && p4 <= 2720)) return 'mastercard'
+  if (p2 === 34 || p2 === 37) return 'amex'
+  if (p4 === 6011 || p2 === 65 || (p3 >= 644 && p3 <= 649)) return 'discover'
+  if (p4 >= 3528 && p4 <= 3589) return 'jcb'
+  if ((p3 >= 300 && p3 <= 305) || p2 === 36 || p2 === 38 || p2 === 39) return 'diners'
+  if (p2 === 62) return 'unionpay'
+  if (p2 === 50 || (p2 >= 56 && p2 <= 58) || p2 === 67 || p2 === 63) return 'maestro'
+  return undefined
+}


### PR DESCRIPTION
Stacked on #279 (shares the detail-header identity tile). Retarget lands automatically when #279 merges — merge #279 first.

## What

Card entries wear their network's mark:
- **List rows**: the mark replaces the generic card glyph in the row tile.
- **Detail header**: the identity tile shows the mark (same slot the favicon uses for logins).
- **Card art**: the mark sits top-right on the plastic-card visual (light tone for wordmarks on the dark face), replacing the placeholder chip.

## How — derived once, stored as metadata

Per design discussion: **no decryption at render time.** The network slug is derived from the number's IIN/BIN ranges in Rust at save time (`src-tauri/src/cards.rs`) and stored in a new `card_brand` metadata column next to `url_host` (schema migration 2). The network isn't a secret — every physical card wears its logo — so the list reads it like any other meta field.

- **Backfill**: cards saved before the column existed are NULL there; on unlock they're unsealed once, the slug stored (`"none"` when unrecognized, so it never re-runs), via a targeted UPDATE that does not stamp `updated_at`.
- **Detection**: Visa, Mastercard (incl. 2-series), Amex, Discover, JCB, Diners, UnionPay, Maestro — specific ranges win over broad ones (6011 → Discover not Maestro, 62 → UnionPay).
- **TS mirror** (`src/utils/cardBrand.ts`) serves the revealed card art (tracks unsaved edits) and the sync-path `toEntryMeta`; Rust and TS test suites assert the same cases so the two can't drift.
- **Marks** (`elements/CardBrandMark.tsx`): inline SVG — real circle-pair geometry for Mastercard/Maestro, typographic marks for Visa/Amex/Discover. JCB/Diners/UnionPay detect but fall back to the generic glyph (follow-up if wanted).

## Verification

- 131/131 vitest (new: detection mirror suite, card-row mark + brandless fallback), 108 cargo tests (new: IIN ranges, precedence, store round-trip with the new column), tsc + eslint clean.
- Visual: existing cards gain marks after one unlock (backfill); new/edited cards immediately; the card art shows the mark top-right; unknown networks keep the neutral chip/glyph.