### PR TITLE
test(e2e): tools and settings — audit, generator, palette, change password

### DIFF
--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -20,6 +20,7 @@ export default function Modal({ onClose, children }: Props) {
       >
         <button
           type="button"
+          data-testid="modal-close"
           onClick={onClose}
           className="absolute right-3 top-3 z-10 grid h-7 w-7 cursor-pointer place-items-center rounded-sm text-text3 transition-colors hover:bg-hover hover:text-text"
         >

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -1,4 +1,5 @@
 export { waitFor, waitForAppReady } from "./app";
+export { chord, pressEnter } from "./keys";
 export { resetPristine, resetEmpty } from "./reset";
 export { setupVault, unlock, lockVault } from "./vault";
 export {

--- a/tests/e2e/helpers/keys.ts
+++ b/tests/e2e/helpers/keys.ts
@@ -1,0 +1,25 @@
+/**
+ * Keyboard chords.
+ *
+ * `Main/useShortcuts.ts` accepts either `metaKey` or `ctrlKey`, so the driver
+ * sends whichever modifier the platform's webview actually reports: Meta on
+ * macOS, Control on the Linux CI runner (where Meta is the window manager's
+ * Super key and never reaches the page).
+ */
+
+// W3C WebDriver key codes.
+const META = "\uE03D";
+const CONTROL = "\uE009";
+const ENTER = "\uE007";
+
+const MODIFIER = process.platform === "darwin" ? META : CONTROL;
+
+/** Press `modifier + key` — the app's Cmd/Ctrl K, L and G bindings. */
+export async function chord(key: string): Promise<void> {
+  await browser.keys([MODIFIER, key]);
+}
+
+/** Press Enter (submits the lock screen and the generator dialog). */
+export async function pressEnter(): Promise<void> {
+  await browser.keys(ENTER);
+}

--- a/tests/e2e/specs/audit.spec.ts
+++ b/tests/e2e/specs/audit.spec.ts
@@ -1,0 +1,171 @@
+import { createLogin, resetEmpty, unlock, waitFor } from "../helpers";
+
+// The Password Audit pane behind the rail's vault-health dial.
+//
+// Everything asserted here is seeded, never sampled: two logins share a
+// password (reused), one carries a trivially guessable one (weak). The
+// Breached group is deliberately excluded — it is gated on the opt-in HIBP
+// lookup, which is a network call (`hibp::check_all`), so the spec pins the
+// preference off and asserts the group is *absent* rather than depending on
+// what a live range query would answer.
+
+const MASTER_PASSWORD = "Pd3$wKn7yBq2xMt!";
+
+const SHARED_PASSWORD = "Rk7#zVm4tQx9pLd!";
+const WEAK_PASSWORD = "abc";
+const FIXED_WEAK_PASSWORD = "Jw5&hCf8nZr3bXq!";
+const FIXED_REUSE_PASSWORD = "Lb9@sPu6dKv1mTy!";
+
+const REUSED_A = "Reused Alpha";
+const REUSED_B = "Reused Beta";
+const WEAK_ONE = "Weak One";
+
+/** The number rendered in one audit group row. */
+async function statValue(key: string): Promise<number> {
+  await waitFor(`audit-stat-${key}`);
+  const text = await $(`[data-testid="audit-stat-${key}"]`)
+    .$('[data-testid="audit-stat-value"]')
+    .getText();
+  return Number(text);
+}
+
+// The audit is recomputed in the background after every write (`thunks.ts`
+// re-runs `get_audit` on save), so a group's number is polled rather than read
+// once — never a fixed pause.
+async function expectStat(key: string, expected: number): Promise<void> {
+  await browser.waitUntil(async () => (await statValue(key)) === expected, {
+    timeout: 15_000,
+    timeoutMsg: `audit-stat-${key} never reached ${expected}`,
+  });
+}
+
+async function openAudit(): Promise<void> {
+  await waitFor("scope-audit");
+  await $('[data-testid="scope-audit"]').click();
+  await waitFor("audit-score");
+}
+
+async function auditScore(): Promise<number> {
+  await waitFor("audit-score");
+  return Number(await $('[data-testid="audit-score"]').getText());
+}
+
+// The rail dial's numeral is an SVG <text> node, which is neither "displayed"
+// nor readable by `getText` in every driver — read its textContent instead.
+async function railScore(): Promise<string> {
+  const dial = $('[data-testid="vault-health-score"]');
+  await dial.waitForExist({ timeout: 10_000 });
+  return String((await dial.getProperty("textContent")) ?? "").trim();
+}
+
+/** Select a login by its title in the list column. */
+async function selectLogin(title: string): Promise<void> {
+  await waitFor("scope-login");
+  await $('[data-testid="scope-login"]').click();
+  await waitFor("entry-item");
+
+  const rows = await $$('[data-testid="entry-item"]');
+  for (const row of rows) {
+    const rowTitle = await row.$('[data-testid="entry-item-title"]').getText();
+    if (rowTitle === title) {
+      await row.click();
+      return;
+    }
+  }
+  throw new Error(`[e2e] no entry row titled "${title}"`);
+}
+
+/** Open a login in the editor and replace just its password. */
+async function repassword(title: string, password: string): Promise<void> {
+  await selectLogin(title);
+
+  await waitFor("edit-entry-button");
+  await $('[data-testid="edit-entry-button"]').click();
+  await waitFor("entry-sheet");
+
+  // Secrets arrive via `revealEntry`, so the field is empty for a beat after
+  // the sheet opens; typing before it lands would be overwritten. Only the
+  // arrival is waited on, never the value: `useRevealed` caches by entry id, so
+  // a re-opened entry can still hand back its pre-edit secret (known bug, out
+  // of scope here — the audit itself recomputes from the saved vault).
+  const field = $('input[name="password"]');
+  await field.waitForDisplayed({ timeout: 10_000 });
+  await browser.waitUntil(async () => (await field.getValue()) !== "", {
+    timeout: 10_000,
+    timeoutMsg: "the editor never filled in the existing password",
+  });
+
+  await field.setValue(password);
+  await expect(field).toHaveValue(password);
+
+  await $('[data-testid="save-entry-button"]').click();
+  await $('[data-testid="entry-sheet"]').waitForDisplayed({
+    reverse: true,
+    timeout: 15_000,
+  });
+}
+
+describe("password audit", () => {
+  before(async () => {
+    // The Breached group is opt-in (`defaults/audit.ts`, off by default). Pin it
+    // so the spec is independent of whatever a previous spec left in
+    // localStorage — the reset below wipes the vault, not the webview storage.
+    await browser.execute(() =>
+      localStorage.setItem("swifty:breachCheck", "false"),
+    );
+
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+
+    await createLogin({
+      title: REUSED_A,
+      username: "alpha@example.com",
+      password: SHARED_PASSWORD,
+    });
+    await createLogin({
+      title: REUSED_B,
+      username: "beta@example.com",
+      password: SHARED_PASSWORD,
+    });
+    await createLogin({
+      title: WEAK_ONE,
+      username: "weak@example.com",
+      password: WEAK_PASSWORD,
+    });
+  });
+
+  it("scores the vault and counts the weak and reused passwords", async () => {
+    await openAudit();
+
+    // Both the rail dial and the pane's own dial render a number.
+    await browser.waitUntil(async () => /^\d+$/.test(await railScore()), {
+      timeout: 15_000,
+      timeoutMsg: "the rail's vault-health dial never showed a score",
+    });
+    expect(await auditScore()).toBeLessThan(10);
+
+    // One trivially guessable password; both copies of the shared one count.
+    await expectStat("weak", 1);
+    await expectStat("reused", 2);
+
+    // Opted out of the breach lookup, so the group is not offered at all.
+    await expect($('[data-testid="audit-stat-breached"]')).not.toBeDisplayed();
+  });
+
+  it("drops the counts and lifts the score once the entries are fixed", async () => {
+    await openAudit();
+    const before = await auditScore();
+
+    await repassword(WEAK_ONE, FIXED_WEAK_PASSWORD);
+    await openAudit();
+    await expectStat("weak", 0);
+    await expectStat("reused", 2);
+
+    // Breaking the pair clears both of its entries, not just the edited one.
+    await repassword(REUSED_B, FIXED_REUSE_PASSWORD);
+    await openAudit();
+    await expectStat("reused", 0);
+
+    expect(await auditScore()).toBeGreaterThan(before);
+  });
+});

--- a/tests/e2e/specs/change-password.spec.ts
+++ b/tests/e2e/specs/change-password.spec.ts
@@ -1,0 +1,93 @@
+import { lockVault, pressEnter, resetEmpty, unlock, waitFor } from "../helpers";
+
+// Changing the master password from Settings, and the only proof that matters:
+// the vault afterwards opens under the new password and refuses the old one.
+
+const OLD_PASSWORD = "Gt5$mQx8pWv3zKn!";
+const NEW_PASSWORD = "Bz7&rHd2jYc9tLm!";
+
+async function fill(name: string, value: string): Promise<void> {
+  const field = $(`input[name="${name}"]`);
+  await field.waitForDisplayed({ timeout: 10_000 });
+  await field.setValue(value);
+  await expect(field).toHaveValue(value);
+}
+
+async function openMasterPasswordSettings(): Promise<void> {
+  await waitFor("settings-button");
+  await $('[data-testid="settings-button"]').click();
+  await $("li=Master Password").waitForDisplayed({ timeout: 10_000 });
+  await $("li=Master Password").click();
+  await waitFor("change-password-submit");
+}
+
+async function submit(): Promise<void> {
+  await $('[data-testid="change-password-submit"]').click();
+}
+
+describe("change master password", () => {
+  before(async () => {
+    // Every selector below is an English label, and the locale lives in
+    // localStorage (which no reset clears) — pin it rather than inherit it.
+    await browser.execute(() => localStorage.setItem("locale", "en-US"));
+
+    await resetEmpty(OLD_PASSWORD);
+    await unlock(OLD_PASSWORD);
+    await openMasterPasswordSettings();
+  });
+
+  it("rejects a wrong current password", async () => {
+    await fill("current_password", "not-the-master-password");
+    await fill("new_password", NEW_PASSWORD);
+    await fill("new_password_repeat", NEW_PASSWORD);
+
+    await submit();
+
+    await waitFor("change-password-error");
+    await expect($('[data-testid="change-password-success"]')).not.toBeDisplayed();
+  });
+
+  it("will not submit while the new password and its repeat differ", async () => {
+    await fill("current_password", OLD_PASSWORD);
+    await fill("new_password", NEW_PASSWORD);
+    await fill("new_password_repeat", `${NEW_PASSWORD}-typo`);
+
+    // The form gates the mismatch on the control itself rather than by running
+    // the change and reporting a failure, so there is nothing to submit.
+    await expect($('[data-testid="change-password-submit"]')).toBeDisabled();
+    await expect($('[data-testid="change-password-success"]')).not.toBeDisplayed();
+  });
+
+  it("accepts the change and re-keys the vault", async () => {
+    await fill("current_password", OLD_PASSWORD);
+    await fill("new_password", NEW_PASSWORD);
+    await fill("new_password_repeat", NEW_PASSWORD);
+
+    await expect($('[data-testid="change-password-submit"]')).toBeEnabled();
+    await submit();
+
+    // Re-keying rewrites every row, so this one is slower than a UI round-trip.
+    await waitFor("change-password-success", 30_000);
+    await expect($('[data-testid="change-password-error"]')).not.toBeDisplayed();
+  });
+
+  it("opens under the new password and refuses the old one", async () => {
+    await $('[data-testid="modal-close"]').click();
+    await $('[data-testid="modal-close"]').waitForDisplayed({
+      reverse: true,
+      timeout: 10_000,
+    });
+
+    await lockVault();
+
+    await $('[data-testid="unlock-password-input"]').setValue(OLD_PASSWORD);
+    await pressEnter();
+    await waitFor("unlock-error");
+    await expect($('[data-testid="unlock-error"]')).toHaveText(
+      "Incorrect Master Password",
+    );
+
+    await unlock(NEW_PASSWORD);
+    await expect($('[data-testid="main-view"]')).toBeDisplayed();
+  });
+});

--- a/tests/e2e/specs/generator.spec.ts
+++ b/tests/e2e/specs/generator.spec.ts
@@ -1,0 +1,107 @@
+import { chord, resetEmpty, unlock, waitFor } from "../helpers";
+
+// The password generator dialog, opened both ways it can be reached: the
+// app-level chord (standalone — it copies) and the login editor's "generate"
+// link (it fills the field it was opened from).
+
+const MASTER_PASSWORD = "Nc8$jRt5vQz1mHf!";
+
+const output = () => $('[data-testid="generator-output"]');
+
+/** The slider reading — characters in random mode, words in memorable mode. */
+async function amount(): Promise<number> {
+  return Number(await $('[data-testid="generator-amount"]').getValue());
+}
+
+async function openGenerator(): Promise<void> {
+  await chord("g");
+  await waitFor("generator-dialog");
+  // The first value arrives from an async `generate` call.
+  await browser.waitUntil(async () => (await output().getText()) !== "", {
+    timeout: 10_000,
+    timeoutMsg: "the generator never produced a value",
+  });
+}
+
+/** Wait for the output to become something other than `previous`. */
+async function waitForNewValue(previous: string): Promise<string> {
+  await browser.waitUntil(
+    async () => {
+      const next = await output().getText();
+      return next !== "" && next !== previous;
+    },
+    { timeout: 10_000, timeoutMsg: `the generator output stayed at "${previous}"` },
+  );
+  return output().getText();
+}
+
+describe("password generator", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+  });
+
+  it("regenerates, switches shape between the two modes, and copies", async () => {
+    await openGenerator();
+
+    // Random mode draws exactly as many characters as the slider asks for.
+    const random = await output().getText();
+    expect(random).toHaveLength(await amount());
+
+    await $('[data-testid="generator-regenerate"]').click();
+    const regenerated = await waitForNewValue(random);
+    expect(regenerated).toHaveLength(await amount());
+
+    // Memorable mode is words joined by hyphens (plus a two-digit suffix),
+    // which is a shape random mode never produces.
+    await $('[data-testid="generator-mode-memorable"]').click();
+    const memorable = await waitForNewValue(regenerated);
+    const words = memorable.split("-");
+    expect(words.length).toBeGreaterThanOrEqual(await amount());
+    for (const word of words) expect(word).toMatch(/^[a-z]+$|^\d{2}$/);
+
+    await $('[data-testid="generator-mode-random"]').click();
+    const backToRandom = await waitForNewValue(memorable);
+    expect(backToRandom).toHaveLength(await amount());
+
+    // Standalone, "Use & copy" has nothing to apply to, so the clipboard toast
+    // is the whole feedback (the clipboard itself is not readable from wdio).
+    await $('[data-testid="generator-use-button"]').click();
+    await waitFor("copy-toast");
+    await expect($('[data-testid="generator-dialog"]')).not.toBeDisplayed();
+  });
+
+  it("fills the login editor's password field when opened from it", async () => {
+    await waitFor("scope-login");
+    await $('[data-testid="scope-login"]').click();
+    await $('[data-testid="add-entry-button"]').click();
+    await waitFor("entry-sheet");
+
+    const field = $('input[name="password"]');
+    await field.waitForDisplayed({ timeout: 10_000 });
+    await expect(field).toHaveValue("");
+
+    // The link next to the Password label (`Form/Login.tsx`) — it opens the
+    // same dialog with a callback bound to this field.
+    await $('[data-testid="entry-sheet"]').$("span*=generate").click();
+    await waitFor("generator-dialog");
+    await browser.waitUntil(async () => (await output().getText()) !== "", {
+      timeout: 10_000,
+      timeoutMsg: "the generator never produced a value",
+    });
+    const generated = await output().getText();
+
+    await $('[data-testid="generator-use-button"]').click();
+    await expect($('[data-testid="generator-dialog"]')).not.toBeDisplayed();
+    await expect(field).toHaveValue(generated);
+
+    // Leave the vault as the next spec's reset expects: discard the draft
+    // (Cancel arms, the second press discards).
+    await $('[data-testid="cancel-entry-button"]').click();
+    await $('[data-testid="cancel-entry-button"]').click();
+    await $('[data-testid="entry-sheet"]').waitForDisplayed({
+      reverse: true,
+      timeout: 10_000,
+    });
+  });
+});

--- a/tests/e2e/specs/palette.spec.ts
+++ b/tests/e2e/specs/palette.spec.ts
@@ -1,0 +1,106 @@
+import {
+  chord,
+  createLogin,
+  resetEmpty,
+  unlock,
+  waitFor,
+} from "../helpers";
+
+// The command palette: its chord is the only way in (nothing else calls
+// `openPalette`), entries and commands share one result list, and running a
+// command has to actually reach the app — so both commands asserted here are
+// checked by their effect, not by the row disappearing.
+
+const MASTER_PASSWORD = "Fy2$dLw9kXn6bVc!";
+const ENTRY_TITLE = "Palette Target Login";
+
+async function openPalette(): Promise<void> {
+  await chord("k");
+  await waitFor("command-palette");
+  await waitFor("command-palette-input");
+}
+
+/** The first result whose text contains `label`, or null while none does. */
+async function findItem(label: string) {
+  const rows = await $$('[data-testid="palette-item"]');
+  for (const row of rows) {
+    if ((await row.getText()).includes(label)) return row;
+  }
+  return null;
+}
+
+/** Type a query and wait for `label` to surface as a result row. */
+async function query(text: string, label: string): Promise<void> {
+  await $('[data-testid="command-palette-input"]').setValue(text);
+  await waitFor("palette-item");
+  await browser.waitUntil(async () => (await findItem(label)) !== null, {
+    timeout: 10_000,
+    timeoutMsg: `"${label}" never surfaced for the query "${text}"`,
+  });
+}
+
+/** Run the result matching `label`. */
+async function runItem(label: string): Promise<void> {
+  const row = await findItem(label);
+  if (!row) throw new Error(`[e2e] no palette row matching "${label}"`);
+  await row.click();
+}
+
+const theme = () =>
+  browser.execute(() => document.documentElement.getAttribute("data-theme"));
+
+describe("command palette", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+    await createLogin({
+      title: ENTRY_TITLE,
+      username: "palette@example.com",
+      password: "P4lette-Search-Key-3!",
+    });
+  });
+
+  it("surfaces a vault entry by title", async () => {
+    await openPalette();
+
+    // Empty query lists the commands only; entries need something to rank by.
+    await query("Palette Target", ENTRY_TITLE);
+    await runItem(ENTRY_TITLE);
+
+    // Opening an entry selects it in the list column and closes the palette.
+    await expect($('[data-testid="command-palette"]')).not.toBeDisplayed();
+    await waitFor("edit-entry-button");
+  });
+
+  it("runs Lock vault", async () => {
+    await openPalette();
+    await query("Lock", "Lock vault");
+    await runItem("Lock vault");
+
+    await waitFor("unlock-password-input");
+    await unlock(MASTER_PASSWORD);
+  });
+
+  it("runs Toggle theme", async () => {
+    const before = await theme();
+
+    await openPalette();
+    await query("Toggle theme", "Toggle theme");
+    await runItem("Toggle theme");
+
+    await browser.waitUntil(async () => (await theme()) !== before, {
+      timeout: 10_000,
+      timeoutMsg: `<html data-theme> stayed at "${before}"`,
+    });
+
+    // The theme is persisted to localStorage, which no reset clears — put it
+    // back so this spec leaves nothing behind for the rest of the run.
+    await openPalette();
+    await query("Toggle theme", "Toggle theme");
+    await runItem("Toggle theme");
+    await browser.waitUntil(async () => (await theme()) === before, {
+      timeout: 10_000,
+      timeoutMsg: `<html data-theme> never returned to "${before}"`,
+    });
+  });
+});

--- a/tests/e2e/specs/sync-indicator.spec.ts
+++ b/tests/e2e/specs/sync-indicator.spec.ts
@@ -1,0 +1,17 @@
+import { resetEmpty, unlock, waitFor } from "../helpers";
+
+// The header's sync pill on a vault that was never connected to a remote.
+// Nothing here touches sync itself — no provider is configured, so the only
+// state the app can be in is the local-only one.
+
+const MASTER_PASSWORD = "Hv6#nTc4qWs8zRb!";
+
+describe("sync indicator", () => {
+  it("reads Local on a vault with no sync configured", async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+
+    await waitFor("sync-indicator");
+    await expect($('[data-testid="sync-indicator"]')).toHaveText("Local");
+  });
+});


### PR DESCRIPTION
PR 4 of 4 (batches 2–4 independent; COVERAGE.md deliberately untouched).

Five new feature specs on the post-#290 harness. Every spec opens with its own
`resetPristine()` / `resetEmpty()`, every assert is preceded by a wait, and
there are no fixed pauses.

| Spec | What it covers |
| --- | --- |
| `audit.spec.ts` | Seeds two logins sharing a password and one with `abc`; opens `scope-audit` and asserts the rail dial, the score, Weak = 1 and Reused = 2, then re-passwords both entries and watches the counts fall to 0 and the score rise. |
| `generator.spec.ts` | Opens the dialog with its chord: output non-empty and as long as the slider asks, regenerate changes it, memorable mode switches to hyphen-joined words, "Use & copy" raises `copy-toast`. Then opens it from the login editor's "generate" link and asserts it fills that password field. |
| `palette.spec.ts` | Opens with its chord, surfaces an entry by title as a `palette-item`, runs **Lock vault** (lands on unlock) and **Toggle theme** (`<html data-theme>` flips, then is toggled back). |
| `change-password.spec.ts` | Wrong current password → `change-password-error`; a mismatched repeat leaves Update disabled; a valid change → `change-password-success`; then lock, confirm the old password gives "Incorrect Master Password", and unlock with the new one. |
| `sync-indicator.spec.ts` | Fresh vault, `sync-indicator` reads "Local". No sync interaction. |

### Also in here

- `tests/e2e/helpers/keys.ts` — `chord()` / `pressEnter()`. The chord modifier is
  Meta on macOS and Control on the Linux CI runner (`useShortcuts` accepts
  either; Meta never reaches the page under a window manager that owns Super).
- `data-testid="modal-close"` on the shared `Modal` — no behaviour change, so
  the change-password spec can leave Settings the way a user would.

### Runtime

| | Spec files | Tests | Wall |
| --- | --- | --- | --- |
| Before | 2 | 3 | ~17s |
| After | 7 | 15 | ~59s |

About 42s added, against a ~2.5 min budget.

### Notes / deviations

- **Breached stat.** `breachCheck` is opt-in and off by default
  (`src/defaults/audit.ts`), and the group is only rendered when it is on, so
  the audit spec pins the preference off and asserts the group is *absent*
  rather than depending on an HIBP range query. Weak and Reused are seeded and
  asserted by value.
- **Mismatched repeat.** `MasterPassword.tsx` gates the mismatch on the Update
  button (`disabled`) instead of running the change and reporting a failure, so
  the spec asserts the disabled control and the absence of a success message —
  there is no error to surface.
- **eslint.** `eslint.config.js` scopes its only config block to `src/**`, so
  `tests/e2e` is not lintable in this repo and `eslint src tests/e2e` errors out
  as "all files ignored". Ran CI's own `eslint src --max-warnings 0` (clean); a
  config block for `tests/**` felt out of scope for a spec PR.

### Gates

- Full local e2e suite green: 7 spec files, 15 tests, 0 failures. Each new spec
  also verified passing on its own.
- `tsc --noEmit` (src) and `tsc -p tests/e2e/tsconfig.json --noEmit` clean.
- `eslint src --max-warnings 0` clean.
- `bun run test` — 21 files, 138 tests passing (`Modal.tsx` touched).

One local-only note for macOS reviewers: WebKit suspends CSS animations while
the app window is occluded, so the sheet and palette overlays never finish
animating in and the suite fails on any backgrounded window — including the
pre-existing smoke/isolation specs. Keeping the app frontmost during the run
works around it. Not touched here; CI on Linux/xvfb is unaffected.
