### PR TITLE
feat(sync): swsync pack format + fresh-install restore

### DIFF
--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -80,7 +80,9 @@ fn gdrive_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(GDRIVE_FILE))
 }
 
-fn kdf_sidecar_path(app: &AppHandle) -> Result<PathBuf> {
+// Public because the sync restore path addresses the sidecar by path (its core
+// runs without an `AppHandle`) rather than duplicating the layout constants.
+pub fn kdf_sidecar_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_dir(app)?.join(KDF_SIDECAR_FILE))
 }
 
@@ -98,6 +100,19 @@ pub fn read_kdf_sidecar(app: &AppHandle) -> Result<Option<String>> {
 // crash never leaves it truncated.
 pub fn write_kdf_sidecar(app: &AppHandle, json: &str) -> Result<()> {
     atomic_write_file(&kdf_sidecar_path(app)?, json)
+}
+
+// Remove a SQLite database and its WAL/SHM siblings, ignoring whatever is
+// already absent. Both callers (the pack scratch snapshot, the failed-restore
+// rollback) must leave no *half* a database behind: a stale `-wal` beside a
+// missing or recreated main file is its own corruption, not a clean slate.
+pub fn remove_db_files(path: &Path) {
+    let _ = fs::remove_file(path);
+    for suffix in ["-wal", "-shm"] {
+        let mut sibling = path.as_os_str().to_owned();
+        sibling.push(suffix);
+        let _ = fs::remove_file(PathBuf::from(sibling));
+    }
 }
 
 fn lockout_sidecar_path(app: &AppHandle) -> Result<PathBuf> {
@@ -125,7 +140,7 @@ pub fn write_lockout_sidecar(app: &AppHandle, json: &str) -> Result<()> {
 // complete old bytes or the complete new bytes — never a truncated/empty file.
 // A leftover `<path>.tmp` (from a crash before the rename) is ignored by readers,
 // which only ever open the target path.
-fn atomic_write_file(path: &Path, data: &str) -> Result<()> {
+pub fn atomic_write_file(path: &Path, data: &str) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| Error::Other("sidecar path has no parent directory".into()))?;

--- a/src-tauri/src/store/mod.rs
+++ b/src-tauri/src/store/mod.rs
@@ -17,7 +17,7 @@ pub mod migrate;
 mod tests;
 
 pub use hash::record_hash;
-pub use sqlite::SqliteStore;
+pub use sqlite::{SqliteStore, SYNC_META_PREFIX};
 
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src-tauri/src/store/sqlite.rs
+++ b/src-tauri/src/store/sqlite.rs
@@ -68,6 +68,12 @@ const META_UPSERT: &str = "INSERT INTO meta (key, value) VALUES (?1, ?2)
 // local write since the last clear.
 const DIRTY_KEY: &str = "sync_dirty";
 
+/// Namespace for every device-local sync bookkeeping key in `meta` (the dirty
+/// flag, and the last-sync state the engine records). Grouped under one prefix
+/// so a restore can scrub the lot without enumerating them — a snapshot carries
+/// the *source* device's bookkeeping, which is meaningless on the target.
+pub const SYNC_META_PREFIX: &str = "sync_";
+
 pub struct SqliteStore {
     conn: Mutex<Connection>,
 }
@@ -251,6 +257,18 @@ impl SqliteStore {
         self.lock()
             .execute("DELETE FROM meta WHERE key = ?1", params![DIRTY_KEY])?;
         Ok(())
+    }
+
+    /// Delete every `meta` row whose key starts with `prefix`, returning how
+    /// many were removed.
+    ///
+    /// Matched with `substr`, not `LIKE`: `_` is a LIKE wildcard, so the literal
+    /// prefix `sync_` would also match `syncX…` — a silent over-delete.
+    pub fn meta_delete_prefix(&self, prefix: &str) -> Result<usize> {
+        Ok(self.lock().execute(
+            "DELETE FROM meta WHERE substr(key, 1, length(?1)) = ?1",
+            params![prefix],
+        )?)
     }
 
     /// Hard-delete tombstones deleted before `cutoff_ms`, returning the number

--- a/src-tauri/src/store/tests.rs
+++ b/src-tauri/src/store/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::{migrate, record_hash, Record, SqliteStore, StoreError, VaultStore};
+use super::{migrate, record_hash, Record, SqliteStore, StoreError, VaultStore, SYNC_META_PREFIX};
 use crate::crypto::{self, KdfParams, VaultKey};
 use crate::models::Entry;
 
@@ -732,6 +732,29 @@ fn purge_tombstones_before_spares_live_and_recent_rows() {
         .collect();
     ids.sort();
     assert_eq!(ids, ["live", "recent"]);
+}
+
+// Restore scrubs the source device's sync bookkeeping by prefix. The match must
+// be a literal prefix — `_` is a LIKE wildcard, so a naive `LIKE 'sync_%'` would
+// also eat `syncopation`, and the dirty flag must fall inside the namespace or
+// the restored vault starts life believing it has unpushed work.
+#[test]
+fn meta_delete_prefix_removes_only_the_namespace() {
+    let store = SqliteStore::open(&tmp_db(), KEY).unwrap();
+    store.upsert(&rec("1", b"x")).unwrap(); // sets sync_dirty
+    store.meta_set("sync_last_digest", "deadbeef").unwrap();
+    store.meta_set("syncopation", "keep").unwrap();
+    store.meta_set("kdf", "argon2id").unwrap();
+
+    assert_eq!(store.meta_delete_prefix(SYNC_META_PREFIX).unwrap(), 2);
+
+    assert!(!store.is_dirty().unwrap());
+    assert_eq!(store.meta_get("sync_last_digest").unwrap(), None);
+    assert_eq!(
+        store.meta_get("syncopation").unwrap().as_deref(),
+        Some("keep")
+    );
+    assert_eq!(store.meta_get("kdf").unwrap().as_deref(), Some("argon2id"));
 }
 
 #[test]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -6,6 +6,8 @@
 mod auth;
 mod drive;
 pub mod merge;
+pub mod pack;
+pub mod restore;
 
 use reqwest::Client;
 use tauri::{async_runtime::block_on, AppHandle};

--- a/src-tauri/src/sync/pack.rs
+++ b/src-tauri/src/sync/pack.rs
@@ -1,0 +1,418 @@
+//! `vault.swsync` — the single-file sync exchange artifact.
+//!
+//! Byte layout:
+//!
+//! ```text
+//! "SWSY"  | format | kdf_len  | kdf params JSON | snapshot
+//! 4 bytes | u8     | u32 (LE) | kdf_len bytes   | rest of file
+//! ```
+//!
+//! The header is plaintext **by design**. KDF parameters are not secret (the
+//! `.kdbx` header carries the same thing in the clear), and they are precisely
+//! what a fresh install must read *before* it can derive a key — a chicken/egg
+//! the header exists to break. Everything after it is the SQLCipher snapshot,
+//! ciphertext end to end, so nothing else leaks: no titles, no hosts, not even
+//! the entry count.
+//!
+//! There is no compression layer. The body is ciphertext, which does not
+//! compress, so a codec would only add a failure mode and a decode cost.
+//!
+//! This module is deliberately pure — paths and bytes, no `AppHandle`, no Tauri
+//! types — so the Drive provider can reuse it and the tests can drive it
+//! directly.
+
+// The pack half of this module is consumed by the Drive provider in the next PR;
+// only the tests and the restore path call into it today.
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::crypto::KdfParams;
+use crate::storage;
+use crate::store::SqliteStore;
+
+/// The remote file name this format is stored under.
+pub const FILE_NAME: &str = "vault.swsync";
+
+const MAGIC: &[u8; 4] = b"SWSY";
+const FORMAT_V1: u8 = 1;
+const HEADER_LEN: usize = MAGIC.len() + 1 + 4;
+
+// A KDF descriptor is a ~150-byte JSON object. The cap turns a corrupt or
+// hostile length field into an error instead of a multi-gigabyte allocation.
+const MAX_KDF_LEN: usize = 64 * 1024;
+
+// The snapshot has no length field — it is "the rest of the file" — so a
+// half-finished upload still parses structurally. This is the one cheap check
+// that catches it: a SQLite database is always a whole number of pages, and 512
+// is the smallest page size SQLite supports, so any real database body is a
+// multiple of it. Catching truncation *here* matters because at open time every
+// failure looks like a wrong key, and telling a user their master password is
+// wrong when the download was short is the misdiagnosis this app cannot afford.
+const SQLITE_MIN_PAGE: usize = 512;
+
+/// Why a `.swsync` file could not be read. Messages are user-safe: they can be
+/// surfaced verbatim without naming offsets, paths, or key material.
+#[derive(Debug, thiserror::Error)]
+pub enum PackError {
+    #[error("not a Swifty sync file")]
+    BadMagic,
+
+    // Kept apart from the corruption cases so a future format v2 reads as
+    // "update the app", never as "your remote vault is damaged".
+    #[error("sync file was written by a newer version of the app")]
+    UnknownVersion(u8),
+
+    #[error("sync file is truncated")]
+    Truncated,
+
+    #[error("sync file header is implausibly large")]
+    KdfTooLarge(usize),
+
+    #[error("sync file has an unreadable key descriptor")]
+    BadKdf,
+
+    #[error("sync file contains no vault data")]
+    EmptySnapshot,
+
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Store(String),
+}
+
+pub type Result<T> = std::result::Result<T, PackError>;
+
+impl From<PackError> for crate::error::Error {
+    fn from(e: PackError) -> Self {
+        crate::error::Error::Other(e.to_string())
+    }
+}
+
+/// A parsed `.swsync` file: its plaintext KDF descriptor and the encrypted
+/// database snapshot that follows it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unpacked {
+    pub kdf_params_json: String,
+    pub snapshot: Vec<u8>,
+}
+
+/// Wrap a SQLCipher snapshot in the `.swsync` header.
+pub fn pack(kdf_params_json: &str, snapshot: &[u8]) -> Vec<u8> {
+    let kdf = kdf_params_json.as_bytes();
+    let mut out = Vec::with_capacity(HEADER_LEN + kdf.len() + snapshot.len());
+    out.extend_from_slice(MAGIC);
+    out.push(FORMAT_V1);
+    out.extend_from_slice(&(kdf.len() as u32).to_le_bytes());
+    out.extend_from_slice(kdf);
+    out.extend_from_slice(snapshot);
+    out
+}
+
+/// Parse a `.swsync` file.
+///
+/// Every field is validated before it is trusted, because the input is a file
+/// pulled from a remote drive: it can be truncated by a failed upload, replaced
+/// by an unrelated file, or written by a build that does not exist yet. Any of
+/// those must produce an error, never a panic and never a partial read.
+pub fn unpack(bytes: &[u8]) -> Result<Unpacked> {
+    if bytes.get(..MAGIC.len()).is_some_and(|m| m != MAGIC) {
+        return Err(PackError::BadMagic);
+    }
+    let header = bytes.get(..HEADER_LEN).ok_or(PackError::Truncated)?;
+
+    let format = header[MAGIC.len()];
+    if format != FORMAT_V1 {
+        return Err(PackError::UnknownVersion(format));
+    }
+
+    let kdf_len = u32::from_le_bytes(header[MAGIC.len() + 1..HEADER_LEN].try_into().unwrap());
+    let kdf_len = kdf_len as usize;
+    if kdf_len > MAX_KDF_LEN {
+        return Err(PackError::KdfTooLarge(kdf_len));
+    }
+    // Capped above, so this addition cannot overflow.
+    let kdf_end = HEADER_LEN + kdf_len;
+
+    let kdf = bytes.get(HEADER_LEN..kdf_end).ok_or(PackError::Truncated)?;
+    let kdf_params_json = std::str::from_utf8(kdf)
+        .map_err(|_| PackError::BadKdf)?
+        .to_owned();
+    // Parsed, not just stored: a descriptor this build cannot derive from is
+    // worthless later, and failing here keeps the bad file out of the restore
+    // path entirely.
+    KdfParams::from_json(&kdf_params_json).map_err(|_| PackError::BadKdf)?;
+
+    let snapshot = &bytes[kdf_end..];
+    if snapshot.is_empty() {
+        return Err(PackError::EmptySnapshot);
+    }
+    if snapshot.len() % SQLITE_MIN_PAGE != 0 {
+        return Err(PackError::Truncated);
+    }
+
+    Ok(Unpacked {
+        kdf_params_json,
+        snapshot: snapshot.to_vec(),
+    })
+}
+
+/// Pack a live store: take a consistent snapshot through the online-backup API
+/// into `scratch_dir`, then wrap it.
+///
+/// The snapshot has to land on disk first — SQLite's backup API writes to a
+/// file, not a buffer — but it is SQLCipher ciphertext from the first byte, so
+/// an interrupted cleanup leaks nothing beyond a stray encrypted blob. It is
+/// still always removed, on the error paths too, via the [`Scratch`] guard.
+pub fn pack_store(
+    store: &SqliteStore,
+    key: &[u8],
+    kdf_params_json: &str,
+    scratch_dir: &Path,
+) -> Result<Vec<u8>> {
+    fs::create_dir_all(scratch_dir)?;
+    let scratch = Scratch(scratch_dir.join(scratch_name()));
+
+    store
+        .snapshot_to(&scratch.0, key)
+        .map_err(|e| PackError::Store(e.to_string()))?;
+
+    let snapshot = fs::read(&scratch.0)?;
+    if snapshot.is_empty() {
+        return Err(PackError::EmptySnapshot);
+    }
+    Ok(pack(kdf_params_json, &snapshot))
+}
+
+// Unique per call so two concurrent packs (a scheduled sync and a manual one)
+// cannot write over each other's snapshot.
+fn scratch_name() -> String {
+    static N: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "swsync-{}-{}.db",
+        std::process::id(),
+        N.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+// Removes the scratch snapshot however `pack_store` returns.
+struct Scratch(PathBuf);
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        storage::remove_db_files(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::VaultStore;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const KEY: &[u8] = &[0x33; 32];
+
+    fn kdf_json() -> String {
+        KdfParams::argon2id(b"salt-0123456789012345", 256, 1, 1)
+            .to_json()
+            .unwrap()
+    }
+
+    fn tmp_dir() -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "swifty-pack-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn record(id: &str, payload: &[u8]) -> crate::store::Record {
+        crate::store::Record {
+            id: id.into(),
+            kind: "login".into(),
+            title: "Example".into(),
+            tags: "[]".into(),
+            url_host: "example.com".into(),
+            created_at: 100,
+            updated_at: 200,
+            deleted_at: None,
+            payload: payload.to_vec(),
+            card_brand: None,
+        }
+    }
+
+    fn seeded_store(dir: &Path) -> SqliteStore {
+        let store = SqliteStore::open(&dir.join("vault.db"), KEY).unwrap();
+        store
+            .import(&[record("1", b"one"), record("2", b"two")])
+            .unwrap();
+        store
+    }
+
+    // A stand-in database body: page-aligned, as any real snapshot is.
+    fn body() -> Vec<u8> {
+        (0..2 * SQLITE_MIN_PAGE).map(|i| (i * 31) as u8).collect()
+    }
+
+    #[test]
+    fn header_round_trips() {
+        let json = kdf_json();
+        let snapshot = body();
+
+        let got = unpack(&pack(&json, &snapshot)).unwrap();
+        assert_eq!(got.kdf_params_json, json);
+        assert_eq!(got.snapshot, snapshot);
+    }
+
+    #[test]
+    fn pack_store_round_trips_through_a_reopened_snapshot() {
+        let dir = tmp_dir();
+        let source = seeded_store(&dir);
+        let scratch = dir.join("scratch");
+
+        let bytes = pack_store(&source, KEY, &kdf_json(), &scratch).unwrap();
+        let unpacked = unpack(&bytes).unwrap();
+        assert_eq!(unpacked.kdf_params_json, kdf_json());
+
+        let restored_path = tmp_dir().join("restored.db");
+        fs::write(&restored_path, &unpacked.snapshot).unwrap();
+        let restored = SqliteStore::open(&restored_path, KEY).unwrap();
+
+        assert_eq!(
+            restored.state_digest().unwrap(),
+            source.state_digest().unwrap()
+        );
+        assert_eq!(restored.get("1").unwrap().unwrap().payload, b"one");
+
+        // The scratch snapshot is cleaned up, siblings included.
+        assert!(fs::read_dir(&scratch).unwrap().next().is_none());
+    }
+
+    // The guard is what makes every `pack_store` exit — including the `?` early
+    // returns — leave no encrypted scratch file behind.
+    #[test]
+    fn the_scratch_guard_removes_the_snapshot_and_its_siblings() {
+        let dir = tmp_dir();
+        let base = dir.join("snap.db");
+        let siblings = [
+            base.clone(),
+            dir.join("snap.db-wal"),
+            dir.join("snap.db-shm"),
+        ];
+        for p in &siblings {
+            fs::write(p, b"x").unwrap();
+        }
+
+        drop(Scratch(base));
+
+        for p in &siblings {
+            assert!(!p.exists(), "{} survived the guard", p.display());
+        }
+    }
+
+    #[test]
+    fn pack_store_errors_cleanly_when_the_scratch_dir_cannot_be_created() {
+        let dir = tmp_dir();
+        let store = seeded_store(&dir);
+        // A file where the scratch directory should be.
+        let scratch = dir.join("occupied");
+        fs::write(&scratch, b"not a directory").unwrap();
+
+        assert!(matches!(
+            pack_store(&store, KEY, &kdf_json(), &scratch),
+            Err(PackError::Io(_))
+        ));
+    }
+
+    // Every prefix of a valid file, byte by byte. Anything cut inside the header
+    // or the descriptor is structurally impossible and must be refused; a cut
+    // inside the body is caught by the page-alignment check unless it happens to
+    // land exactly on a page boundary, which is the one case the format cannot
+    // see (there is no body length field) and the SQLCipher open rejects instead.
+    #[test]
+    fn truncation_at_every_length_errors_without_panicking() {
+        let full = pack(&kdf_json(), &body());
+        let body_start = full.len() - body().len();
+
+        for len in 0..full.len() {
+            let result = unpack(&full[..len]);
+            let page_aligned_body = len > body_start && (len - body_start) % SQLITE_MIN_PAGE == 0;
+            assert_eq!(
+                result.is_err(),
+                !page_aligned_body,
+                "a {len}-byte prefix was classified wrongly"
+            );
+        }
+        assert!(unpack(&full).is_ok());
+    }
+
+    #[test]
+    fn a_body_that_is_not_a_whole_number_of_pages_is_refused() {
+        let mut short = pack(&kdf_json(), &body());
+        short.truncate(short.len() - 1);
+        assert!(matches!(unpack(&short), Err(PackError::Truncated)));
+    }
+
+    #[test]
+    fn garbage_of_every_length_errors_without_panicking() {
+        let garbage: Vec<u8> = (0u16..=1024).map(|b| b.wrapping_mul(37) as u8).collect();
+        for len in 0..garbage.len() {
+            assert!(unpack(&garbage[..len]).is_err());
+        }
+    }
+
+    #[test]
+    fn wrong_magic_is_not_reported_as_corruption() {
+        let mut bytes = pack(&kdf_json(), b"snapshot");
+        bytes[0] = b'X';
+        assert!(matches!(unpack(&bytes), Err(PackError::BadMagic)));
+    }
+
+    #[test]
+    fn unknown_format_version_is_its_own_error() {
+        let mut bytes = pack(&kdf_json(), b"snapshot");
+        bytes[MAGIC.len()] = 2;
+        assert!(matches!(unpack(&bytes), Err(PackError::UnknownVersion(2))));
+    }
+
+    #[test]
+    fn kdf_length_beyond_the_cap_is_refused_before_allocating() {
+        let mut bytes = pack(&kdf_json(), b"snapshot");
+        bytes[5..9].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(matches!(unpack(&bytes), Err(PackError::KdfTooLarge(_))));
+    }
+
+    #[test]
+    fn kdf_length_past_the_buffer_reads_as_truncated() {
+        let mut bytes = pack(&kdf_json(), b"snapshot");
+        // Under the cap, but longer than what the file actually holds.
+        bytes[5..9].copy_from_slice(&(MAX_KDF_LEN as u32 - 1).to_le_bytes());
+        assert!(matches!(unpack(&bytes), Err(PackError::Truncated)));
+    }
+
+    #[test]
+    fn a_header_with_no_snapshot_is_refused() {
+        assert!(matches!(
+            unpack(&pack(&kdf_json(), b"")),
+            Err(PackError::EmptySnapshot)
+        ));
+    }
+
+    #[test]
+    fn an_unparseable_kdf_descriptor_is_refused() {
+        assert!(matches!(
+            unpack(&pack("{\"algo\":\"rot13\"}", b"snapshot")),
+            Err(PackError::BadKdf)
+        ));
+        assert!(matches!(
+            unpack(&pack("not json at all", b"snapshot")),
+            Err(PackError::BadKdf)
+        ));
+    }
+}

--- a/src-tauri/src/sync/restore.rs
+++ b/src-tauri/src/sync/restore.rs
@@ -1,0 +1,302 @@
+//! Fresh-install restore: adopt a remote `.swsync` file as *the* local vault.
+//!
+//! This is the one path that installs a vault it did not create, and it only
+//! ever runs on an install that has none. A device that already holds a vault
+//! merges instead (the sync engine); replacing an existing DB with a remote
+//! snapshot would silently discard whatever had not been pushed yet.
+
+// Called by the Drive provider + unlock UI in the next PR.
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::Path;
+
+use tauri::AppHandle;
+
+use super::pack;
+use crate::crypto::{self, KdfParams, VaultKey};
+use crate::error::{Error, Result};
+use crate::storage;
+use crate::store::{SqliteStore, StoreError, SYNC_META_PREFIX};
+
+/// Restore the vault carried by `bytes` into this install's data dir.
+pub fn restore_from_pack(
+    app: &AppHandle,
+    bytes: &[u8],
+    password: &str,
+) -> Result<(VaultKey, SqliteStore)> {
+    restore_at(
+        &storage::db_path(app)?,
+        &storage::kdf_sidecar_path(app)?,
+        bytes,
+        password,
+    )
+}
+
+/// The path-level core of [`restore_from_pack`].
+///
+/// Sequence: refuse if a vault is already here, unpack, write the KDF sidecar,
+/// derive, write the snapshot, open. Opening is what validates the password —
+/// SQLCipher cannot read a byte under the wrong key — and what surfaces a
+/// snapshot from a future build as [`Error::VaultTooNew`] rather than as a
+/// wrong password.
+pub fn restore_at(
+    db_path: &Path,
+    sidecar_path: &Path,
+    bytes: &[u8],
+    password: &str,
+) -> Result<(VaultKey, SqliteStore)> {
+    // Hard guard, before anything is read or written. Not `db_exists` (which
+    // ignores a zero-length file): if anything at all sits at the vault path,
+    // this install is not the fresh install this path is for.
+    if db_path.exists() {
+        return Err(Error::Other(
+            "a local vault already exists on this device".into(),
+        ));
+    }
+
+    // Validated before the first write, so a bad file never touches the disk.
+    let unpacked = pack::unpack(bytes)?;
+
+    match install(db_path, sidecar_path, &unpacked, password) {
+        Ok(restored) => Ok(restored),
+        Err(e) => {
+            // Everything this function wrote goes away. A half-restored install
+            // is the worst outcome available: a sidecar whose params do not
+            // match the DB, or a DB that never finished, reads as "wrong master
+            // password" forever after, and the user has no way to tell that
+            // from actually mistyping it.
+            storage::remove_db_files(db_path);
+            let _ = fs::remove_file(sidecar_path);
+            Err(e)
+        }
+    }
+}
+
+// The write half, split out so `restore_at` has exactly one cleanup site.
+fn install(
+    db_path: &Path,
+    sidecar_path: &Path,
+    unpacked: &pack::Unpacked,
+    password: &str,
+) -> Result<(VaultKey, SqliteStore)> {
+    let params = KdfParams::from_json(&unpacked.kdf_params_json)?;
+
+    // Sidecar first, same invariant as `create_vault`: a DB must never exist
+    // without the descriptor needed to open it. Written verbatim from the
+    // header so the restored install derives byte-identically to the source.
+    storage::atomic_write_file(sidecar_path, &unpacked.kdf_params_json)?;
+
+    let key = VaultKey::Argon2 {
+        master: crypto::derive(password.as_bytes(), &params)?,
+    };
+
+    write_private(db_path, &unpacked.snapshot)?;
+
+    let store = SqliteStore::open(db_path, &key.sqlcipher_key()).map_err(|e| match e {
+        StoreError::SchemaNewer => Error::VaultTooNew,
+        _ => Error::InvalidPassword,
+    })?;
+
+    // The snapshot carries the *source* device's sync bookkeeping. Keeping it
+    // would have this install believe it had already synced state it has never
+    // seen; scrubbing by prefix keeps that true for keys the engine has not
+    // invented yet.
+    store
+        .meta_delete_prefix(SYNC_META_PREFIX)
+        .map_err(crate::commands::store_err)?;
+
+    Ok((key, store))
+}
+
+// Create the DB file 0600 from the outset — `SqliteStore::open` chmods it too,
+// but only after the bytes are already on disk and readable.
+fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut opts = fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+
+    let mut file = opts.open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::{Record, VaultStore};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    const PASSWORD: &str = "correct horse battery staple";
+
+    // Low-cost Argon2id keeps these tests fast; production uses the 64 MiB defaults.
+    fn params() -> KdfParams {
+        KdfParams::argon2id(b"salt-restore-0123456789012345678", 256, 1, 1)
+    }
+
+    fn key_for(password: &str) -> VaultKey {
+        VaultKey::Argon2 {
+            master: crypto::derive(password.as_bytes(), &params()).unwrap(),
+        }
+    }
+
+    fn tmp_dir() -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "swifty-restore-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn record(id: &str) -> Record {
+        Record {
+            id: id.into(),
+            kind: "login".into(),
+            title: "Example".into(),
+            tags: "[]".into(),
+            url_host: "example.com".into(),
+            created_at: 100,
+            updated_at: 200,
+            deleted_at: None,
+            payload: b"sealed".to_vec(),
+            card_brand: None,
+        }
+    }
+
+    // A source vault plus its packed bytes — what the remote drive would hold.
+    fn packed_source() -> (SqliteStore, Vec<u8>) {
+        let dir = tmp_dir();
+        let key = key_for(PASSWORD);
+        let store = SqliteStore::open(&dir.join("vault.db"), &key.sqlcipher_key()).unwrap();
+        store.import(&[record("1"), record("2")]).unwrap();
+        // Bookkeeping the restore must not inherit (`import` sets the dirty flag).
+        store.meta_set("sync_last_digest", "deadbeef").unwrap();
+        // …and app meta that it must keep.
+        store.meta_set("kdf", "argon2id").unwrap();
+
+        let bytes = pack::pack_store(
+            &store,
+            &key.sqlcipher_key(),
+            &params().to_json().unwrap(),
+            &dir.join("scratch"),
+        )
+        .unwrap();
+        (store, bytes)
+    }
+
+    // Where a fresh install's vault would go: an empty data dir.
+    fn fresh_target() -> (PathBuf, PathBuf) {
+        let dir = tmp_dir();
+        (dir.join("vault.db"), dir.join("vault.kdf.json"))
+    }
+
+    fn is_empty(dir: &Path) -> bool {
+        fs::read_dir(dir).unwrap().next().is_none()
+    }
+
+    #[test]
+    fn restores_a_packed_vault_onto_a_fresh_install() {
+        let (source, bytes) = packed_source();
+        let (db, sidecar) = fresh_target();
+
+        let (_, store) = restore_at(&db, &sidecar, &bytes, PASSWORD).unwrap();
+
+        assert_eq!(
+            store.state_digest().unwrap(),
+            source.state_digest().unwrap()
+        );
+        assert_eq!(store.list().unwrap().len(), 2);
+        assert_eq!(store.get("1").unwrap().unwrap().payload, b"sealed");
+        // The sidecar is the source's descriptor verbatim, so the next unlock
+        // derives the same key this restore just did.
+        assert_eq!(
+            fs::read_to_string(&sidecar).unwrap(),
+            params().to_json().unwrap()
+        );
+    }
+
+    #[test]
+    fn restore_scrubs_the_source_devices_sync_bookkeeping() {
+        let (_, bytes) = packed_source();
+        let (db, sidecar) = fresh_target();
+
+        let (_, store) = restore_at(&db, &sidecar, &bytes, PASSWORD).unwrap();
+
+        assert!(!store.is_dirty().unwrap());
+        assert_eq!(store.meta_get("sync_last_digest").unwrap(), None);
+        // Scrubbing is scoped to the prefix: app meta is untouched.
+        assert_eq!(store.meta_get("kdf").unwrap().as_deref(), Some("argon2id"));
+    }
+
+    #[test]
+    fn restore_refuses_when_a_vault_is_already_installed() {
+        let (_, bytes) = packed_source();
+        let (db, sidecar) = fresh_target();
+        fs::write(&db, b"an existing vault").unwrap();
+
+        assert!(restore_at(&db, &sidecar, &bytes, PASSWORD).is_err());
+        // Untouched: the local vault is authoritative, and no sidecar appeared.
+        assert_eq!(fs::read(&db).unwrap(), b"an existing vault");
+        assert!(!sidecar.exists());
+    }
+
+    #[test]
+    fn a_wrong_password_leaves_no_remnants_behind() {
+        let (_, bytes) = packed_source();
+        let (db, sidecar) = fresh_target();
+
+        match restore_at(&db, &sidecar, &bytes, "wrong password").map(|_| ()) {
+            Err(Error::InvalidPassword) => {}
+            other => panic!("expected InvalidPassword, got {other:?}"),
+        }
+        // Exactly as the install started — nothing to masquerade as a broken vault.
+        assert!(is_empty(db.parent().unwrap()));
+    }
+
+    #[test]
+    fn a_snapshot_from_a_future_build_says_so_and_still_cleans_up() {
+        let dir = tmp_dir();
+        let key = key_for(PASSWORD);
+        let store = SqliteStore::open(&dir.join("vault.db"), &key.sqlcipher_key()).unwrap();
+        store.import(&[record("1")]).unwrap();
+        store.set_user_version(99).unwrap();
+        let bytes = pack::pack_store(
+            &store,
+            &key.sqlcipher_key(),
+            &params().to_json().unwrap(),
+            &dir.join("scratch"),
+        )
+        .unwrap();
+
+        let (db, sidecar) = fresh_target();
+        match restore_at(&db, &sidecar, &bytes, PASSWORD).map(|_| ()) {
+            Err(Error::VaultTooNew) => {}
+            other => panic!("expected VaultTooNew, got {other:?}"),
+        }
+        assert!(is_empty(db.parent().unwrap()));
+    }
+
+    #[test]
+    fn a_corrupt_pack_is_rejected_before_anything_is_written() {
+        let (_, bytes) = packed_source();
+        let (db, sidecar) = fresh_target();
+
+        assert!(restore_at(&db, &sidecar, &bytes[..bytes.len() / 2], PASSWORD).is_err());
+        assert!(is_empty(db.parent().unwrap()));
+    }
+}


### PR DESCRIPTION
PR 2 of 3 of the [Drive Sync v2 design](https://claude.ai/code/artifact/03870f8c-7a86-47d8-8c46-ed5e46ed8518).

Adds the sync exchange-file format (`vault.swsync`) and the fresh-install restore path. Backend only — no Drive/network code, no UI wiring, no frontend changes. Those are PR 3.

## Byte layout

```text
"SWSY"  | format | kdf_len  | kdf params JSON | snapshot
4 bytes | u8 = 1 | u32 (LE) | kdf_len bytes   | rest of file
```

## Semantics

- **The header is plaintext by design.** KDF params are not secret (the `.kdbx` header carries the same thing in the clear) and they are precisely what a fresh install must read *before* it can derive a key — a chicken/egg the header exists to break. Everything after the header is the SQLCipher snapshot, ciphertext end to end, so nothing else leaks: no titles, no hosts, not even the entry count. No compression layer either: the body is ciphertext, which does not compress, so a codec would only add a failure mode.
- **Strict parsing.** Exact magic; an unknown format version gets its own error ("written by a newer version of the app", never "corrupt"); `kdf_len` is capped at 64 KiB and bounds-checked; the descriptor must parse as `KdfParams`; the body must be non-empty. Truncated or garbage input errors cleanly — a byte-by-byte truncation fuzz over a valid pack is part of the suite.
- **Page-alignment check on the body** (one small addition beyond the spec'd validation). The snapshot has no length field — it is "the rest of the file" — so a half-finished upload parses structurally. A SQLite database is always a whole number of pages and 512 is the smallest page size SQLite supports, so any real body is a multiple of it. Catching truncation at unpack matters because at open time *every* failure looks like a wrong key, and telling a user their master password is wrong when the download was short is the misdiagnosis this app cannot afford.
- **`pack_store` always cleans up its scratch snapshot**, error paths included, via a `Drop` guard that also removes `-wal`/`-shm` siblings. The scratch file is ciphertext throughout, so even an interrupted cleanup leaks nothing.
- **Restore refuses if a local vault DB already exists.** Hard guard, first thing, before anything is read or written. An existing vault always merges (PR 3); it never gets replaced.
- **Sidecar before DB**, the same invariant as `create_vault`: a DB must never exist without the descriptor needed to open it. The sidecar is written verbatim from the header so the restored install derives byte-identically to the source.
- **Cleanup on any failure after files were written** — wrong password, corrupt snapshot, schema too new. The sidecar, the DB and its `-wal`/`-shm` all go away, leaving the install exactly as it started. A half-restored state that masquerades as "wrong password" forever after is the failure mode this codebase specifically fights.
- **Device-local meta is scrubbed** after a successful open: `meta_delete_prefix("sync_")` drops the source device's `sync_dirty` and any future `sync_*` bookkeeping the engine records. Scrubbing by prefix keeps restore future-proof. Matched with `substr`, not `LIKE` — `_` is a LIKE wildcard, so `LIKE 'sync_%'` would also eat `syncopation`.
- Restore's core is path-based (`restore_at`) with a thin `AppHandle` wrapper (`restore_from_pack`), so it is testable without a Tauri harness and reusable by PR 3.

## Public API

```rust
// sync::pack
pub const FILE_NAME: &str = "vault.swsync";
pub struct Unpacked { pub kdf_params_json: String, pub snapshot: Vec<u8> }
pub enum PackError { BadMagic, UnknownVersion(u8), Truncated, KdfTooLarge(usize), BadKdf, EmptySnapshot, Io(std::io::Error), Store(String) }
pub fn pack(kdf_params_json: &str, snapshot: &[u8]) -> Vec<u8>;
pub fn unpack(bytes: &[u8]) -> Result<Unpacked, PackError>;
pub fn pack_store(store: &SqliteStore, key: &[u8], kdf_params_json: &str, scratch_dir: &Path) -> Result<Vec<u8>, PackError>;

// sync::restore
pub fn restore_from_pack(app: &AppHandle, bytes: &[u8], password: &str) -> Result<(VaultKey, SqliteStore)>;
pub fn restore_at(db_path: &Path, sidecar_path: &Path, bytes: &[u8], password: &str) -> Result<(VaultKey, SqliteStore)>;

// store
pub const SYNC_META_PREFIX: &str = "sync_";
impl SqliteStore { pub fn meta_delete_prefix(&self, prefix: &str) -> Result<usize>; }

// storage (visibility widened for the path-level restore core)
pub fn kdf_sidecar_path(app: &AppHandle) -> Result<PathBuf>;
pub fn atomic_write_file(path: &Path, data: &str) -> Result<()>;
pub fn remove_db_files(path: &Path);
```

## Tests

`cargo test`: **124 -> 144**, all green. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

Pack:
- header round-trip (identical KDF JSON + snapshot bytes)
- `pack_store` round-trip: seeded store -> pack -> unpack -> write snapshot to a fresh path -> reopen with the same key -> `state_digest` equal to the source; scratch dir left empty
- the scratch `Drop` guard removes the snapshot and its `-wal`/`-shm` siblings
- `pack_store` errors cleanly when the scratch dir cannot be created
- truncation at every length of a valid pack, classified exactly (header/descriptor cuts refused; page-aligned body cuts are the one case the format cannot see)
- a body that is not a whole number of pages is refused
- 1 KiB of garbage truncated at every length — no panics
- wrong magic, unknown format version, `kdf_len` over the cap, `kdf_len` past the buffer, empty snapshot, unparseable descriptor — each its own distinct error

Restore:
- fresh install + correct password: vault opens, entries present, digest matches the source, sidecar byte-identical to the header
- `sync_dirty` and `sync_*` scrubbed; non-sync app meta survives
- refuses when a DB already exists, and changes nothing (existing DB untouched, no sidecar appears)
- wrong password -> `InvalidPassword` and the data dir is left completely empty
- future-schema snapshot (stamped via the `set_user_version` seam before packing) -> `VaultTooNew`, and cleanup ran
- corrupt pack rejected before anything is written

Store:
- `meta_delete_prefix` removes only the namespace (`syncopation` survives, the dirty flag does not)

## Stacking

Stacked on #284 (`feat/sync-merge-primitives`), which this builds on (`merge_records`, `state_digest`, `record_hash`, the `sync_dirty` meta key, `purge_tombstones_before`). Based on `v1-0-0` deliberately rather than on that branch, so the diff shows #284's commits until it merges, after which it shrinks to just this work.