### PR TITLE
fix(entries): stale decrypt after in-place save — copy served the old password

### DIFF
--- a/src/components/Main/Body/Aside/Form/index.tsx
+++ b/src/components/Main/Body/Aside/Form/index.tsx
@@ -35,13 +35,19 @@ export default function Form({ entry }: Props) {
   // What the model looked like when it was last loaded — the dirty baseline.
   const [pristine, setPristine] = useState<EntryDraft>(initial)
 
-  // When editing, secret fields arrive encrypted; swap in the decrypted values.
+  // When editing, secret fields arrive encrypted; swap in the decrypted values —
+  // once. The hook refetches when the entry's `updatedAt` moves (e.g. a sync
+  // merge landing mid-edit), and adopting that refetch here would silently
+  // replace whatever the user has typed. The form's baseline is the state at
+  // open; a concurrent change resolves through last-writer-wins on save.
   const revealed = useRevealed(entry)
+  const [adopted, setAdopted] = useState(false)
   useEffect(() => {
-    if (!revealed) return
+    if (!revealed || adopted) return
+    setAdopted(true)
     setModel({ ...revealed })
     setPristine({ ...revealed })
-  }, [revealed])
+  }, [revealed, adopted])
 
   const dirty = JSON.stringify(model) !== JSON.stringify(pristine)
 

--- a/src/hooks/useRevealed.ts
+++ b/src/hooks/useRevealed.ts
@@ -5,9 +5,15 @@ import { revealEntry, type Entry } from '@/lib/commands'
 // whole vault is never decrypted at once, only the entry currently in view/edit.
 // Takes anything carrying an id (list metadata or a full entry). Returns null
 // until the reveal resolves (and for missing entries).
-export function useRevealed(entry?: { id: string } | null): Entry | null {
+//
+// Keyed on `updatedAt` as well as `id`: the id survives an in-place save, and a
+// decrypt keyed on it alone kept serving the PRE-edit secrets to a detail pane
+// that stays mounted across saves — including its "Copy password" action, which
+// then copied the rotated-away password.
+export function useRevealed(entry?: { id: string; updatedAt?: string } | null): Entry | null {
   const [revealed, setRevealed] = useState<Entry | null>(null)
   const id = entry?.id
+  const stamp = entry?.updatedAt
 
   useEffect(() => {
     setRevealed(null)
@@ -19,7 +25,7 @@ export function useRevealed(entry?: { id: string } | null): Entry | null {
     return () => {
       active = false
     }
-  }, [id])
+  }, [id, stamp])
 
   return revealed
 }

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -89,6 +89,27 @@ describe('Form', () => {
     )
     expect(screen.queryByTestId('generator-dialog')).not.toBeInTheDocument()
   })
+
+  it('keeps in-progress edits when the entry refreshes mid-edit', async () => {
+    // The revealed title differs from the metadata title so this wait proves
+    // the decrypted values were actually adopted, not just the initial meta.
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ title: 'Google (decrypted)' }))
+    const { rerender } = renderWithStore(<Form entry={loginMeta()} />)
+    const title = document.querySelector<HTMLInputElement>('input[name="title"]')!
+    await waitFor(() => expect(title.value).toBe('Google (decrypted)'))
+
+    await userEvent.clear(title)
+    await userEvent.type(title, 'Renamed by me')
+
+    // A sync merge landing mid-edit bumps updatedAt and re-runs the decrypt.
+    // The form adopts the reveal once, at open — a refetch must not clobber
+    // what the user has typed (their save wins by last-writer-wins anyway).
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ title: 'Merged elsewhere' }))
+    rerender(<Form entry={loginMeta({ updatedAt: '2024-06-01T00:00:00.000Z' })} />)
+    await waitFor(() => expect(revealEntry).toHaveBeenCalledTimes(2))
+
+    expect(title.value).toBe('Renamed by me')
+  })
 })
 
 describe('Show', () => {
@@ -128,6 +149,26 @@ describe('Show', () => {
     expect(copyToClipboard).toHaveBeenCalledWith('hunter2', expect.any(Number))
     // The password row is still masked: nothing toggled its reveal.
     expect(screen.getByTitle('Reveal')).toBeInTheDocument()
+  })
+
+  it('re-decrypts after an in-place save, so copy never serves the old secret', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'old-secret' }))
+    const { rerender } = renderWithStore(<Show entry={loginMeta()} />)
+    const action = await screen.findByTestId('primary-action-button')
+    await waitFor(() => expect(action).toBeEnabled())
+
+    // A save keeps the id but stamps updatedAt. The pane stays mounted across
+    // saves, so a decrypt keyed on the id alone kept serving — and copying —
+    // the pre-edit password. The regression: rotate, then copy.
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'new-secret' }))
+    rerender(<Show entry={loginMeta({ updatedAt: '2024-06-01T00:00:00.000Z' })} />)
+    await waitFor(() => expect(revealEntry).toHaveBeenCalledTimes(2))
+
+    const refreshed = screen.getByTestId('primary-action-button')
+    await waitFor(() => expect(refreshed).toBeEnabled())
+    await userEvent.click(refreshed)
+
+    expect(copyToClipboard).toHaveBeenCalledWith('new-secret', expect.any(Number))
   })
 
   it('runs the primary action on a bare Enter', async () => {

--- a/tests/e2e/specs/logins-crud.spec.ts
+++ b/tests/e2e/specs/logins-crud.spec.ts
@@ -85,13 +85,20 @@ describe("login entries", () => {
     await expect($('[data-testid="entry-value-username"]')).toHaveText(USERNAME);
     expect(await entryItems()).toHaveLength(1);
 
-    // The rotated secret is read back through a fresh decrypt (reopening the
-    // editor) rather than off the detail pane. `useRevealed` keys its decrypt
-    // on the entry id alone, so saving in place leaves the pane — and the
-    // header's "Copy password" — holding the values decrypted before the edit.
-    // That staleness is a bug, not a contract, so this spec deliberately does
-    // not assert `entry-value-password` here; once the decrypt re-runs on
-    // save, add that assertion back.
+    // The pane re-decrypts after an in-place save (`useRevealed` keys on
+    // updatedAt as well as the id), so the rotated secret shows up right here —
+    // this assertion is the regression test for the stale-reveal bug.
+    await browser.waitUntil(
+      async () =>
+        (await $('[data-testid="entry-value-password"]').getText()) ===
+        EDITED_PASSWORD,
+      {
+        timeout: 15_000,
+        timeoutMsg: "the detail pane kept the pre-edit password after a save",
+      },
+    );
+
+    // And the editor agrees on a fresh decrypt.
     await openEditor(EDITED_PASSWORD);
     await expect(field("title")).toHaveValue(EDITED_TITLE);
     await closeEditor();


### PR DESCRIPTION
## The bug
`useRevealed` keyed its decrypt on the entry **id** alone. An in-place save keeps the id, and the detail pane stays mounted across saves — so after rotating a password, the pane kept rendering the pre-edit values and **the header's Copy password copied the rotated-away password**. Caught by the e2e suite's login-CRUD spec on its first run (#291 carried a workaround + pointer comment).

## The fix
- `useRevealed` keys on `updatedAt` as well as `id` — every save (and every sync merge) stamps it, so the pane re-decrypts exactly when content can have changed.
- The edit form adopts the decrypted values **once per open**: with the hook now refetching on `updatedAt`, a sync merge landing mid-edit would otherwise silently clobber unsaved typing. Baseline stays the open-time state; concurrent edits resolve by LWW on save (guarded by its own regression test).

## Tests
- vitest: `Show` re-decrypts after a save and copies the **new** secret; `Form` keeps in-progress edits through a mid-edit refetch. 140 passing (+2).
- e2e: the deliberately-downgraded pane assertion in `logins-crud.spec.ts` is restored — the spec now fails without this fix. Full local suite: **15 files / 40 tests green**.
- Gates: tsc, eslint, e2e-project tsc all clean. No Rust changes.