### PR TITLE
feat(e2e): per-spec isolation, spec helpers, testid hooks

### DIFF
--- a/docs/v1-next.md
+++ b/docs/v1-next.md
@@ -90,7 +90,10 @@ regressions in the core flows.
 
 ---
 
-## 3. E2E specs port from legacy ❌
+## 3. E2E specs port from legacy 🟡
+
+> Live coverage matrix (legacy floor, planned additions, and what is deliberately not
+> e2e-able): [`tests/e2e/COVERAGE.md`](../tests/e2e/COVERAGE.md).
 
 Port the legacy Electron E2E coverage onto the new `tauri-plugin-webdriver` harness landed in
 the remediation phase (`tests/e2e/`, mirrors the reticle app; one smoke spec today). The legacy

--- a/src-tauri/src/commands/e2e.rs
+++ b/src-tauri/src/commands/e2e.rs
@@ -1,0 +1,166 @@
+//! Per-spec state reset for the E2E suite.
+//!
+//! The suite runs ONE app process against ONE data dir for the whole run, so
+//! without a reset seam every spec inherits whatever vault the previous spec
+//! left behind. This command gives each spec an explicit starting state.
+//!
+//! Triple-gated, because a "wipe the data dir" command is exactly the thing that
+//! must never reach a user:
+//!   1. `#[cfg(debug_assertions)]` on the module *and* on the `invoke_handler`
+//!      registration in `lib.rs` — a release binary does not contain it at all.
+//!      (The suite drives the debug binary, which is also the only build that
+//!      carries the in-app WebDriver server.)
+//!   2. `SWIFTY_E2E=1` must be set — a developer's own `tauri dev` run is a
+//!      debug build too, and must not expose this to a stray `invoke`.
+//!   3. `SWIFTY_DB_DIR` must be set — the wipe targets *that* dir and nothing
+//!      else, so even a debug binary run by hand can never touch the real
+//!      app-data dir (which is what `storage::app_dir` falls back to).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tauri::{AppHandle, State};
+
+use crate::commands::create_vault;
+use crate::error::{Error, Result};
+use crate::state::AppState;
+
+// The state a spec wants to start from.
+enum ResetMode {
+    // No vault on disk: the app boots into the first-run setup choice screen.
+    Pristine,
+    // A freshly created, entry-less vault, left locked: the app boots into unlock.
+    Empty,
+}
+
+impl ResetMode {
+    fn parse(mode: &str) -> Result<Self> {
+        match mode {
+            "pristine" => Ok(Self::Pristine),
+            "empty" => Ok(Self::Empty),
+            other => Err(Error::Other(format!("unknown e2e reset mode: {other}"))),
+        }
+    }
+}
+
+// Gates 2 and 3. Returns the one directory this command is allowed to erase.
+// `storage::app_dir` returns `SWIFTY_DB_DIR` verbatim when it is set, so the dir
+// resolved here is by construction the same one the app reads and writes.
+fn e2e_data_dir() -> Result<PathBuf> {
+    if std::env::var("SWIFTY_E2E").as_deref() != Ok("1") {
+        return Err(Error::Other("e2e_reset requires SWIFTY_E2E=1".into()));
+    }
+    match std::env::var("SWIFTY_DB_DIR") {
+        Ok(dir) if !dir.is_empty() => Ok(PathBuf::from(dir)),
+        _ => Err(Error::Other("e2e_reset requires SWIFTY_DB_DIR".into())),
+    }
+}
+
+// Empty the directory without removing the directory itself (the app already
+// holds its path). Covers the DB triple, both sidecars, the biometric marker,
+// cached icons, sync scratch — everything, so no spec inherits a stray file.
+fn wipe_dir(dir: &Path) -> Result<()> {
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+        return Ok(());
+    }
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        // `file_type` here does not follow symlinks, so a link is unlinked
+        // rather than recursed into.
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(entry.path())?;
+        } else {
+            fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+/// Reset the E2E data dir to `mode`. `password` is required for `"empty"`.
+///
+/// The frontend reloads itself after this resolves (see `src/lib/e2e.ts`), so
+/// the app re-runs `is_initialized` against the state left here.
+#[tauri::command]
+pub fn e2e_reset(
+    mode: String,
+    password: Option<String>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<()> {
+    let dir = e2e_data_dir()?;
+    let mode = ResetMode::parse(&mode)?;
+
+    // Drop the session BEFORE touching the files. It owns the open SQLCipher
+    // connection; deleting the DB out from under a live handle leaves the
+    // connection writing WAL frames for a file that no longer exists, and the
+    // next `create_vault` would open beside them.
+    state.session.lock().unwrap().clear();
+
+    wipe_dir(&dir)?;
+
+    match mode {
+        ResetMode::Pristine => Ok(()),
+        ResetMode::Empty => {
+            let password = password
+                .ok_or_else(|| Error::Other("e2e_reset mode \"empty\" needs a password".into()))?;
+            // Same path the real setup command uses, so the vault an "empty"
+            // spec unlocks is byte-for-byte what a user's first run produces.
+            let (_key, store) = create_vault(&app, &password)?;
+            // Leave the session locked: the reload lands on the unlock screen.
+            drop(store);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn tmp_dir() -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "swifty-e2e-reset-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_accepts_only_the_two_known_modes() {
+        assert!(matches!(
+            ResetMode::parse("pristine"),
+            Ok(ResetMode::Pristine)
+        ));
+        assert!(matches!(ResetMode::parse("empty"), Ok(ResetMode::Empty)));
+        assert!(ResetMode::parse("Pristine").is_err());
+        assert!(ResetMode::parse("").is_err());
+    }
+
+    #[test]
+    fn wipe_removes_files_and_subdirs_but_keeps_the_dir() {
+        let dir = tmp_dir();
+        fs::write(dir.join("vault.db"), "db").unwrap();
+        fs::write(dir.join("vault.db-wal"), "wal").unwrap();
+        fs::write(dir.join("vault.kdf.json"), "{}").unwrap();
+        fs::create_dir_all(dir.join("icons")).unwrap();
+        fs::write(dir.join("icons/example.png"), "png").unwrap();
+
+        wipe_dir(&dir).unwrap();
+
+        assert!(dir.exists(), "the data dir itself must survive");
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn wipe_recreates_a_missing_dir() {
+        let dir = tmp_dir();
+        fs::remove_dir_all(&dir).unwrap();
+        wipe_dir(&dir).unwrap();
+        assert!(dir.is_dir());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,10 @@
 pub mod audit;
 pub mod auth;
 pub mod clipboard;
+// E2E-only reset seam. Compiled out of release builds entirely (see e2e.rs for
+// the full gating rationale); the registration in lib.rs carries the same cfg.
+#[cfg(debug_assertions)]
+pub mod e2e;
 pub mod generator;
 pub mod import;
 pub mod sync;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,12 @@ pub fn run() {
             commands::sync::sync_now,
             commands::sync::sync_import,
             commands::sync::sync_status,
+            // E2E-only vault reset. `generate_handler!` honours per-command
+            // attributes, so in a release build the match arm — and with it the
+            // only reference to the (also cfg'd-out) module — simply is not
+            // generated. See `commands/e2e.rs` for the runtime gates.
+            #[cfg(debug_assertions)]
+            commands::e2e::e2e_reset,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -76,7 +76,18 @@ export function Auth({ touchID }: Props) {
     <>
       <Controls />
       <AuthShell meta={`${t('offline')} · aes-256-gcm`}>
-        <Eyebrow tone={error ? 'bad' : 'muted'}>
+        {/* One element carries all three states, so the testid names which one
+            is showing rather than forcing specs to parse the message. */}
+        <Eyebrow
+          tone={error ? 'bad' : 'muted'}
+          testid={
+            retryAfter > 0
+              ? 'unlock-lockout'
+              : error
+                ? 'unlock-error'
+                : 'unlock-status'
+          }
+        >
           {error ?? t('Vault sealed')}
         </Eyebrow>
         <div className="mt-8">

--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -49,7 +49,10 @@ export default function Score({ audit }: Props) {
       <div className="text-center">
         {/* 34px is a documented one-off: the dial numeral sits above the 24px
             display tier so it fills the ring. */}
-        <div className="text-[34px] font-semibold tracking-display text-text">
+        <div
+          data-testid="audit-score"
+          className="text-[34px] font-semibold tracking-display text-text"
+        >
           {score}
         </div>
         <div className="font-mono text-xs uppercase tracking-label text-text3">

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -14,10 +14,30 @@ export default function Audit() {
 
   if (isPristine || !audit) return null
 
-  const stats: { label: string; value: number; dot: string; show: boolean }[] = [
-    { label: t('Weak'), value: count(audit, 'isWeak'), dot: 'bg-bad', show: true },
-    { label: t('Reused'), value: count(audit, 'isRepeating'), dot: 'bg-warn', show: true },
-    { label: t('Breached'), value: count(audit, 'breached'), dot: 'bg-bad', show: !!breachCheck }
+  // `key` is the untranslated slug — the label is localised, so e2e selectors
+  // and the React key both hang off the slug instead.
+  const stats: {
+    key: string
+    label: string
+    value: number
+    dot: string
+    show: boolean
+  }[] = [
+    { key: 'weak', label: t('Weak'), value: count(audit, 'isWeak'), dot: 'bg-bad', show: true },
+    {
+      key: 'reused',
+      label: t('Reused'),
+      value: count(audit, 'isRepeating'),
+      dot: 'bg-warn',
+      show: true
+    },
+    {
+      key: 'breached',
+      label: t('Breached'),
+      value: count(audit, 'breached'),
+      dot: 'bg-bad',
+      show: !!breachCheck
+    }
   ]
 
   return (
@@ -31,12 +51,15 @@ export default function Audit() {
           .filter(s => s.show)
           .map(s => (
             <div
-              key={s.label}
+              key={s.key}
+              data-testid={`audit-stat-${s.key}`}
               className="flex items-center gap-3 px-4 py-3 shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none"
             >
               <span className={`h-[7px] w-[7px] flex-none rounded-full ${s.dot}`} />
               <span className="flex-1 text-base text-text2">{s.label}</span>
-              <span className="font-mono text-base text-text">{s.value}</span>
+              <span data-testid="audit-stat-value" className="font-mono text-base text-text">
+                {s.value}
+              </span>
             </div>
           ))}
       </Panel>

--- a/src/components/Main/Body/Aside/Empty/Actions.tsx
+++ b/src/components/Main/Body/Aside/Empty/Actions.tsx
@@ -19,7 +19,9 @@ export default function Actions() {
 
   return (
     <div className="mt-6 flex items-center gap-3">
-      <Button onClick={() => newEntry()}>{t('Create First Entry')}</Button>
+      <Button testid="create-first-entry-button" onClick={() => newEntry()}>
+        {t('Create First Entry')}
+      </Button>
       <span className="text-base text-text3">{t('or')}</span>
       <Button variant="pale" loading={loading} onClick={onImport}>
         {t('Import from Gdrive')}

--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -127,11 +127,15 @@ export default function Form({ entry }: Props) {
       onClose={onCancel}
       onSubmit={onSave}
       footer={footer}
+      testid="entry-sheet"
     >
       <div className="flex flex-col gap-4">{fields()}</div>
 
       {saveError && (
-        <div className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-base text-bad">
+        <div
+          data-testid="entry-save-error"
+          className="mt-4 rounded-lg border border-bad/40 bg-bad/5 px-4 py-3 text-base text-bad"
+        >
           {saveError}
         </div>
       )}

--- a/src/components/Main/Body/Aside/Show/Actions.tsx
+++ b/src/components/Main/Body/Aside/Show/Actions.tsx
@@ -86,7 +86,12 @@ export default function Actions({ type, revealed, onDelete }: Props) {
 
   return (
     <div className="flex flex-none items-center gap-1.5">
-      <Button variant="pale" size="md" onClick={() => editEntry()}>
+      <Button
+        variant="pale"
+        size="md"
+        testid="edit-entry-button"
+        onClick={() => editEntry()}
+      >
         {t('Edit')}
       </Button>
 
@@ -106,9 +111,11 @@ export default function Actions({ type, revealed, onDelete }: Props) {
               <PencilGlyph />
               {t('Edit')}
             </DropdownItem>
+            {/* Same element for both presses: arm, then confirm. */}
             <DropdownItem
               separated
               danger
+              testid={armDelete ? 'delete-entry-confirm' : 'delete-entry-button'}
               onClick={armDelete ? run(onDelete) : () => setArmDelete(true)}
             >
               <TrashGlyph />

--- a/src/components/Main/Body/List/Group.tsx
+++ b/src/components/Main/Body/List/Group.tsx
@@ -13,14 +13,19 @@ interface Props {
 export default function Group({ title, entries }: Props) {
   if (entries.length === 0) return null
 
+  // Keyed off the untranslated title so e2e selectors survive a locale switch.
+  const slug = title.toLowerCase().replace(/\s+/g, '-')
+
   return (
-    <div>
+    <div data-testid={`list-group-${slug}`}>
       <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
         <span className="font-mono text-xs uppercase tracking-label text-text3">
           {t(title)}
         </span>
         <span className="h-px flex-1 bg-line" />
-        <span className="font-mono text-xs text-text3">{entries.length}</span>
+        <span data-testid="list-group-count" className="font-mono text-xs text-text3">
+          {entries.length}
+        </span>
       </div>
       {entries.map(entry => (
         <Item entry={entry} key={entry.id} />

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -27,7 +27,10 @@ export default function Row({ glyph, title, sub, flag }: Props) {
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-[7px]">
-          <span className="truncate text-base font-medium text-text">
+          <span
+            data-testid="entry-item-title"
+            className="truncate text-base font-medium text-text"
+          >
             {title}
           </span>
           {flag}

--- a/src/components/Main/Body/List/SortMenu.tsx
+++ b/src/components/Main/Body/List/SortMenu.tsx
@@ -36,7 +36,11 @@ export default function SortMenu() {
         <div className="absolute right-0 top-full mt-1 w-[180px]">
           <Dropdown onBlur={() => setOpen(false)}>
             {OPTIONS.map(option => (
-              <DropdownItem key={option.mode} onClick={() => pick(option.mode)}>
+              <DropdownItem
+                key={option.mode}
+                testid={`sort-option-${option.mode}`}
+                onClick={() => pick(option.mode)}
+              >
                 <span className="grid w-3.5 flex-none place-items-center text-accent">
                   {sort === option.mode && <CheckGlyph />}
                 </span>

--- a/src/components/Main/Generator/Amount.tsx
+++ b/src/components/Main/Generator/Amount.tsx
@@ -25,6 +25,7 @@ export default function Amount({ settings, onChange }: Props) {
       <input
         type="range"
         aria-label={t(byWords ? 'Words' : 'Length')}
+        data-testid="generator-amount"
         min={min}
         max={max}
         value={value}

--- a/src/components/Main/Generator/Tabs.tsx
+++ b/src/components/Main/Generator/Tabs.tsx
@@ -20,6 +20,7 @@ export default function Tabs({ mode, onChange }: Props) {
         <button
           key={tab.mode}
           type="button"
+          data-testid={`generator-mode-${tab.mode}`}
           onClick={() => onChange(tab.mode)}
           className={cx(
             'cursor-pointer rounded-sm px-2.5 py-[3px] text-base transition-colors',

--- a/src/components/Main/Header/Search.tsx
+++ b/src/components/Main/Header/Search.tsx
@@ -16,6 +16,7 @@ export default function Search() {
         <input
           type="search"
           name="search"
+          data-testid="search-input"
           placeholder={t('Search')}
           value={query}
           onChange={e => setFilterQuery(e.target.value)}
@@ -35,6 +36,7 @@ export default function Search() {
             type="button"
             onClick={() => setFilterQuery('')}
             aria-label={t('Clear')}
+            data-testid="search-clear-button"
             className="grid h-4 w-4 flex-none place-items-center rounded-full text-text3 hover:text-text"
           >
             <CloseGlyph size={12} />

--- a/src/components/Main/Header/SyncIndicator.tsx
+++ b/src/components/Main/Header/SyncIndicator.tsx
@@ -28,7 +28,10 @@ export default function SyncIndicator() {
 
   return (
     <Tooltip content={message()}>
-      <div className="flex h-7 items-center gap-[7px] rounded-sm px-2.5 font-mono text-xs text-text3">
+      <div
+        data-testid="sync-indicator"
+        className="flex h-7 items-center gap-[7px] rounded-sm px-2.5 font-mono text-xs text-text3"
+      >
         <span className={cx('h-[5px] w-[5px] flex-none rounded-full', dot())} />
         {label()}
       </div>

--- a/src/components/Main/Header/Tags/Chip.tsx
+++ b/src/components/Main/Header/Tags/Chip.tsx
@@ -13,6 +13,11 @@ export default function Chip({ label, count, selected, onClick }: Props) {
   return (
     <button
       type="button"
+      // One chip per tag, so specs disambiguate on `data-tag` (the raw tag —
+      // the visible label is the same string but sits beside a count span).
+      data-testid="tag-item"
+      data-tag={label}
+      aria-pressed={selected}
       onClick={onClick}
       className={cx(
         'flex h-6 flex-none items-center gap-1.5 rounded-sm border px-[9px] text-xs whitespace-nowrap',

--- a/src/components/Main/Header/Tags/index.tsx
+++ b/src/components/Main/Header/Tags/index.tsx
@@ -27,7 +27,10 @@ export default function Tags() {
   if (tags.length === 0) return null
 
   return (
-    <div className="mt-3.5 flex gap-[5px] overflow-x-auto pb-0.5">
+    <div
+      data-testid="tags-list"
+      className="mt-3.5 flex gap-[5px] overflow-x-auto pb-0.5"
+    >
       {tags.map(([tag, count]) => (
         <Chip
           key={tag}

--- a/src/components/Main/Palette/Row.tsx
+++ b/src/components/Main/Palette/Row.tsx
@@ -27,6 +27,9 @@ export default function Row({ focused, onClick, onHover, className, children }: 
       ref={ref}
       role="option"
       aria-selected={focused}
+      // Every palette result (entry and command alike) flows through this
+      // shell, so one hook here covers the whole result list.
+      data-testid="palette-item"
       onClick={onClick}
       // mousemove, not mouseenter: a row sliding under a still cursor while the
       // list scrolls shouldn't steal focus from the arrow keys.

--- a/src/components/Main/Sidebar/Settings/MasterPassword.tsx
+++ b/src/components/Main/Sidebar/Settings/MasterPassword.tsx
@@ -72,11 +72,24 @@ export default function MasterPassword({ section }: Props) {
         />
       </Row>
       <StatusRow>
-        <Button onClick={onSubmit} disabled={disabled} loading={processing}>
+        <Button
+          testid="change-password-submit"
+          onClick={onSubmit}
+          disabled={disabled}
+          loading={processing}
+        >
           {t('Update')}
         </Button>
-        {error && <span className={DANGER}>{error}</span>}
-        {success && <span className={SUCCESS}>{success}</span>}
+        {error && (
+          <span data-testid="change-password-error" className={DANGER}>
+            {error}
+          </span>
+        )}
+        {success && (
+          <span data-testid="change-password-success" className={SUCCESS}>
+            {success}
+          </span>
+        )}
       </StatusRow>
     </>
   )

--- a/src/components/Main/Sidebar/Switcher.tsx
+++ b/src/components/Main/Sidebar/Switcher.tsx
@@ -29,6 +29,7 @@ export default function Switcher() {
                   ? 'current bg-tile text-text'
                   : 'text-text2 hover:bg-hover hover:text-text'
               )}
+              data-testid={`scope-${current}`}
               onClick={() => setFilterScope(current)}
             >
               {selected && (

--- a/src/components/Main/Sidebar/VaultHealth.tsx
+++ b/src/components/Main/Sidebar/VaultHealth.tsx
@@ -40,6 +40,7 @@ export default function VaultHealth() {
   return (
     <Tooltip content={t('Vault Health')}>
       <div
+        data-testid="scope-audit"
         onClick={() => setFilterScope('audit')}
         className={cx(
           'grid h-10 w-10 cursor-pointer place-items-center rounded-lg transition-colors',
@@ -63,6 +64,7 @@ export default function VaultHealth() {
             />
           )}
           <text
+            data-testid="vault-health-score"
             x="18"
             y="21.5"
             textAnchor="middle"

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -27,7 +27,10 @@ export function Main() {
           display flip is what replays `animate-pop`. App-level so copies from
           the palette and standalone generator get feedback too. Centering uses
           auto margins so the pop's transform doesn't fight it. */}
-      <div className="copied-notification hidden animate-pop fixed inset-x-0 top-4 z-50 mx-auto w-max rounded-full bg-text px-5 py-2 text-base text-detail shadow-[var(--shadow)]">
+      <div
+        data-testid="copy-toast"
+        className="copied-notification hidden animate-pop fixed inset-x-0 top-4 z-50 mx-auto w-max rounded-full bg-text px-5 py-2 text-base text-detail shadow-[var(--shadow)]"
+      >
         {t('Copied to Clipboard')}
       </div>
     </div>

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -29,14 +29,23 @@ interface ItemProps {
   separated?: boolean
   // Destructive entry (delete, disconnect, ...): inked in the `bad` token.
   danger?: boolean
+  testid?: string
   onClick?: () => void
   children: ReactNode
 }
 
-export function DropdownItem({ id, separated, danger, onClick, children }: ItemProps) {
+export function DropdownItem({
+  id,
+  separated,
+  danger,
+  testid,
+  onClick,
+  children
+}: ItemProps) {
   return (
     <div
       id={id}
+      data-testid={testid}
       onClick={onClick}
       className={cx(
         'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-base transition-colors hover:bg-hover',

--- a/src/components/elements/Error.tsx
+++ b/src/components/elements/Error.tsx
@@ -5,7 +5,10 @@ interface Props {
 export default function Error({ error }: Props) {
   if (!error) return null
   return (
-    <div className="mt-2.5 text-center font-mono text-xs tracking-label text-bad">
+    <div
+      data-testid="form-error"
+      className="mt-2.5 text-center font-mono text-xs tracking-label text-bad"
+    >
       {error}
     </div>
   )

--- a/src/components/elements/Eyebrow.tsx
+++ b/src/components/elements/Eyebrow.tsx
@@ -6,11 +6,12 @@ type Tone = 'muted' | 'bad' | 'accent'
 interface Props {
   children: ReactNode
   tone?: Tone
+  testid?: string
 }
 
 // Mono, uppercase, letter-spaced status line with a slow "breathing" dot.
 // Shared by every auth screen (lock / setup / restore) as its eyebrow.
-export default function Eyebrow({ children, tone = 'muted' }: Props) {
+export default function Eyebrow({ children, tone = 'muted', testid }: Props) {
   const dot =
     tone === 'bad' ? 'bg-bad' : tone === 'accent' ? 'bg-accent' : 'bg-text3'
   const text = tone === 'bad' ? 'text-bad' : 'text-text3'
@@ -23,7 +24,9 @@ export default function Eyebrow({ children, tone = 'muted' }: Props) {
           dot
         )}
       />
-      <span className={text}>{children}</span>
+      <span data-testid={testid} className={text}>
+        {children}
+      </span>
     </div>
   )
 }

--- a/src/components/elements/PasswordStrength.tsx
+++ b/src/components/elements/PasswordStrength.tsx
@@ -28,7 +28,7 @@ export default function PasswordStrength({ password }: Props) {
     : strength?.warning || strength?.suggestions[0] || ''
 
   return (
-    <div className="mx-auto mt-4 w-60">
+    <div data-testid="password-strength" className="mx-auto mt-4 w-60">
       <div className="flex gap-1">
         {[0, 1, 2, 3, 4].map(i => (
           <span
@@ -41,7 +41,9 @@ export default function PasswordStrength({ password }: Props) {
         ))}
       </div>
       <div className="mt-1.5 flex justify-between gap-2 font-mono text-xs text-text3">
-        <span>{score !== null ? t(LABELS[score]) : ''}</span>
+        <span data-testid="password-strength-label">
+          {score !== null ? t(LABELS[score]) : ''}
+        </span>
         {hint && <span className="text-right text-text3">{hint}</span>}
       </div>
     </div>

--- a/src/components/elements/Sheet.tsx
+++ b/src/components/elements/Sheet.tsx
@@ -12,13 +12,21 @@ interface Props {
   onSubmit?: () => void
   // Pinned action row at the bottom of the panel.
   footer?: ReactNode
+  testid?: string
   children: ReactNode
 }
 
 // Full-height 520px panel sliding in from the right over a blurred scrim, with
 // a fixed header, a scrollable body and a pinned footer. Sibling of Modal:
 // same overlay language, different anchor.
-export default function Sheet({ title, onClose, onSubmit, footer, children }: Props) {
+export default function Sheet({
+  title,
+  onClose,
+  onSubmit,
+  footer,
+  testid,
+  children
+}: Props) {
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') return onClose()
@@ -37,6 +45,7 @@ export default function Sheet({ title, onClose, onSubmit, footer, children }: Pr
       onClick={onClose}
     >
       <div
+        data-testid={testid}
         className="animate-sheet flex h-full w-[520px] flex-col border-l border-line2 bg-detail text-text shadow-[var(--shadow)]"
         onClick={event => event.stopPropagation()}
       >

--- a/src/lib/e2e.ts
+++ b/src/lib/e2e.ts
@@ -1,0 +1,29 @@
+import { invoke } from '@tauri-apps/api/core'
+
+/**
+ * Dev-only bridge to the backend's `e2e_reset` command, so a spec can put the
+ * vault into a known state between tests.
+ *
+ * Zero production footprint: the only caller guards on `import.meta.env.DEV`
+ * and imports this module dynamically, so Vite folds the branch to `false` and
+ * drops the whole module from a production bundle. The command it calls is in
+ * turn compiled out of release binaries (see `src-tauri/src/commands/e2e.rs`).
+ *
+ * The bridge deliberately does NOT reload the page: navigating while a
+ * WebDriver script is still resolving tears the execution context out from
+ * under the driver. The spec helper reloads through `browser.refresh()`
+ * instead, which waits for the new document properly.
+ */
+
+export type E2EResetMode = 'pristine' | 'empty'
+
+declare global {
+  interface Window {
+    __e2eReset?: (mode: E2EResetMode, password?: string) => Promise<void>
+  }
+}
+
+export function installE2EBridge(): void {
+  window.__e2eReset = (mode, password) =>
+    invoke('e2e_reset', { mode, password: password ?? null })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>
 )
 
+// E2E state-reset bridge. Dynamic import behind the DEV flag: Vite substitutes
+// a literal `false` here for production builds, so the branch — and the module
+// behind it — never reach a shipped bundle. E2E runs against the dev server.
+if (import.meta.env.DEV) {
+  void import('./lib/e2e').then(({ installE2EBridge }) => installE2EBridge())
+}
+
 // Stage any signed update in the background; the toast surfaces it when ready.
 void runStartupUpdateCheck((version, notes) =>
   useStore.getState().setUpdateReady(version, notes)

--- a/tests/e2e/COVERAGE.md
+++ b/tests/e2e/COVERAGE.md
@@ -1,0 +1,79 @@
+# E2E coverage matrix
+
+The live tracker for the E2E port (item 3 of [`docs/v1-next.md`](../../docs/v1-next.md)).
+Four PRs: **PR 1** is the foundation (per-spec isolation, helpers, `data-testid` hooks);
+**PRs 2–4** are spec batches that can land in parallel once PR 1 is in.
+
+Every spec opens with an explicit `resetPristine()` or `resetEmpty(password)` — the suite
+runs one app process against one data dir, so nothing may depend on file order.
+
+---
+
+## Legacy floor — the 18 Spectron specs on `master`
+
+| # | Legacy spec (`test/features/…`) | Lands in | New spec | Notes |
+|---|---|---|---|---|
+| 1 | `setup/launch.spec.js` | PR 2 | `setup.spec.ts` | Choice screen renders; Setup vs Restore. |
+| 2 | `setup/password.spec.js` | PR 2 | `setup.spec.ts` | Weak-password gate, mismatch error. Drop the old welcome copy assertion (rebrand). |
+| 3 | `authentication/password.spec.js` | PR 2 | `unlock.spec.ts` | Wrong password → `unlock-error`; correct password → `main-view`. |
+| 4 | `launch/scope.spec.js` | PR 2 | `unlock.spec.ts` | Boot lands on unlock when a vault exists (`resetEmpty`). |
+| 5 | `logins/create.spec.js` | PR 2 | `logins.spec.ts` | |
+| 6 | `logins/edit.spec.js` | PR 2 | `logins.spec.ts` | Includes the discard guard (see additions). |
+| 7 | `logins/delete.spec.js` | PR 2 | `logins.spec.ts` | Two-press confirm, not a dialog (see additions). |
+| 8 | `logins/password.spec.js` | PR 2 | `logins.spec.ts` | Reveal/hide + copy of the password field. |
+| 9 | `logins/search.spec.js` | PR 2 | `search.spec.ts` | |
+| 10 | `logins/empty.spec.js` | PR 3 | `empty.spec.ts` | `create-first-entry-button` state. |
+| 11 | `cards/create.spec.js` | PR 3 | `cards.spec.ts` | Plus brand mark + interactive face (see additions). |
+| 12 | `notes/create.spec.js` | PR 3 | `notes.spec.ts` | |
+| 13 | `tags/filter.spec.js` | PR 3 | `tags.spec.ts` | |
+| 14 | `tags/empty.spec.js` | PR 3 | `tags.spec.ts` | `tags-list` absent when no entry carries a tag. |
+| 15 | `audit/index.spec.js` | PR 4 | `audit.spec.ts` | Groups are **Weak / Reused / Breached** now, not the legacy buckets. |
+| 16 | `settings/change_password.spec.js` | PR 4 | `settings.spec.ts` | |
+| 17 | `settings/password.spec.js` | PR 4 | `generator.spec.ts` | Generator *defaults* panel in Settings. |
+| 18 | `settings/vault.spec.js` | PR 4 | `settings.spec.ts` | Minus the sync assertions the legacy spec made against the old Drive UI. |
+
+## Planned additions — flows the legacy suite never had
+
+| Flow | Lands in | Hook |
+|---|---|---|
+| Discard-changes guard on a dirty edit | PR 2 | `cancel-entry-button` pressed twice ("Discard changes?") |
+| Delete confirm | PR 2 | `delete-entry-button` → `delete-entry-confirm` inside `more-actions-button` |
+| Kind scopes in the rail | PR 2 | `scope-login` / `scope-note` / `scope-card` / `scope-audit` |
+| Sort control | PR 3 | `sort-menu` → `sort-option-recent` / `sort-option-alpha`, assert `entry-item-title` order |
+| Card face: reveal + copy | PR 3 | `card-reveal-button`, `entry-value-number` / `-expires` / `-cvc` / `-pin` |
+| Card brand mark | PR 3 | brand slug derived at save time; assert per-network glyph |
+| Empty states per scope | PR 3 | `create-first-entry-button` |
+| Command palette | PR 4 | `command-palette`, `command-palette-input`, `palette-item` |
+| Password generator | PR 4 | `generator-mode-random` / `-memorable`, `generator-amount`, `generator-regenerate`, `generator-output`, `generator-use-button` |
+| Change master password | PR 4 | `change-password-submit`, `change-password-error`, `change-password-success` |
+| Sync indicator reads "Local" | PR 4 | `sync-indicator` |
+| Copy toast | PR 4 | `copy-toast` — always in the DOM, toggled via the `hidden` class, so assert *visibility* |
+
+---
+
+## Deliberately not e2e-able
+
+These are not gaps in the suite; the coverage lives elsewhere and belongs there.
+
+| Area | Why not e2e | Where it is covered |
+|---|---|---|
+| Drive sync loop | Needs a live Google account + OAuth consent; a WebDriver run cannot hold credentials. | Rust tests around `sync::engine` against a fake `Remote`, plus the pack/restore round-trip tests. |
+| Biometric unlock | Gated by the OS (Touch ID prompt); no WebDriver surface, and the secure store is machine-bound. | `secure_store` / `biometrics` are behind a platform trait; unit-tested through it. |
+| `.swftx` import / export, backup restore | Opens a **native** file dialog outside the webview — the driver cannot reach it. | `import::` and `store::` Rust tests cover parse, reseal-on-import and the export round-trip. |
+| Updater | Talks to the release endpoint and stages a signed bundle. | `services/autoUpdate.test.ts` against a mocked plugin. |
+| HIBP breach check | Network call to the k-anonymity range API. | `hibp` Rust unit tests; the audit spec runs with the breach check off. |
+| Site favicons | Fetches from each entry's own host. | E2E asserts only the **glyph fallback**; fetching/caching is covered in `favicon` Rust tests. |
+
+---
+
+## Harness reference
+
+- `helpers/reset.ts` — `resetPristine()`, `resetEmpty(password)`
+- `helpers/vault.ts` — `setupVault(password)`, `unlock(password)`, `lockVault()`
+- `helpers/entries.ts` — `createLogin`, `createCard`, `createNote`, `entryItems()`
+- `helpers/app.ts` — `waitFor(testid)`, `waitForAppReady()`
+
+Reset goes through `window.__e2eReset` (installed only when `import.meta.env.DEV`) onto the
+`e2e_reset` Tauri command, which is compiled out of release builds and additionally refuses
+to run unless `SWIFTY_E2E=1` **and** `SWIFTY_DB_DIR` are set — so it can only ever erase the
+suite's own temp dir. See `src-tauri/src/commands/e2e.rs`.

--- a/tests/e2e/helpers/entries.ts
+++ b/tests/e2e/helpers/entries.ts
@@ -1,0 +1,90 @@
+import { waitFor } from "./app";
+
+/**
+ * Entry creation through the real UI.
+ *
+ * There is no kind picker in the add flow: the new entry inherits the sidebar
+ * scope (`Form/index.tsx` reads `filters.scope`), so every helper here selects
+ * its rail item first and only then presses Add.
+ */
+
+type Scope = "login" | "card" | "note";
+
+export interface LoginFields {
+  title: string;
+  username: string;
+  password: string;
+  website?: string;
+}
+
+export interface CardFields {
+  title: string;
+  number: string;
+  month: string;
+  year: string;
+  cvc: string;
+  pin: string;
+  name?: string;
+}
+
+export interface NoteFields {
+  title: string;
+  note: string;
+}
+
+async function openForm(scope: Scope): Promise<void> {
+  await waitFor(`scope-${scope}`);
+  await $(`[data-testid="scope-${scope}"]`).click();
+  await $('[data-testid="add-entry-button"]').click();
+  await waitFor("entry-sheet");
+  await $('input[name="title"]').waitForDisplayed({ timeout: 5_000 });
+}
+
+// Fields are addressed by `name` — the form renders plain inputs (and one
+// textarea for note bodies), so there is no per-field testid to depend on.
+async function fill(name: string, value: string, tag = "input"): Promise<void> {
+  await $(`${tag}[name="${name}"]`).setValue(value);
+}
+
+// Save and wait for the sheet to close, which is the store's "write landed"
+// signal (a failed write leaves the sheet open with `entry-save-error`).
+async function save(): Promise<void> {
+  await $('[data-testid="save-entry-button"]').click();
+  await $('[data-testid="entry-sheet"]').waitForDisplayed({
+    reverse: true,
+    timeout: 15_000,
+  });
+}
+
+export async function createLogin(fields: LoginFields): Promise<void> {
+  await openForm("login");
+  await fill("title", fields.title);
+  if (fields.website !== undefined) await fill("website", fields.website);
+  await fill("username", fields.username);
+  await fill("password", fields.password);
+  await save();
+}
+
+export async function createCard(fields: CardFields): Promise<void> {
+  await openForm("card");
+  await fill("title", fields.title);
+  await fill("number", fields.number);
+  await fill("month", fields.month);
+  await fill("year", fields.year);
+  await fill("cvc", fields.cvc);
+  await fill("pin", fields.pin);
+  if (fields.name !== undefined) await fill("name", fields.name);
+  await save();
+}
+
+export async function createNote(fields: NoteFields): Promise<void> {
+  await openForm("note");
+  await fill("title", fields.title);
+  await fill("note", fields.note, "textarea");
+  await save();
+}
+
+/** Every entry row currently rendered in the list column. */
+export function entryItems() {
+  return $$('[data-testid="entry-item"]');
+}

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -1,0 +1,12 @@
+export { waitFor, waitForAppReady } from "./app";
+export { resetPristine, resetEmpty } from "./reset";
+export { setupVault, unlock, lockVault } from "./vault";
+export {
+  createLogin,
+  createCard,
+  createNote,
+  entryItems,
+  type LoginFields,
+  type CardFields,
+  type NoteFields,
+} from "./entries";

--- a/tests/e2e/helpers/reset.ts
+++ b/tests/e2e/helpers/reset.ts
@@ -1,0 +1,80 @@
+import { waitFor } from "./app";
+
+/**
+ * Per-spec state isolation.
+ *
+ * The suite runs ONE app process against ONE data dir for the whole run, so
+ * without this every spec would inherit the vault the previous spec left
+ * behind (and would only pass in one particular file order). Each spec instead
+ * opens with an explicit `resetPristine()` / `resetEmpty()`.
+ *
+ * Both go through `window.__e2eReset`, the dev-only bridge installed by
+ * `src/main.tsx`, onto the debug-only `e2e_reset` Tauri command.
+ */
+
+type ResetMode = "pristine" | "empty";
+
+// The bridge is installed from a dynamic import, so on a cold boot (and again
+// after every refresh) it lands one module fetch behind the first paint. Wait
+// for it rather than assuming the app has settled.
+async function waitForBridge(): Promise<void> {
+  await browser.waitUntil(
+    () =>
+      browser.execute(
+        () =>
+          typeof (window as unknown as { __e2eReset?: unknown }).__e2eReset ===
+          "function",
+      ),
+    {
+      timeout: 30_000,
+      timeoutMsg:
+        "window.__e2eReset never appeared — is the app running against the Vite dev server?",
+    },
+  );
+}
+
+// Run the backend reset, then reload the app so it re-reads disk.
+//
+// The reload is a WebDriver `refresh` rather than a `location.reload()` inside
+// the bridge on purpose: navigating away while an injected script is still
+// resolving destroys the execution context the driver is waiting on. `refresh`
+// waits for the new document instead.
+async function reset(mode: ResetMode, password?: string): Promise<void> {
+  await waitForBridge();
+
+  const failure = await browser.executeAsync(
+    function (
+      mode: string,
+      password: string | null,
+      done: (error: string | null) => void,
+    ) {
+      const bridge = (
+        window as unknown as {
+          __e2eReset: (mode: string, password?: string) => Promise<void>;
+        }
+      ).__e2eReset;
+      bridge(mode, password ?? undefined).then(
+        () => done(null),
+        (error: unknown) => done(String(error)),
+      );
+    },
+    mode,
+    password ?? null,
+  );
+
+  if (failure) throw new Error(`[e2e] reset("${mode}") failed: ${failure}`);
+
+  await browser.refresh();
+}
+
+/** No vault on disk: the app lands on the first-run setup choice screen. */
+export async function resetPristine(): Promise<void> {
+  await reset("pristine");
+  await waitFor("start-setup-button");
+}
+
+/** A fresh, entry-less vault keyed to `password`, left locked: lands on unlock. */
+export async function resetEmpty(password: string): Promise<void> {
+  await reset("empty", password);
+  await waitFor("unlock-password-input");
+}

--- a/tests/e2e/helpers/vault.ts
+++ b/tests/e2e/helpers/vault.ts
@@ -1,0 +1,32 @@
+import { waitFor, waitForAppReady } from "./app";
+
+/** Drive the real first-run setup UI from the choice screen to an unlocked vault. */
+export async function setupVault(password: string): Promise<void> {
+  await waitFor("start-setup-button");
+  await $('[data-testid="start-setup-button"]').click();
+
+  await waitFor("setup-password-input");
+  await $('[data-testid="setup-password-input"]').setValue(password);
+  await $('[data-testid="setup-continue-button"]').click();
+
+  await waitFor("setup-confirm-password-input");
+  await $('[data-testid="setup-confirm-password-input"]').setValue(password);
+  await $('[data-testid="setup-finish-button"]').click();
+
+  await waitForAppReady();
+}
+
+/** Unlock from the lock screen: type the password and submit with Enter. */
+export async function unlock(password: string): Promise<void> {
+  await waitFor("unlock-password-input");
+  await $('[data-testid="unlock-password-input"]').setValue(password);
+  await browser.keys([""]); // Enter
+  await waitForAppReady();
+}
+
+/** Lock the vault from the top chrome and wait for the lock screen. */
+export async function lockVault(): Promise<void> {
+  await waitFor("lock-vault-button");
+  await $('[data-testid="lock-vault-button"]').click();
+  await waitFor("unlock-password-input");
+}

--- a/tests/e2e/specs/isolation.spec.ts
+++ b/tests/e2e/specs/isolation.spec.ts
@@ -1,0 +1,52 @@
+import {
+  createLogin,
+  entryItems,
+  resetEmpty,
+  resetPristine,
+  setupVault,
+  unlock,
+  waitFor,
+} from "../helpers";
+
+// Proof that the reset seam actually isolates specs. Not feature coverage —
+// every other spec in this suite depends on these two guarantees holding.
+
+const MASTER_PASSWORD = "Zt4$rNb8kHyD2wS!";
+const LEAKY_ENTRY_TITLE = "Should Not Survive A Reset";
+
+describe("per-spec state isolation", () => {
+  it("resetEmpty lands on unlock with a vault that accepts the password", async () => {
+    await resetEmpty(MASTER_PASSWORD);
+
+    // A vault exists (setup was skipped) and it is locked.
+    await expect($('[data-testid="start-setup-button"]')).not.toBeDisplayed();
+
+    await unlock(MASTER_PASSWORD);
+    await expect($('[data-testid="main-view"]')).toBeDisplayed();
+    expect(await entryItems()).toHaveLength(0);
+  });
+
+  it("resetPristine erases the previous spec's vault, entries and all", async () => {
+    // Arrange: a vault with one entry in it.
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+    await createLogin({
+      title: LEAKY_ENTRY_TITLE,
+      username: "leak@example.com",
+      password: "Le@k-Test-Password-7!",
+    });
+    await waitFor("entry-item");
+
+    // Act: wipe back to a first-run state.
+    await resetPristine();
+
+    // The vault itself is gone — the app is offering setup, not unlock.
+    await expect($('[data-testid="start-setup-button"]')).toBeDisplayed();
+    await expect($('[data-testid="unlock-password-input"]')).not.toBeDisplayed();
+
+    // And a vault created afresh (same password, so a leaked DB would still
+    // open) starts empty.
+    await setupVault(MASTER_PASSWORD);
+    expect(await entryItems()).toHaveLength(0);
+  });
+});

--- a/tests/e2e/specs/smoke.spec.ts
+++ b/tests/e2e/specs/smoke.spec.ts
@@ -1,4 +1,11 @@
-import { waitFor, waitForAppReady } from "../helpers/app";
+import {
+  createLogin,
+  lockVault,
+  resetPristine,
+  setupVault,
+  unlock,
+  waitFor,
+} from "../helpers";
 
 // A single continuous smoke flow: first-run setup, lock/unlock, and one entry
 // round-trip. Kept as one test (not several independent `it`s) since each step
@@ -11,46 +18,21 @@ const ENTRY_PASSWORD = "C0rrect-Horse-Battery-9!";
 
 describe("Tauri app smoke test", () => {
   it("completes setup, locks, unlocks, and round-trips one entry", async () => {
-    // ── First-run vault setup ────────────────────────────────────────────────
-    await waitFor("start-setup-button");
-    await $('[data-testid="start-setup-button"]').click();
+    await resetPristine();
 
-    await waitFor("setup-password-input");
-    await $('[data-testid="setup-password-input"]').setValue(MASTER_PASSWORD);
-    await $('[data-testid="setup-continue-button"]').click();
-
-    await waitFor("setup-confirm-password-input");
-    await $('[data-testid="setup-confirm-password-input"]').setValue(MASTER_PASSWORD);
-    await $('[data-testid="setup-finish-button"]').click();
-
-    // ── Verify unlocked ──────────────────────────────────────────────────────
-    await waitForAppReady();
+    await setupVault(MASTER_PASSWORD);
     await expect($('[data-testid="main-view"]')).toBeDisplayed();
 
-    // ── Lock ─────────────────────────────────────────────────────────────────
-    // Lock now lives in the top chrome (not behind Settings), so click it directly.
-    await waitFor("lock-vault-button");
-    await $('[data-testid="lock-vault-button"]').click();
+    await lockVault();
+    await unlock(MASTER_PASSWORD);
 
-    // ── Unlock with the same master password ────────────────────────────────
-    await waitFor("unlock-password-input");
-    const unlockInput = await $('[data-testid="unlock-password-input"]');
-    await unlockInput.setValue(MASTER_PASSWORD);
-    await browser.keys([""]); // Enter
+    await createLogin({
+      title: ENTRY_TITLE,
+      username: ENTRY_USERNAME,
+      password: ENTRY_PASSWORD,
+    });
 
-    await waitForAppReady();
-
-    // ── Add one entry ────────────────────────────────────────────────────────
-    await $('[data-testid="add-entry-button"]').click();
-
-    await $('input[name="title"]').waitForDisplayed({ timeout: 5_000 });
-    await $('input[name="title"]').setValue(ENTRY_TITLE);
-    await $('input[name="username"]').setValue(ENTRY_USERNAME);
-    await $('input[name="password"]').setValue(ENTRY_PASSWORD);
-
-    await $('[data-testid="save-entry-button"]').click();
-
-    // ── Reveal it and assert the value ───────────────────────────────────────
+    // ── Reveal it and assert the values ──────────────────────────────────────
     await waitFor("entry-item");
     await expect($('[data-testid="entry-value-password"]')).toHaveText(ENTRY_PASSWORD);
     await expect($('[data-testid="entry-value-username"]')).toHaveText(ENTRY_USERNAME);

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "esModuleInterop": true,
-    "types": ["node", "mocha"]
+    "types": ["node", "mocha", "@wdio/globals/types", "expect-webdriverio"]
   },
   "ts-node": {
     "transpileOnly": true

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -16,7 +16,6 @@ import fs from "fs";
 import net from "net";
 import os from "os";
 import path from "path";
-import { waitFor } from "./helpers/app";
 
 const ROOT = path.resolve(__dirname, "../..");
 
@@ -101,10 +100,10 @@ export const config: WebdriverIO.Config = {
     },
   },
 
-  before: async () => {
-    // Fresh vault: the app boots straight into the setup/restore choice screen.
-    await waitFor("start-setup-button");
-  },
+  // No global `before` hook: waiting for the setup screen here would assume
+  // every spec inherits a pristine vault, which is exactly the run-order
+  // coupling this harness now avoids. Each spec opens with its own
+  // `resetPristine()` / `resetEmpty()` (see helpers/reset.ts).
 
   onPrepare: async () => {
     fs.mkdirSync(TEST_DB_DIR, { recursive: true });
@@ -143,7 +142,11 @@ export const config: WebdriverIO.Config = {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
+        // Both are gates on the `e2e_reset` command: it refuses to run unless
+        // SWIFTY_E2E is 1, and it only ever wipes SWIFTY_DB_DIR — so it can
+        // never reach a developer's real app-data dir. See commands/e2e.rs.
         SWIFTY_DB_DIR: TEST_DB_DIR,
+        SWIFTY_E2E: "1",
         WEBKIT_DISABLE_COMPOSITING_MODE: "1",
       },
     });


### PR DESCRIPTION
**PR 1 of 4 — PRs 2–4 are spec batches that can proceed in parallel once this lands.**

## The problem

The E2E harness boots **one** app process against **one** temp data dir for the whole run. Every spec therefore inherits whatever vault the previous spec left behind, and the global `before` hook waiting for `start-setup-button` baked that in: it only worked because there was exactly one spec, running first, against a pristine dir. The legacy Spectron suite had `before({ storage: 'pristine' | 'empty' })` per spec. This PR builds the equivalent.

## The reset seam — `e2e_reset(mode, password)`

`src-tauri/src/commands/e2e.rs`. Contract:

| mode | effect | app lands on |
|---|---|---|
| `"pristine"` | wipe the data dir | first-run setup choice screen |
| `"empty"` | wipe, then `create_vault(password)`, session left locked | unlock screen |

Order matters: the session is dropped **first**. It owns the open SQLCipher connection, and deleting the DB out from under a live handle leaves the connection writing WAL frames for a file that no longer exists — the next `create_vault` would then open beside them.

The wipe empties the directory's contents (DB triple, KDF + lockout sidecars, biometric marker, `icons/`, `sync-scratch/`) rather than removing a known list, so no spec can inherit a stray file.

### Triple-gated

A "wipe the data dir" command is exactly the thing that must never reach a user:

1. **`#[cfg(debug_assertions)]`** on the module *and* on the `invoke_handler` registration. `generate_handler!` honours per-command attributes (`tauri-macros` parses `Attribute::parse_outer` before each path and emits them on the match arm), so a release build does not generate the arm at all — and with it, the only reference to the cfg'd-out module. E2E drives the debug binary, which is also the only build carrying the in-app WebDriver server.
2. **`SWIFTY_E2E=1`** must be set at runtime. A developer's own `tauri dev` is a debug build too, and must not expose this to a stray `invoke`.
3. **`SWIFTY_DB_DIR`** must be set, and is the only directory touched. `storage::app_dir` returns it verbatim when present, so the dir erased is by construction the one the app reads — and a debug binary run by hand, without it, can never reach the real app-data dir.

**Release proof:** `cargo clippy --release -- -D warnings` and `cargo check --release` both pass with the module cfg'd out.

## The dev-only bridge

`src/lib/e2e.ts` installs `window.__e2eReset`. `src/main.tsx` imports it **dynamically, behind `import.meta.env.DEV`** — Vite substitutes a literal `false` for production, so the branch and the module behind it are dropped.

**Zero prod footprint, verified:** after `bun run build`, `grep -r 'e2e_reset\|__e2eReset\|installE2EBridge' dist/` returns nothing, and no extra chunk is emitted (single `index-*.js`).

The bridge deliberately does **not** call `location.reload()`. Navigating while an injected script is still resolving destroys the execution context the driver is waiting on; the helper reloads via `browser.refresh()`, which waits for the new document properly.

## Helpers (`tests/e2e/helpers/`)

```ts
resetPristine(): Promise<void>                 // → waits for start-setup-button
resetEmpty(password: string): Promise<void>    // → waits for unlock-password-input
setupVault(password: string): Promise<void>    // drives the real setup UI
unlock(password: string): Promise<void>        // fill + Enter → main-view
lockVault(): Promise<void>
createLogin({ title, username, password, website? }): Promise<void>
createCard({ title, number, month, year, cvc, pin, name? }): Promise<void>
createNote({ title, note }): Promise<void>
entryItems(): ChainablePromiseArray
```

Two things the survey turned up that shaped these:

- **There is no kind picker in the add flow.** A new entry inherits the sidebar scope (`Form/index.tsx` reads `filters.scope`), so each create helper selects its rail item before pressing Add.
- The bridge arrives one module fetch behind first paint, so `reset()` waits for `window.__e2eReset` rather than assuming the app has settled.

`wdio.conf.ts`: exports `SWIFTY_E2E=1` to the app env, and the global `before` hook is **removed** — each spec now declares its own starting state. `tests/e2e/tsconfig.json` picks up `@wdio/globals/types` + `expect-webdriverio`, so the helpers and specs typecheck (they did not before).

## `data-testid` hooks

Every existing testid is untouched — CI's e2e job and the vitest suite depend on them. Per-item hooks are interpolated from an **untranslated** slug so selectors survive a locale switch. Three primitives grow the same optional `testid` prop `Button`/`IconButton` already carry.

| Testid | Where |
|---|---|
| `search-input`, `search-clear-button` | `Main/Header/Search.tsx` |
| `sort-option-recent`, `sort-option-alpha` | `Body/List/SortMenu.tsx` (via a new `testid` prop on `DropdownItem`) |
| `scope-login`, `scope-note`, `scope-card` | `Sidebar/Switcher.tsx` |
| `scope-audit`, `vault-health-score` | `Sidebar/VaultHealth.tsx` — the audit scope button lives here, not in the Switcher |
| `tags-list` / `tag-item` (+ `data-tag`, `aria-pressed`) | `Header/Tags/index.tsx`, `Tags/Chip.tsx` |
| `audit-score` | `Aside/Audit/Score.tsx` |
| `audit-stat-weak` / `-reused` / `-breached`, `audit-stat-value` | `Aside/Audit/index.tsx` — the groups are Weak/Reused/Breached, not the legacy buckets |
| `list-group-<title>`, `list-group-count` | `Body/List/Group.tsx` (shared by audit severities and recency buckets) |
| `unlock-status` / `unlock-error` / `unlock-lockout` | `Auth/index.tsx` (via a new `testid` prop on `Eyebrow`) — one element carries all three states, so the testid names which is showing rather than making specs parse the message |
| `form-error` | `elements/Error.tsx` — covers the setup weak-password gate and the mismatch error |
| `password-strength`, `password-strength-label` | `elements/PasswordStrength.tsx` |
| `entry-sheet` | `elements/Sheet.tsx` (new `testid` prop), passed from `Aside/Form/index.tsx` |
| `entry-save-error` | `Aside/Form/index.tsx` |
| `edit-entry-button` | `Aside/Show/Actions.tsx` |
| `delete-entry-button` → `delete-entry-confirm` | `Aside/Show/Actions.tsx` — delete is a two-press dropdown item, **not** a dialog; the same element reports both states |
| `entry-item-title` | `Body/List/Item/Row.tsx` |
| `create-first-entry-button` | `Aside/Empty/Actions.tsx` |
| `change-password-submit`, `change-password-error`, `change-password-success` | `Settings/MasterPassword.tsx` |
| `palette-item` | `Palette/Row.tsx` — one hook on the shared shell covers both entry and command results |
| `generator-mode-random` / `-memorable` | `Generator/Tabs.tsx` |
| `generator-amount` | `Generator/Amount.tsx` |
| `copy-toast` | `Main/index.tsx` |
| `sync-indicator` | `Header/SyncIndicator.tsx` |

**Not added, on purpose:** the discard-changes guard is the *same* `cancel-entry-button` armed twice, and `generator-regenerate` / `generator-use-button` / `generator-output` / `sort-menu` / `more-actions-button` / `card-reveal-button` already exist. Palette rows already carry `role="option"` + `aria-selected`.

## Proof specs

`tests/e2e/specs/isolation.spec.ts`:
1. `resetEmpty` lands on unlock with a vault that accepts the given password, and the list is empty.
2. Create an entry, `resetPristine()`, and the app is back at setup with no unlock screen — then re-setup **under the same password** (so a leaked DB would still open) and the list is still empty.

`smoke.spec.ts` now opens with `resetPristine()` and uses the helpers, keeping its continuous-flow character.

## Results

- E2E suite: **2 spec files, 3 tests, all passing, 17s** (isolation runs first alphabetically and smoke second — order independence is exercised, not assumed).
- `cargo test` 159 passed · `cargo clippy --all-targets -D warnings` clean · `cargo fmt --check` clean · `cargo clippy --release -D warnings` clean.
- `bun run test` 138 passed (21 files) · `bunx tsc --noEmit` clean · `bunx eslint src --max-warnings 0` clean · e2e project typechecks.

Coverage matrix: [`tests/e2e/COVERAGE.md`](https://github.com/swiftyapp/swifty/blob/feat/e2e-foundation/tests/e2e/COVERAGE.md) — the 18 legacy specs mapped to PRs 2–4, the planned additions, and the deliberately-not-e2e-able list with where that coverage lives instead.
