### PR TITLE
feat(store): sync merge primitives — LWW merge, state digest, tombstone GC

### DIFF
--- a/src-tauri/src/store/hash.rs
+++ b/src-tauri/src/store/hash.rs
@@ -1,0 +1,87 @@
+//! Content hashing for sync: a canonical fingerprint per record, and a digest
+//! over the whole entry table.
+//!
+//! Both are consumed by the sync engine as *comparison* primitives, so the only
+//! property that matters is that two stores agree bit-for-bit on the same
+//! content — never that the bytes are secret. The encoding is therefore fixed
+//! and injective, not merely "hash the fields": every variable-length field is
+//! length-prefixed and every `Option` carries a presence tag, so no two
+//! different records can share a preimage. Naive concatenation would let
+//! ("ab", "c") and ("a", "bc") collide, which in the merge tie-break would mean
+//! two genuinely different records comparing equal and one silently winning.
+
+use sha2::{Digest, Sha256};
+
+use super::Record;
+
+/// `u64` LE length, then the bytes. The prefix is what makes the concatenation
+/// of fields unambiguous.
+fn field(h: &mut Sha256, bytes: &[u8]) {
+    h.update((bytes.len() as u64).to_le_bytes());
+    h.update(bytes);
+}
+
+/// Presence tag (0/1) then, when present, the 8-byte LE value. `None` and
+/// `Some(0)` must not encode alike.
+fn opt_i64(h: &mut Sha256, v: Option<i64>) {
+    match v {
+        None => h.update([0u8]),
+        Some(n) => {
+            h.update([1u8]);
+            h.update(n.to_le_bytes());
+        }
+    }
+}
+
+fn opt_field(h: &mut Sha256, v: Option<&str>) {
+    match v {
+        None => h.update([0u8]),
+        Some(s) => {
+            h.update([1u8]);
+            field(h, s.as_bytes());
+        }
+    }
+}
+
+/// SHA-256 over a record's content: everything that makes two rows the same
+/// row, in a fixed field order.
+///
+/// `id` is deliberately excluded — it is the key the comparison is made *under*
+/// (records are only ever hashed against another record of the same id), so
+/// including it would add nothing. [`state_digest`] adds it back, because there
+/// the identity of each row is part of what is being fingerprinted.
+///
+/// Timestamps are included: a record whose only change is `updated_at` is a
+/// different record for merge purposes.
+pub fn record_hash(r: &Record) -> [u8; 32] {
+    let mut h = Sha256::new();
+    field(&mut h, r.kind.as_bytes());
+    field(&mut h, r.title.as_bytes());
+    field(&mut h, r.tags.as_bytes());
+    field(&mut h, r.url_host.as_bytes());
+    h.update(r.created_at.to_le_bytes());
+    h.update(r.updated_at.to_le_bytes());
+    opt_i64(&mut h, r.deleted_at);
+    field(&mut h, &r.payload);
+    opt_field(&mut h, r.card_brand.as_deref());
+    h.finalize().into()
+}
+
+/// SHA-256 over an entire entry set — tombstones included — as
+/// (length-prefixed id, [`record_hash`]) pairs in ascending id byte order.
+///
+/// Equal digests mean identical entry state, which is what lets the sync engine
+/// decide a push by digest inequality alone. Sorting happens here rather than
+/// being inherited from a caller's `ORDER BY` so the ordering contract stays
+/// with the definition of the digest.
+pub fn state_digest(recs: &[Record]) -> [u8; 32] {
+    let mut order: Vec<&Record> = recs.iter().collect();
+    order.sort_unstable_by(|a, b| a.id.as_bytes().cmp(b.id.as_bytes()));
+
+    let mut h = Sha256::new();
+    for r in order {
+        field(&mut h, r.id.as_bytes());
+        h.update(record_hash(r));
+    }
+    h.finalize().into()
+}

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -6,6 +6,7 @@
 //! encrypts it (the caller applies its own AEAD). The only crypto here is
 //! SQLCipher at-rest, keyed by a byte key injected at [`SqliteStore::open`].
 
+mod hash;
 mod sqlite;
 
 // Migration glue lives in-module but deliberately references the app's crypto —
@@ -15,6 +16,7 @@ pub mod migrate;
 #[cfg(test)]
 mod tests;
 
+pub use hash::record_hash;
 pub use sqlite::SqliteStore;
 
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -5,9 +5,10 @@ use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
 
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::{params, Connection, OptionalExtension, Row, Statement};
 use rusqlite_migration::{Migrations, M};
 
+use super::hash::{record_hash, state_digest};
 use super::{now_ms, EntryMeta, Record, Result, StoreError, VaultStore};
 
 // Ordered schema migrations, versioned via SQLite's `user_version` pragma. This
@@ -45,6 +46,16 @@ const COLS: &str =
     "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, payload, card_brand";
 const META_COLS: &str =
     "id, kind, title, tags, url_host, created_at, updated_at, deleted_at, card_brand";
+
+const META_UPSERT: &str = "INSERT INTO meta (key, value) VALUES (?1, ?2)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value";
+
+// Set by user-initiated writes, consumed by the sync engine purely as a
+// *debounce trigger* ("something happened locally, consider syncing soon").
+// It is never the push decision — that is `state_digest` inequality, because a
+// flag cannot see the case where local is a strict superset of remote with no
+// local write since the last clear.
+const DIRTY_KEY: &str = "sync_dirty";
 
 pub struct SqliteStore {
     conn: Mutex<Connection>,
@@ -131,12 +142,106 @@ impl SqliteStore {
 
     /// Set the derived card-network slug without stamping `updated_at` — it is
     /// derived metadata, not a user edit (used by the one-time unlock backfill).
+    /// Deliberately does not mark the vault dirty for the same reason.
     pub fn set_card_brand(&self, id: &str, brand: &str) -> Result<()> {
         self.lock().execute(
             "UPDATE entries SET card_brand = ?1 WHERE id = ?2",
             params![brand, id],
         )?;
         Ok(())
+    }
+
+    /// Merge foreign records into the vault, last-writer-wins per id, in one
+    /// transaction. Returns how many rows were written.
+    ///
+    /// A record wins when its `updated_at` is strictly newer, or — on an exact
+    /// timestamp tie — when its [`record_hash`] sorts higher bytewise. That
+    /// tie-break is the whole reason this is not a plain "newer or keep local":
+    /// "keep local" is not commutative, so on a tie two devices each keep their
+    /// own row, every sync sees a difference, and they ping-pong pushes forever
+    /// without ever converging. Ordering by content hash makes the merge a true
+    /// join — idempotent, commutative, associative — so both sides
+    /// independently pick the same winner and the vaults converge. Equal
+    /// timestamp *and* equal hash is the same content, so nothing is written.
+    ///
+    /// Tombstones take part like any other row (they are looked up, and they
+    /// can win or lose), which is what makes "deleted on one device" and
+    /// "edited on another" resolve by time rather than by which side ran first.
+    ///
+    /// Winners are written verbatim: no timestamp is stamped here, or the
+    /// merged row would immediately look newer than its source everywhere else.
+    /// This does not set the dirty flag — a merge is not a user edit, and the
+    /// engine decides pushes from `state_digest`, not from dirt.
+    pub fn merge_records(&self, recs: &[Record]) -> Result<usize> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        let mut changed = 0usize;
+        {
+            // Tombstones must be visible here, so this reads the raw row rather
+            // than going through `get` (which hides them).
+            let mut find = tx.prepare(&format!("SELECT {COLS} FROM entries WHERE id = ?1"))?;
+            let mut write = tx.prepare(&verbatim_upsert())?;
+
+            for incoming in recs {
+                let local: Option<Record> = find
+                    .query_row(params![incoming.id], row_to_record)
+                    .optional()?;
+
+                let wins = match &local {
+                    None => true,
+                    Some(local) => {
+                        incoming.updated_at > local.updated_at
+                            || (incoming.updated_at == local.updated_at
+                                && record_hash(incoming) > record_hash(local))
+                    }
+                };
+
+                if wins {
+                    exec_record(&mut write, incoming)?;
+                    changed += 1;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(changed)
+    }
+
+    /// Fingerprint of the whole entry table, tombstones included. Two vaults
+    /// hold the same entry state exactly when their digests match, which is the
+    /// sync engine's push decision: push when the digests differ, full stop.
+    pub fn state_digest(&self) -> Result<[u8; 32]> {
+        Ok(state_digest(&self.export_for_sync()?))
+    }
+
+    /// Whether a user-initiated write has landed since the last
+    /// [`clear_dirty`](Self::clear_dirty). See [`DIRTY_KEY`]: a trigger, not the
+    /// push decision.
+    pub fn is_dirty(&self) -> Result<bool> {
+        Ok(self.meta_get(DIRTY_KEY)?.as_deref() == Some("1"))
+    }
+
+    pub fn clear_dirty(&self) -> Result<()> {
+        self.lock()
+            .execute("DELETE FROM meta WHERE key = ?1", params![DIRTY_KEY])?;
+        Ok(())
+    }
+
+    /// Hard-delete tombstones deleted before `cutoff_ms`, returning the number
+    /// of rows reclaimed.
+    ///
+    /// Tombstones cannot be kept forever, and dropping one is not free: a device
+    /// that has been offline since before the cutoff still holds the row as
+    /// live, sees no tombstone to tell it otherwise, and re-pushes it as a new
+    /// record — the entry resurrects. A ~90-day cutoff is the trade: only a
+    /// device dormant for a full quarter can resurrect anything, and the vault
+    /// does not grow without bound. Deciding *when* to call this (never before
+    /// the tombstone has been pushed at least once, or the delete is lost
+    /// instead of propagated) belongs to the sync engine, not the store.
+    pub fn purge_tombstones_before(&self, cutoff_ms: i64) -> Result<usize> {
+        Ok(self.lock().execute(
+            "DELETE FROM entries WHERE deleted_at IS NOT NULL AND deleted_at < ?1",
+            params![cutoff_ms],
+        )?)
     }
 }
 
@@ -151,11 +256,7 @@ impl VaultStore for SqliteStore {
     }
 
     fn meta_set(&self, key: &str, value: &str) -> Result<()> {
-        self.lock().execute(
-            "INSERT INTO meta (key, value) VALUES (?1, ?2)
-             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            params![key, value],
-        )?;
+        self.lock().execute(META_UPSERT, params![key, value])?;
         Ok(())
     }
 
@@ -177,8 +278,9 @@ impl VaultStore for SqliteStore {
 
     fn upsert(&self, rec: &Record) -> Result<()> {
         let now = now_ms();
+        let conn = self.lock();
         // created_at is set only on insert; updated_at is always stamped to now.
-        self.lock().execute(
+        conn.execute(
             &format!(
                 "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
                  ON CONFLICT(id) DO UPDATE SET
@@ -204,16 +306,17 @@ impl VaultStore for SqliteStore {
                 rec.card_brand,
             ],
         )?;
-        Ok(())
+        mark_dirty(&conn)
     }
 
     fn delete(&self, id: &str) -> Result<()> {
         let now = now_ms();
-        self.lock().execute(
+        let conn = self.lock();
+        conn.execute(
             "UPDATE entries SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
             params![now, id],
         )?;
-        Ok(())
+        mark_dirty(&conn)
     }
 
     fn export_for_sync(&self) -> Result<Vec<Record>> {
@@ -228,33 +331,55 @@ impl VaultStore for SqliteStore {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
         {
-            // Bulk sync-in: timestamps are preserved verbatim (no stamping).
-            let mut stmt = tx.prepare(&format!(
-                "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
-                 ON CONFLICT(id) DO UPDATE SET
-                   kind=excluded.kind, title=excluded.title, tags=excluded.tags,
-                   url_host=excluded.url_host, created_at=excluded.created_at,
-                   updated_at=excluded.updated_at, deleted_at=excluded.deleted_at,
-                   payload=excluded.payload, card_brand=excluded.card_brand"
-            ))?;
+            // Bulk sync-in: timestamps are preserved verbatim (no stamping), and
+            // every incoming row clobbers unconditionally — unlike merge_records,
+            // this is a user restoring a file, not a peer proposing changes.
+            let mut stmt = tx.prepare(&verbatim_upsert())?;
             for r in recs {
-                stmt.execute(params![
-                    r.id,
-                    r.kind,
-                    r.title,
-                    r.tags,
-                    r.url_host,
-                    r.created_at,
-                    r.updated_at,
-                    r.deleted_at,
-                    r.payload,
-                    r.card_brand,
-                ])?;
+                exec_record(&mut stmt, r)?;
             }
         }
+        // In-transaction so a `.swftx` import and its trigger land together.
+        mark_dirty(&tx)?;
         tx.commit()?;
         Ok(())
     }
+}
+
+// One full-row write that keeps the record's own timestamps — the shape both
+// sync-in paths (import, merge_records) need.
+fn verbatim_upsert() -> String {
+    format!(
+        "INSERT INTO entries ({COLS}) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)
+         ON CONFLICT(id) DO UPDATE SET
+           kind=excluded.kind, title=excluded.title, tags=excluded.tags,
+           url_host=excluded.url_host, created_at=excluded.created_at,
+           updated_at=excluded.updated_at, deleted_at=excluded.deleted_at,
+           payload=excluded.payload, card_brand=excluded.card_brand"
+    )
+}
+
+fn exec_record(stmt: &mut Statement, r: &Record) -> rusqlite::Result<usize> {
+    stmt.execute(params![
+        r.id,
+        r.kind,
+        r.title,
+        r.tags,
+        r.url_host,
+        r.created_at,
+        r.updated_at,
+        r.deleted_at,
+        r.payload,
+        r.card_brand,
+    ])
+}
+
+// Takes the connection rather than `&self` so callers already inside a
+// transaction (import) flag atomically, and callers holding the mutex guard
+// (upsert, delete) do not deadlock re-locking it.
+fn mark_dirty(conn: &Connection) -> Result<()> {
+    conn.execute(META_UPSERT, params![DIRTY_KEY, "1"])?;
+    Ok(())
 }
 
 fn row_to_record(row: &Row) -> rusqlite::Result<Record> {

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::{migrate, Record, SqliteStore, VaultStore};
+use super::{migrate, record_hash, Record, SqliteStore, VaultStore};
 use crate::crypto::{self, KdfParams, VaultKey};
 use crate::models::Entry;
 
@@ -53,6 +53,41 @@ fn rec(id: &str, payload: &[u8]) -> Record {
         payload: payload.to_vec(),
         card_brand: None,
     }
+}
+
+// A record with the timestamps merge actually reasons about. `created_at` is
+// held constant so a differing `updated_at` is the only axis under test.
+fn stamped(id: &str, payload: &[u8], updated_at: i64) -> Record {
+    Record {
+        created_at: 100,
+        updated_at,
+        ..rec(id, payload)
+    }
+}
+
+fn tombstone(id: &str, at: i64) -> Record {
+    Record {
+        deleted_at: Some(at),
+        ..stamped(id, b"", at)
+    }
+}
+
+// Seed rows with their timestamps intact (import, unlike upsert, does not stamp)
+// and clear the dirty flag the seeding itself sets.
+fn seeded(recs: &[Record]) -> SqliteStore {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    store.import(recs).unwrap();
+    store.clear_dirty().unwrap();
+    store
+}
+
+fn row(store: &SqliteStore, id: &str) -> Record {
+    store
+        .export_for_sync()
+        .unwrap()
+        .into_iter()
+        .find(|r| r.id == id)
+        .unwrap()
 }
 
 #[test]
@@ -466,4 +501,244 @@ fn import_swftx_wrong_source_password_errors() {
 
     let wrong = Cryptor::new(&hash_secret("not-the-password"));
     assert!(wrong.decrypt_data::<VaultData>(&blob).is_err());
+}
+
+// ---- sync merge primitives ------------------------------------------------
+
+// The length prefixes exist so that shifting a byte across a field boundary is
+// a different preimage; without them ("ab","c") and ("a","bc") would collide,
+// and the merge tie-break would call two different records equal.
+#[test]
+fn record_hash_separates_adjacent_fields() {
+    let mut a = rec("1", b"x");
+    a.title = "ab".into();
+    a.tags = "c".into();
+    let mut b = a.clone();
+    b.title = "a".into();
+    b.tags = "bc".into();
+
+    assert_ne!(record_hash(&a), record_hash(&b));
+    // Same content, same hash — the id is deliberately not part of it.
+    assert_eq!(record_hash(&a), record_hash(&a.clone()));
+    assert_eq!(
+        record_hash(&a),
+        record_hash(&Record {
+            id: "2".into(),
+            ..a
+        })
+    );
+}
+
+#[test]
+fn merge_newer_incoming_wins() {
+    let store = seeded(&[stamped("1", b"old", 1000)]);
+    assert_eq!(
+        store.merge_records(&[stamped("1", b"new", 2000)]).unwrap(),
+        1
+    );
+
+    let got = row(&store, "1");
+    assert_eq!(got.payload, b"new");
+    assert_eq!(got.updated_at, 2000);
+}
+
+#[test]
+fn merge_older_incoming_is_a_no_op() {
+    let store = seeded(&[stamped("1", b"local", 2000)]);
+    let before = row(&store, "1");
+
+    assert_eq!(
+        store
+            .merge_records(&[stamped("1", b"stale", 1000)])
+            .unwrap(),
+        0
+    );
+    // Byte-identical, timestamps included: the loser must not touch the row.
+    assert_eq!(row(&store, "1"), before);
+}
+
+#[test]
+fn merge_inserts_unknown_record_verbatim() {
+    let store = seeded(&[]);
+    let mut incoming = stamped("1", b"fresh", 222);
+    incoming.created_at = 111;
+
+    assert_eq!(store.merge_records(&[incoming]).unwrap(), 1);
+
+    let got = row(&store, "1");
+    // created_at is carried over, not re-stamped to now as upsert would.
+    assert_eq!((got.created_at, got.updated_at), (111, 222));
+    assert_eq!(got.payload, b"fresh");
+}
+
+#[test]
+fn merge_newer_tombstone_beats_older_edit() {
+    let store = seeded(&[stamped("1", b"live", 1000)]);
+    assert_eq!(store.merge_records(&[tombstone("1", 2000)]).unwrap(), 1);
+
+    assert_eq!(store.get("1").unwrap(), None);
+    assert_eq!(row(&store, "1").deleted_at, Some(2000));
+}
+
+// The mirror case: an edit made after the delete resurrects the entry. That is
+// LWW working, not a bug — the user's later intent wins.
+#[test]
+fn merge_newer_edit_beats_older_tombstone() {
+    let store = seeded(&[tombstone("1", 1000)]);
+    assert_eq!(
+        store
+            .merge_records(&[stamped("1", b"revived", 2000)])
+            .unwrap(),
+        1
+    );
+
+    let got = store.get("1").unwrap().unwrap();
+    assert_eq!(got.payload, b"revived");
+    assert_eq!(got.deleted_at, None);
+}
+
+#[test]
+fn merge_tie_on_identical_content_writes_nothing() {
+    let store = seeded(&[stamped("1", b"same", 1000)]);
+    let mine = store.export_for_sync().unwrap();
+    assert_eq!(store.merge_records(&mine).unwrap(), 0);
+}
+
+// The convergence property. On an exact timestamp tie the two sides hold
+// different content, so *someone* must yield — and both must pick the same
+// side, or they diverge permanently and push at each other forever.
+#[test]
+fn merge_tie_picks_the_same_winner_on_both_sides() {
+    let a = seeded(&[stamped("1", b"aaa", 5000)]);
+    let b = seeded(&[stamped("1", b"bbb", 5000)]);
+    let (from_a, from_b) = (a.export_for_sync().unwrap(), b.export_for_sync().unwrap());
+
+    a.merge_records(&from_b).unwrap();
+    b.merge_records(&from_a).unwrap();
+
+    assert_eq!(a.state_digest().unwrap(), b.state_digest().unwrap());
+    // Exactly one of the two payloads survived on both sides.
+    let payload = row(&a, "1").payload;
+    assert_eq!(payload, row(&b, "1").payload);
+    assert!(payload == b"aaa" || payload == b"bbb");
+}
+
+#[test]
+fn merge_is_idempotent() {
+    let source = seeded(&[stamped("1", b"x", 1000), stamped("2", b"y", 2000)]);
+    let target = seeded(&[stamped("1", b"older", 500)]);
+    let export = source.export_for_sync().unwrap();
+
+    assert_eq!(target.merge_records(&export).unwrap(), 2);
+    let digest = target.state_digest().unwrap();
+
+    // Replaying the same batch is a no-op — every record now ties itself.
+    assert_eq!(target.merge_records(&export).unwrap(), 0);
+    assert_eq!(target.state_digest().unwrap(), digest);
+}
+
+#[test]
+fn merge_is_commutative_across_divergent_stores() {
+    let a = seeded(&[
+        stamped("1", b"a1", 100), // b wins
+        stamped("2", b"a2", 300), // a wins
+        stamped("3", b"a3", 100), // only in a
+    ]);
+    let b = seeded(&[
+        stamped("1", b"b1", 200),
+        stamped("2", b"b2", 200),
+        stamped("4", b"b4", 100), // only in b
+    ]);
+    let (from_a, from_b) = (a.export_for_sync().unwrap(), b.export_for_sync().unwrap());
+
+    a.merge_records(&from_b).unwrap();
+    b.merge_records(&from_a).unwrap();
+
+    assert_eq!(a.state_digest().unwrap(), b.state_digest().unwrap());
+    assert_eq!(row(&a, "1").payload, b"b1");
+    assert_eq!(row(&a, "2").payload, b"a2");
+    // Records held by only one side are additions, never conflicts.
+    assert_eq!(a.export_for_sync().unwrap().len(), 4);
+}
+
+#[test]
+fn merge_preserves_timestamps_end_to_end() {
+    let mut original = stamped("1", b"x", 222);
+    original.created_at = 111;
+    let a = seeded(&[original]);
+    let b = seeded(&[]);
+
+    b.merge_records(&a.export_for_sync().unwrap()).unwrap();
+
+    assert_eq!(row(&b, "1"), row(&a, "1"));
+}
+
+#[test]
+fn state_digest_matches_exactly_on_equal_state() {
+    let rows = [stamped("1", b"x", 100), stamped("2", b"y", 200)];
+    let a = seeded(&rows);
+    let b = seeded(&rows);
+    assert_eq!(a.state_digest().unwrap(), b.state_digest().unwrap());
+
+    // Any content change moves the digest.
+    b.merge_records(&[stamped("2", b"changed", 300)]).unwrap();
+    assert_ne!(a.state_digest().unwrap(), b.state_digest().unwrap());
+}
+
+// Tombstones are state: a vault that has seen a delete is not the same vault as
+// one that never held the row, and the digest has to say so or the delete never
+// propagates.
+#[test]
+fn state_digest_counts_tombstones() {
+    let a = seeded(&[stamped("1", b"x", 100)]);
+    let b = seeded(&[stamped("1", b"x", 100), tombstone("2", 100)]);
+    assert_ne!(a.state_digest().unwrap(), b.state_digest().unwrap());
+
+    b.purge_tombstones_before(200).unwrap();
+    assert_eq!(a.state_digest().unwrap(), b.state_digest().unwrap());
+}
+
+#[test]
+fn purge_tombstones_before_spares_live_and_recent_rows() {
+    let store = seeded(&[
+        stamped("live", b"x", 1000),
+        tombstone("old", 1000),
+        tombstone("recent", 9000),
+    ]);
+
+    assert_eq!(store.purge_tombstones_before(5000).unwrap(), 1);
+
+    let mut ids: Vec<String> = store
+        .export_for_sync()
+        .unwrap()
+        .into_iter()
+        .map(|r| r.id)
+        .collect();
+    ids.sort();
+    assert_eq!(ids, ["live", "recent"]);
+}
+
+#[test]
+fn dirty_flag_tracks_user_writes_only() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    assert!(!store.is_dirty().unwrap());
+
+    store.upsert(&rec("1", b"x")).unwrap();
+    assert!(store.is_dirty().unwrap());
+    store.clear_dirty().unwrap();
+    assert!(!store.is_dirty().unwrap());
+
+    store.delete("1").unwrap();
+    assert!(store.is_dirty().unwrap());
+    store.clear_dirty().unwrap();
+
+    store.import(&[stamped("2", b"y", 1000)]).unwrap();
+    assert!(store.is_dirty().unwrap());
+    store.clear_dirty().unwrap();
+
+    // A merge is a peer's write, and a brand backfill is derived metadata —
+    // neither is a local edit, so neither may re-trigger a push cycle.
+    assert_eq!(store.merge_records(&[stamped("2", b"z", 2000)]).unwrap(), 1);
+    store.set_card_brand("2", "visa").unwrap();
+    assert!(!store.is_dirty().unwrap());
 }


### PR DESCRIPTION
Store-layer groundwork for Google Drive sync. Pure primitives — no engine, no pack format, no UI, nothing wired up. The frontend is untouched.

## Design

PR 1 of 3 of the Drive Sync v2 design: https://claude.ai/code/artifact/03870f8c-7a86-47d8-8c46-ed5e46ed8518

PR 2 brings the pack format, PR 3 the Drive engine that composes these primitives.

## Semantics

- **LWW merge with a content-hash tie-break** — `merge_records` takes incoming records and, per id, keeps the row with the strictly newer `updated_at`; on an exact tie the higher `record_hash` (bytewise) wins. From the design's adversarial review: "keep local on tie" is *not commutative*, so two devices each keep their own row, every sync sees a difference, and they ping-pong pushes forever without converging. Hash order makes the merge a true join — idempotent, commutative, associative — so both sides independently elect the same winner and the vaults converge structurally. Equal timestamp *and* equal hash is identical content, so nothing is written.
- **State digest as the push decision** — `state_digest` is SHA-256 over every row including tombstones, sorted by id. The same review found that dirty-flag and "did the merge change anything" heuristics silently lose the case where *local is a strict superset of remote*: nothing changed locally, nothing changed on merge, and the local-only records are never pushed. Digest inequality has no such blind spot, so PR 3 will decide pushes on that alone.
- **Dirty flag is a trigger, never a decision** — `sync_dirty` is set by `upsert`/`delete`/`import` (user-initiated writes) and exists only to wake the debounce. Deliberately *not* set by `merge_records` (a peer's write is not a local edit) or `set_card_brand` (derived-metadata backfill must not re-dirty the vault).
- **Tombstone GC** — `purge_tombstones_before` hard-deletes tombstones older than a cutoff. The store only exposes the primitive; the "never purge before the tombstone has been pushed at least once" policy is the engine's job. The ~90-day resurrection trade-off is doc-commented: a device dormant past the cutoff still holds the row as live and will re-push it.

Merge winners are written verbatim — no timestamp stamping, or a merged row would immediately look newer than its source on every other device. `record_hash` uses a fixed injective encoding (u64-LE length prefixes, fixed 8-byte integers, presence tags on options), so no two different records can share a preimage.

## Tests

15 new tests (108 → 123), all in `src-tauri/src/store/tests.rs`:

- hash encoding is injective across adjacent field boundaries; id excluded from `record_hash`
- newer incoming wins; older incoming is a no-op (row byte-identical after, timestamps included)
- unknown record inserts verbatim — `created_at` carried over, not re-stamped
- newer tombstone beats an older edit; newer edit beats an older tombstone (resurrection by edit is correct LWW)
- tie on identical content writes nothing; tie on different content elects the same winner on both sides (mirrored stores, cross-merge, equal digests)
- idempotence: replaying the same export changes 0 rows, digest unchanged
- commutativity: two divergent stores, cross-merged both ways, end at equal digests
- digest: equal state ⇔ equal digest, any content change moves it, tombstone-only differences count
- `purge_tombstones_before` spares live rows and newer tombstones
- dirty flag set by upsert/delete/import, not by merge/`set_card_brand`; `clear_dirty` works
- timestamps preserved verbatim end-to-end (export from A, merge into B, rows equal)

## Gates

`cargo test` (123 passed), `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean). No frontend changes, so the JS suite was not run.