### PR TITLE
fix(unlock): rescue #283 — newer-schema vault says 'update the app', not 'wrong password'

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -37,8 +37,14 @@ pub fn derive_key(app: &AppHandle, password: &str) -> Result<VaultKey> {
 // Open the existing store with `key` and return its handle + entry metadata. A
 // wrong key fails SQLCipher's open verification -> surfaced as invalid password.
 pub fn open_with_key(app: &AppHandle, key: &VaultKey) -> Result<(SqliteStore, Vec<EntryMetaDto>)> {
-    let store = SqliteStore::open(&storage::db_path(app)?, &key.sqlcipher_key())
-        .map_err(|_| Error::InvalidPassword)?;
+    // Everything else that fails an open IS a key problem (SQLCipher can't
+    // read a byte of a wrongly-keyed file) — but a schema from a newer build
+    // must say so, not send the user doubting their master password.
+    let store =
+        SqliteStore::open(&storage::db_path(app)?, &key.sqlcipher_key()).map_err(|e| match e {
+            StoreError::SchemaNewer => Error::VaultTooNew,
+            _ => Error::InvalidPassword,
+        })?;
     backfill_card_brands(&store, key);
     let metas = list_metas(&store)?;
     Ok((store, metas))

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -7,6 +7,12 @@ pub enum Error {
     #[error("invalid master password")]
     InvalidPassword,
 
+    // The vault was written by a newer build (schema ahead of this binary).
+    // Distinct from InvalidPassword so the UI never blames the user's memory
+    // for a version mismatch. The message string is the frontend's match key.
+    #[error("vault requires a newer version of the app")]
+    VaultTooNew,
+
     // Failed-unlock backoff (T-AUTH-3): too many wrong attempts, wait it out.
     // `retry_after_secs` rides along in the serialized payload (see `Serialize`
     // below) so the frontend can render a countdown without parsing the message.

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -26,6 +26,12 @@ pub enum StoreError {
     #[error("sqlite: {0}")]
     Sqlite(#[from] rusqlite::Error),
 
+    // The DB was stamped by a build with more migrations than this one knows.
+    // Kept distinct so the app boundary can say "update the app" instead of
+    // the catch-all "wrong password".
+    #[error("vault schema is newer than this app version")]
+    SchemaNewer,
+
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -15,7 +15,18 @@ use super::{now_ms, EntryMeta, Record, Result, StoreError, VaultStore};
 // change (Phase 2 KDF columns, Phase 3 sync columns). The `meta` k/v table holds
 // APP data (KDF descriptor, biometric flag, settings), not schema versioning.
 fn migrations() -> Migrations<'static> {
-    Migrations::new(vec![
+    Migrations::new(migration_list())
+}
+
+// After running all migrations, `user_version` equals the list length. A DB
+// above that was written by a newer build — refuse with a dedicated error
+// instead of letting the failure masquerade as a wrong key (see `open`).
+fn schema_version() -> i64 {
+    migration_list().len() as i64
+}
+
+fn migration_list() -> Vec<M<'static>> {
+    vec![
         M::up(
             "CREATE TABLE meta (
            key   TEXT PRIMARY KEY,
@@ -37,7 +48,7 @@ fn migrations() -> Migrations<'static> {
         // so listings show brand marks without touching the payload. NULL =
         // not yet derived (backfilled once on unlock).
         M::up("ALTER TABLE entries ADD COLUMN card_brand TEXT;"),
-    ])
+    ]
 }
 
 // card_brand is appended last so pre-existing column indexes stay put.
@@ -85,6 +96,14 @@ impl SqliteStore {
             .map_err(|_| StoreError::Other("cannot open database (wrong key?)".into()))?;
         }
 
+        // A vault stamped by a newer build must surface as "update the app",
+        // never as a key failure — for a password manager, a fake "wrong
+        // password" is the worst possible misdiagnosis.
+        let version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+        if version > schema_version() {
+            return Err(StoreError::SchemaNewer);
+        }
+
         // Apply pending schema migrations on the decrypted DB (tracked via
         // `user_version`; idempotent — a no-op once the DB is at the latest).
         migrations()
@@ -126,6 +145,14 @@ impl SqliteStore {
     pub fn rekey(&self, new_key: &[u8]) -> Result<()> {
         self.lock()
             .execute_batch(&format!("PRAGMA rekey = \"x'{}'\";", hex(new_key)))?;
+        Ok(())
+    }
+
+    /// Test seam: stamp the DB as if a future build had migrated it further.
+    #[cfg(test)]
+    pub(crate) fn set_user_version(&self, version: i64) -> Result<()> {
+        self.lock()
+            .execute_batch(&format!("PRAGMA user_version = {version}"))?;
         Ok(())
     }
 

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::{migrate, Record, SqliteStore, VaultStore};
+use super::{migrate, Record, SqliteStore, StoreError, VaultStore};
 use crate::crypto::{self, KdfParams, VaultKey};
 use crate::models::Entry;
 
@@ -187,6 +187,22 @@ fn rekey_reencrypts_db_in_place() {
     assert!(SqliteStore::open(&path, KEY).is_err());
     let store = SqliteStore::open(&path, KEY2).unwrap();
     assert_eq!(store.get("1").unwrap().unwrap().payload, b"durable");
+}
+
+// The one open failure that must NOT read as a wrong key: a vault stamped by
+// a newer build (user_version above this binary's migration list).
+#[test]
+fn future_schema_fails_as_schema_newer_not_wrong_key() {
+    let path = tmp_db();
+    {
+        let store = SqliteStore::open(&path, KEY).unwrap();
+        store.set_user_version(99).unwrap();
+    }
+    match SqliteStore::open(&path, KEY) {
+        Err(StoreError::SchemaNewer) => {}
+        Err(other) => panic!("expected SchemaNewer, got error: {other}"),
+        Ok(_) => panic!("expected SchemaNewer, but the open succeeded"),
+    }
 }
 
 #[test]

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -22,6 +22,16 @@ const isTooManyAttempts = (error: unknown): error is TooManyAttemptsError =>
   error !== null &&
   typeof (error as TooManyAttemptsError).retryAfterSecs === 'number'
 
+// Rust's `Error::VaultTooNew` (see error.rs) — the vault's schema is ahead of
+// this build. Shown as its own message: blaming the password would be wrong.
+const isVaultTooNew = (error: unknown): boolean =>
+  error === 'vault requires a newer version of the app'
+
+const unlockError = (error: unknown): string =>
+  isVaultTooNew(error)
+    ? t('Vault needs a newer version of Swifty')
+    : t('Incorrect Master Password')
+
 const lockedMessage = (seconds: number) =>
   `${t('Too many failed attempts')}. ${t('Try again in')} ${seconds}s`
 
@@ -49,7 +59,7 @@ export function Auth({ touchID }: Props) {
           setRetryAfter(err.retryAfterSecs)
           setError(lockedMessage(err.retryAfterSecs))
         } else {
-          setError(t('Incorrect Master Password'))
+          setError(unlockError(err))
         }
       })
   }
@@ -59,7 +69,7 @@ export function Auth({ touchID }: Props) {
     // already rate-limits it), so it stays available even while locked out.
     unlockBiometric()
       .then(result => enterMain(result))
-      .catch(() => setError(t('Incorrect Master Password')))
+      .catch((err: unknown) => setError(unlockError(err)))
   }
 
   return (

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -9,6 +9,7 @@
   "Repeat New Password": "Repeat New Password",
   "Confirm Master Password": "Confirm Master Password",
   "Incorrect Master Password": "Incorrect Master Password",
+  "Vault needs a newer version of Swifty": "Vault needs a newer version of Swifty",
   "Too many failed attempts": "Too many failed attempts",
   "Try again in": "Try again in",
   "Current password is invalid": "Current password is invalid",

--- a/src/test/auth.test.tsx
+++ b/src/test/auth.test.tsx
@@ -32,6 +32,17 @@ describe('Auth', () => {
     expect(await screen.findByText('Incorrect Master Password')).toBeInTheDocument()
   })
 
+  it('names the real problem when the vault schema is newer than the app', async () => {
+    // Rust's Error::VaultTooNew serializes as this exact string (error.rs).
+    vi.mocked(unlock).mockRejectedValue('vault requires a newer version of the app')
+    renderWithStore(<Auth touchID={false} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Master Password'), 'right{Enter}')
+
+    expect(await screen.findByText('Vault needs a newer version of Swifty')).toBeInTheDocument()
+    expect(screen.queryByText('Incorrect Master Password')).not.toBeInTheDocument()
+  })
+
   it('disables the input and shows a countdown on too many attempts', async () => {
     vi.mocked(unlock).mockRejectedValue({ retryAfterSecs: 2 })
     renderWithStore(<Auth touchID={false} />)


### PR DESCRIPTION
## Summary
Rescue PR: **#283 was merged into `feat/site-favicons` after that base had already landed**, so its content never reached `v1-0-0` (same stranding as #277 and #282). This is a clean cherry-pick of its single commit `5a573d3` onto current `v1-0-0` — no new changes.

- `StoreError::SchemaNewer` + `PRAGMA user_version > schema_version()` guard in `SqliteStore::open`
- `Error::VaultTooNew` mapped in `open_with_key` instead of flattening into `InvalidPassword`
- Frontend: both unlock paths show *Vault needs a newer version of Swifty*
- Tests: `future_schema_fails_as_schema_newer_not_wrong_key` (Rust) + honest-message assertion (vitest)

## Gates
109 cargo tests · clippy `-D warnings` clean · fmt clean · 132 vitest · tsc clean

## Note
#284 (sync merge primitives) touches the same store files — whichever of the two merges second will need a trivial conflict resolution. Recommend enabling **Settings → Automatically delete head branches** to stop this recurring stranding for good.