### PR TITLE
CI: skip the Rust CodeQL leg on frontend-only PRs, cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [master, v1-0-0]
   pull_request:
 
+# Cancel superseded PR runs (rapid pushes stack full matrices otherwise);
+# push runs on the protected branches are never cancelled.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   frontend:
     name: Frontend (build + lint)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,10 +17,47 @@ on:
     # Weekly re-scan so advisories added to the CodeQL packs after merge surface.
     - cron: '27 3 * * 1'
 
+# A superseded commit's analysis is worthless — cancel it. Push runs group per
+# ref; PR runs per PR.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # The Rust leg costs ~8 minutes, so on PRs it only runs when Rust inputs
+  # changed. Pushes to the protected branches and the weekly cron always run
+  # everything, so Security-tab coverage never regresses.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'src-tauri/**'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    needs: changes
+    # `needs` never skips us: `always()` keeps this job alive on push/schedule,
+    # where `changes` itself is skipped. On PRs the Rust leg runs only when
+    # Rust inputs changed; a skipped leg satisfies branch protection.
+    if: >-
+      always() && (
+        matrix.language != 'rust' ||
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.rust == 'true'
+      )
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
The Rust CodeQL leg takes ~8.5 min per run vs ~1 min for JS/TS — and it is `continue-on-error` (advisory), so on a PR those minutes can't even block anything.

## Changes

1. **Path-gated Rust leg on PRs**: a `changes` job (dorny/paths-filter) detects whether `src-tauri/**`, the CodeQL config, or the workflow itself changed; the Rust analyze leg runs on PRs only then. A skipped leg satisfies branch protection. **Pushes to `master`/`v1-0-0` and the weekly cron still always run both legs**, so Security-tab baselines and advisory re-scans are unchanged.
2. **Concurrency groups** on both `codeql.yml` and `ci.yml`: a superseded commit's run is cancelled when a new push lands on the same PR (`cancel-in-progress` only for PRs — protected-branch push runs are never cancelled).
3. JS/TS leg (the blocking gate) untouched — still on every PR.

The `always() && (...)` guard on `analyze` keeps push/schedule runs alive even though `changes` (PR-only) is skipped as their dependency.

## Not done here (worth considering separately)

The CI workflow's 3-OS Rust test matrix also runs on frontend-only PRs. The same `changes` gating would work there, but those are blocking required checks — semantics change, so it deserves its own decision.

## Verify

- This PR touches the workflow itself, so its own run should include the Rust leg (the filter includes `.github/workflows/codeql.yml`).
- A follow-up frontend-only PR should show "Analyze (rust): skipped".