### PR TITLE
test(e2e): content kinds — cards, notes, tags, list states

### DIFF
--- a/src/components/elements/TagsInput.tsx
+++ b/src/components/elements/TagsInput.tsx
@@ -39,6 +39,8 @@ export default function TagsInput({ value, onChange }: Props) {
         </span>
       ))}
       <input
+        // The one input in the entry form with no `name` — specs address it here.
+        data-testid="tags-input"
         className="min-w-[80px] flex-1 !border-0 !bg-transparent !p-1 !text-base !text-text !outline-none"
         value={input}
         onChange={e => setInput(e.target.value)}

--- a/tests/e2e/helpers/entries.ts
+++ b/tests/e2e/helpers/entries.ts
@@ -15,6 +15,7 @@ export interface LoginFields {
   username: string;
   password: string;
   website?: string;
+  tags?: string[];
 }
 
 export interface CardFields {
@@ -25,11 +26,13 @@ export interface CardFields {
   cvc: string;
   pin: string;
   name?: string;
+  tags?: string[];
 }
 
 export interface NoteFields {
   title: string;
   note: string;
+  tags?: string[];
 }
 
 async function openForm(scope: Scope): Promise<void> {
@@ -44,6 +47,20 @@ async function openForm(scope: Scope): Promise<void> {
 // textarea for note bodies), so there is no per-field testid to depend on.
 async function fill(name: string, value: string, tag = "input"): Promise<void> {
   await $(`${tag}[name="${name}"]`).setValue(value);
+}
+
+// Tags live in a chip input, not a plain field: each tag is committed with
+// Enter (the component also commits on blur, but Enter keeps the caret in the
+// input for the next one). Enter inside the sheet is inert — the sheet only
+// submits on ⌘/Ctrl+Enter — so this never saves early.
+async function fillTags(tags: string[] = []): Promise<void> {
+  if (tags.length === 0) return;
+  const input = $('[data-testid="tags-input"]');
+  await input.waitForDisplayed({ timeout: 5_000 });
+  for (const tag of tags) {
+    await input.setValue(tag);
+    await browser.keys("Enter");
+  }
 }
 
 // Save and wait for the sheet to close, which is the store's "write landed"
@@ -62,6 +79,7 @@ export async function createLogin(fields: LoginFields): Promise<void> {
   if (fields.website !== undefined) await fill("website", fields.website);
   await fill("username", fields.username);
   await fill("password", fields.password);
+  await fillTags(fields.tags);
   await save();
 }
 
@@ -74,6 +92,7 @@ export async function createCard(fields: CardFields): Promise<void> {
   await fill("cvc", fields.cvc);
   await fill("pin", fields.pin);
   if (fields.name !== undefined) await fill("name", fields.name);
+  await fillTags(fields.tags);
   await save();
 }
 
@@ -81,6 +100,7 @@ export async function createNote(fields: NoteFields): Promise<void> {
   await openForm("note");
   await fill("title", fields.title);
   await fill("note", fields.note, "textarea");
+  await fillTags(fields.tags);
   await save();
 }
 

--- a/tests/e2e/specs/cards.spec.ts
+++ b/tests/e2e/specs/cards.spec.ts
@@ -1,0 +1,105 @@
+import {
+  createCard,
+  entryItems,
+  resetEmpty,
+  unlock,
+  waitFor,
+} from "../helpers";
+
+// The card detail is an interactive card face, not a list of rows: every value
+// copies on click and one eye reveals number/CVC/PIN together. These specs
+// cover that face plus the brand mark the number is derived into at save.
+
+const MASTER_PASSWORD = "Hq6&tWn4jZv8mB!e";
+
+const VISA = {
+  title: "Visa Everyday",
+  number: "4111111111111111",
+  month: "04",
+  year: "2029",
+  cvc: "123",
+  pin: "4321",
+  name: "ADA LOVELACE",
+};
+
+const MASTERCARD = {
+  title: "Mastercard Travel",
+  number: "5555555555554444",
+  month: "11",
+  year: "2030",
+  cvc: "456",
+  pin: "8765",
+};
+
+const MASKED_NUMBER = "•••• •••• •••• 1111";
+const REVEALED_NUMBER = "4111 1111 1111 1111";
+
+const value = (field: string) => $(`[data-testid="entry-value-${field}"]`);
+const brandMark = (slug: string) => $(`svg[aria-label="${slug}"]`);
+
+describe("card entries", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+    await createCard(VISA);
+    // Saving selects the new entry, so the face is what the detail pane shows.
+    await waitFor("entry-value-number");
+  });
+
+  it("renders the saved values on the card face, secrets masked", async () => {
+    await expect(value("number")).toHaveText(MASKED_NUMBER);
+    await expect(value("cvc")).toHaveText("•••");
+    await expect(value("pin")).toHaveText("••••");
+    // Expiry and cardholder are not secrets — they read plainly.
+    await expect(value("expires")).toHaveText("04/29");
+    await expect(value("name")).toHaveText(VISA.name);
+  });
+
+  it("shows the brand mark derived from the number", async () => {
+    await brandMark("visa").waitForDisplayed({ timeout: 15_000 });
+    await expect(brandMark("visa")).toBeDisplayed();
+  });
+
+  it("reveals number, CVC and PIN together and hides them again", async () => {
+    await waitFor("card-reveal-button");
+    await $('[data-testid="card-reveal-button"]').click();
+
+    await expect(value("number")).toHaveText(REVEALED_NUMBER);
+    await expect(value("cvc")).toHaveText(VISA.cvc);
+    await expect(value("pin")).toHaveText(VISA.pin);
+
+    await $('[data-testid="card-reveal-button"]').click();
+
+    await expect(value("number")).toHaveText(MASKED_NUMBER);
+    await expect(value("cvc")).toHaveText("•••");
+    await expect(value("pin")).toHaveText("••••");
+  });
+
+  it("copies the number on click and confirms with the toast", async () => {
+    const toast = $('[data-testid="copy-toast"]');
+    // The toast lives in the DOM permanently and is toggled with `hidden`, so
+    // "not displayed" is the resting state, not a missing element.
+    await expect(toast).not.toBeDisplayed();
+
+    await waitFor("entry-value-number");
+    await value("number").click();
+
+    await expect(toast).toBeDisplayed();
+    await expect(toast).toHaveText("Copied to Clipboard");
+
+    // Let it time out rather than leaking a visible toast into the next test.
+    await toast.waitForDisplayed({ reverse: true, timeout: 10_000 });
+  });
+
+  it("derives the mastercard mark from a mastercard number", async () => {
+    await createCard(MASTERCARD);
+    await browser.waitUntil(async () => (await entryItems()).length === 2, {
+      timeout: 15_000,
+      timeoutMsg: "the second card never reached the list",
+    });
+
+    await brandMark("mastercard").waitForDisplayed({ timeout: 15_000 });
+    await expect(brandMark("mastercard")).toBeDisplayed();
+    await expect(value("number")).toHaveText("•••• •••• •••• 4444");
+  });
+});

--- a/tests/e2e/specs/list.spec.ts
+++ b/tests/e2e/specs/list.spec.ts
@@ -1,0 +1,121 @@
+import { createLogin, entryItems, resetEmpty, unlock, waitFor } from "../helpers";
+
+// The list column itself: what a vault with nothing in it offers, and the two
+// orders the sort menu can put entries in.
+
+const MASTER_PASSWORD = "Wc8*hFj5pAe0uY!s";
+
+const PASSWORD = "L1st-Ord3r-Test-Pw!";
+const ZEPHYR = "Zephyr Mail";
+const ACME = "Acme Bank";
+const MERCURY = "Mercury Cloud";
+
+type SortMode = "recent" | "alpha";
+
+async function pickSort(mode: SortMode): Promise<void> {
+  await waitFor("sort-menu");
+  await $('[data-testid="sort-menu"]').click();
+  await waitFor(`sort-option-${mode}`);
+  await $(`[data-testid="sort-option-${mode}"]`).click();
+  // The menu closes on pick; wait for that before reading the list back.
+  await $(`[data-testid="sort-option-${mode}"]`).waitForDisplayed({
+    reverse: true,
+    timeout: 5_000,
+  });
+}
+
+async function titles(): Promise<string[]> {
+  const rows = await $$('[data-testid="entry-item-title"]');
+  const out: string[] = [];
+  for (const row of rows) out.push(await row.getText());
+  return out;
+}
+
+async function expectOrder(expected: string[]): Promise<void> {
+  await browser.waitUntil(
+    async () => (await titles()).join(" | ") === expected.join(" | "),
+    {
+      timeout: 15_000,
+      timeoutMsg: `list never settled on ${expected.join(" | ")}`,
+    },
+  );
+}
+
+// Click the row with this title. Rows carry no per-entry testid, so they are
+// matched on their title text.
+async function openEntry(title: string): Promise<void> {
+  const rows = await $$('[data-testid="entry-item"]');
+  for (const row of rows) {
+    if ((await row.$('[data-testid="entry-item-title"]').getText()) === title) {
+      await row.click();
+      return;
+    }
+  }
+  throw new Error(`[e2e] no list row titled "${title}"`);
+}
+
+describe("entry list states and ordering", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+    // The sort mode is a persisted UI preference, so a previous spec (or a
+    // previous partial run) could leave it on alpha. Start from the default.
+    await pickSort("recent");
+  });
+
+  it("offers the first-entry action on an empty vault and opens the create sheet", async () => {
+    await waitFor("create-first-entry-button");
+    expect(await entryItems()).toHaveLength(0);
+
+    await $('[data-testid="create-first-entry-button"]').click();
+    await waitFor("entry-sheet");
+
+    await $('[data-testid="cancel-entry-button"]').click();
+    await $('[data-testid="entry-sheet"]').waitForDisplayed({
+      reverse: true,
+      timeout: 15_000,
+    });
+    await waitFor("create-first-entry-button");
+  });
+
+  it("orders entries A to Z under Alphabetical", async () => {
+    // Seeded out of alphabetical order on purpose.
+    for (const title of [ZEPHYR, ACME, MERCURY]) {
+      await createLogin({
+        title,
+        username: `${title.split(" ")[0].toLowerCase()}@example.com`,
+        password: PASSWORD,
+      });
+    }
+    await browser.waitUntil(async () => (await entryItems()).length === 3, {
+      timeout: 20_000,
+      timeoutMsg: "the seed entries never reached the list",
+    });
+
+    await pickSort("alpha");
+    await expectOrder([ACME, MERCURY, ZEPHYR]);
+  });
+
+  it("puts the most recently edited entry first under Recent", async () => {
+    await pickSort("recent");
+    // Newest write first: the seed order reversed.
+    await expectOrder([MERCURY, ACME, ZEPHYR]);
+
+    // Re-saving restamps `updatedAt`, which is what Recent orders on — so the
+    // oldest entry should jump to the top.
+    await openEntry(ZEPHYR);
+    await waitFor("edit-entry-button");
+    await $('[data-testid="edit-entry-button"]').click();
+    await waitFor("entry-sheet");
+    // Saving before the decrypted values land would submit an invalid draft.
+    await expect($('input[name="password"]')).toHaveValue(PASSWORD);
+
+    await $('[data-testid="save-entry-button"]').click();
+    await $('[data-testid="entry-sheet"]').waitForDisplayed({
+      reverse: true,
+      timeout: 15_000,
+    });
+
+    await expectOrder([ZEPHYR, MERCURY, ACME]);
+  });
+});

--- a/tests/e2e/specs/notes.spec.ts
+++ b/tests/e2e/specs/notes.spec.ts
@@ -1,0 +1,66 @@
+import { createNote, resetEmpty, unlock, waitFor } from "../helpers";
+
+// Known app bug (not fixed here): `useRevealed` keys the decrypt on the entry
+// id alone, so after an in-place save the detail pane keeps serving the
+// pre-edit plaintext. Clearing the selection unmounts the pane, so re-opening
+// the entry forces a fresh reveal — which is what this asserts against.
+async function reopenFirstEntry(): Promise<void> {
+  await waitFor("scope-login");
+  await $('[data-testid="scope-login"]').click();
+  await waitFor("scope-note");
+  await $('[data-testid="scope-note"]').click();
+  await waitFor("entry-item");
+  await $('[data-testid="entry-item"]').click();
+  await waitFor("entry-value-note");
+}
+
+// Secure notes: the body is a single encrypted field, so the round-trip that
+// matters is "what was typed comes back, and an edit replaces it".
+
+const MASTER_PASSWORD = "Rj3^bYu7nCx1qF!d";
+
+const TITLE = "Recovery Codes";
+// Single-line on purpose: `getText()` is rendered text, and asserting exact
+// newlines through it would be testing the driver's whitespace handling.
+const NOTE = "recovery code 8842-1907";
+const EDITED_NOTE = "recovery code 3316-5520 (rotated)";
+
+describe("secure notes", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+    await createNote({ title: TITLE, note: NOTE });
+    await waitFor("entry-item");
+  });
+
+  it("renders the note body in the detail pane", async () => {
+    await waitFor("entry-value-note");
+    await expect($('[data-testid="entry-value-note"]')).toHaveText(NOTE);
+    await expect($('[data-testid="entry-item-title"]')).toHaveText(TITLE);
+  });
+
+  it("round-trips an edit of the body", async () => {
+    await waitFor("edit-entry-button");
+    await $('[data-testid="edit-entry-button"]').click();
+    await waitFor("entry-sheet");
+
+    // The form opens on encrypted metadata and swaps in the decrypted values a
+    // tick later; typing before that lands would be overwritten.
+    const body = $('textarea[name="note"]');
+    await expect(body).toHaveValue(NOTE);
+
+    await body.setValue(EDITED_NOTE);
+    await expect(body).toHaveValue(EDITED_NOTE);
+
+    await $('[data-testid="save-entry-button"]').click();
+    await $('[data-testid="entry-sheet"]').waitForDisplayed({
+      reverse: true,
+      timeout: 15_000,
+    });
+
+    await reopenFirstEntry();
+    await expect($('[data-testid="entry-value-note"]')).toHaveText(
+      EDITED_NOTE,
+    );
+  });
+});

--- a/tests/e2e/specs/tags.spec.ts
+++ b/tests/e2e/specs/tags.spec.ts
@@ -1,0 +1,75 @@
+import { createLogin, entryItems, resetEmpty, unlock, waitFor } from "../helpers";
+
+// Tags are typed into the entry form and surface as a filter chip row above
+// the list, scoped to the current rail selection.
+
+const MASTER_PASSWORD = "Ld5!gXm2vQr6tN@k";
+
+const UNTAGGED = "Untagged Account";
+const WORK_ENTRY = "Work Account";
+const HOME_ENTRY = "Home Account";
+
+const CREDENTIALS = {
+  username: "tagged@example.com",
+  password: "T@gg3d-Pa55word-4!",
+};
+
+const chip = (tag: string) => $(`[data-testid="tag-item"][data-tag="${tag}"]`);
+
+// Wait for the list to settle on a row count before reading it.
+async function expectRowCount(count: number): Promise<void> {
+  await browser.waitUntil(async () => (await entryItems()).length === count, {
+    timeout: 15_000,
+    timeoutMsg: `the list never settled on ${count} row(s)`,
+  });
+}
+
+describe("tag filtering", () => {
+  before(async () => {
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+  });
+
+  it("shows no chip row while nothing in scope is tagged", async () => {
+    await waitFor("main-view");
+    await expect($('[data-testid="tags-list"]')).not.toBeDisplayed();
+
+    // Still nothing to filter by once an untagged entry exists.
+    await createLogin({ title: UNTAGGED, ...CREDENTIALS });
+    await waitFor("entry-item");
+    await expect($('[data-testid="tags-list"]')).not.toBeDisplayed();
+  });
+
+  it("surfaces one chip per tag used in the current scope", async () => {
+    await createLogin({ title: WORK_ENTRY, ...CREDENTIALS, tags: ["work"] });
+    await createLogin({ title: HOME_ENTRY, ...CREDENTIALS, tags: ["home"] });
+    await expectRowCount(3);
+
+    await waitFor("tags-list");
+    await expect($$('[data-testid="tag-item"]')).toBeElementsArrayOfSize(2);
+    await expect(chip("home")).toBeDisplayed();
+    await expect(chip("work")).toBeDisplayed();
+  });
+
+  it("filters the list to the selected tag and clears on a second press", async () => {
+    await chip("work").waitForDisplayed({ timeout: 15_000 });
+    await chip("work").click();
+
+    await expectRowCount(1);
+    await expect($('[data-testid="entry-item-title"]')).toHaveText(WORK_ENTRY);
+    await expect(chip("work")).toHaveAttribute("aria-pressed", "true");
+
+    await chip("work").click();
+
+    await expectRowCount(3);
+    await expect(chip("work")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("keeps the chip row out of a scope with no tagged entries", async () => {
+    await waitFor("scope-note");
+    await $('[data-testid="scope-note"]').click();
+
+    await expectRowCount(0);
+    await expect($('[data-testid="tags-list"]')).not.toBeDisplayed();
+  });
+});


### PR DESCRIPTION
Batch 3 of the E2E spec port, on top of the PR #290 harness. Feature specs only — no harness or `COVERAGE.md` changes.

## Specs

| File | Covers |
|---|---|
| `tests/e2e/specs/cards.spec.ts` | Card face renders the saved values (number/CVC/PIN masked, expiry + cardholder plain); the `visa` brand mark is derived from the number; `card-reveal-button` reveals number+CVC+PIN together and hides them again; clicking the number copies it and raises the `copy-toast`; a mastercard number yields the `mastercard` mark. |
| `tests/e2e/specs/notes.spec.ts` | A secure note's body renders in `entry-value-note`, and an edit round-trips through the form back into the detail pane. |
| `tests/e2e/specs/tags.spec.ts` | No chip row while nothing in scope is tagged; one `tag-item` per tag once entries carry them; selecting a chip filters the list and a second press clears it; the row stays absent in a scope with no tagged entries. |
| `tests/e2e/specs/list.spec.ts` | A fresh vault offers `create-first-entry-button` and it opens the create sheet; `sort-option-alpha` orders A→Z; `sort-option-recent` puts the most recently edited entry first (an older entry is re-saved and moves to the top). |

## Supporting changes

- `data-testid="tags-input"` on the `TagsInput` field — it is the only input in the entry form without a `name`, so there was nothing stable to address it by. No behaviour change.
- `tags?: string[]` added to `createLogin` / `createCard` / `createNote`, committed through that input with Enter. Purely additive; existing callers are untouched.

## Suite runtime

| | Spec files | Tests | wdio wall |
|---|---|---|---|
| Before (`smoke` + `isolation`) | 2 | 3 | 37s |
| After | 6 | 17 | 49s |

**+12s**, well inside the ~2 minute budget. Every spec also passes on its own (`--spec <file>`): cards 5/5 in 6.9s, list 3/3 in 9.0s, notes 2/2 in 4.6s, tags 4/4 in 6.0s. Zero fixed pauses — every assertion is preceded by a wait.

## Notes for review

- **Tags empty state** is asserted as the *absence* of `tags-list`, matching `COVERAGE.md` row 14 ("`tags-list` absent when no entry carries a tag"). The `Tags` component returns `null` when no tag is in use — there is no hint element to assert.
- **Known stale-reveal bug** (not fixed here): `useRevealed` keys the decrypt on the entry id alone, so the detail pane keeps serving pre-edit plaintext after an in-place save. `notes.spec.ts` re-opens the entry before asserting the edited body, with an in-file comment pointing at the bug.
- **macOS local runs**: WebKit suspends CSS animations while the app window is occluded, and the entry sheet animates in from `opacity: 0` with `animation-fill-mode: both` — so every create helper times out on `entry-sheet` locally unless the window is kept frontmost. Environment-only; CI (Linux/xvfb) is unaffected, and nothing in the harness was changed for it.

PR 3 of 4 (batches 2–4 independent; `COVERAGE.md` deliberately untouched).
