### PR TITLE
feat(window): set a minimum window size

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,8 @@
         "create": false,
         "width": 900,
         "height": 700,
+        "minWidth": 820,
+        "minHeight": 640,
         "center": true,
         "resizable": true,
         "transparent": true,


### PR DESCRIPTION
Adds `minWidth: 820` / `minHeight: 640` to the main window in `tauri-conf`. Default stays 900x700, so the window still resizes down.

The numbers come from the layout parts that do not shrink:

- **820** = 68px icon rail + 348px list column + 404px detail pane (68px of it padding, leaving ~336px of content, enough for the 208px OTP column next to a readable field panel). It also clears the fixed-width overlays: the 620px command palette and the 520px form sheet.
- **640** — the settings modal is the tallest fixed surface (`min-h-[560px]` inside a `pt-[10vh]` / `p-4` scrim), so (560 + 16) / 0.9 = 640 is the point below which it starts getting cropped.

Base is `v1-0-0`, not `master`.