### PR TITLE
feat(lock): set the passphrase card into the ground instead of floating it

### DIFF
--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -42,10 +42,12 @@ interface Props {
 // the design in both themes.
 //
 // The lock variant is deliberately unlike every other field in the app: a
-// floating white card with big centered dots, whose halo carries the state —
-// accent on focus, red (plus a shake) on a bad passphrase, green while a
-// successful unlock lands. Its only chrome is Touch ID (primary) and reveal
-// (secondary, only once there is something to reveal) on the right edge.
+// white card set gently into the window ground (see --lockfield-shadow) with
+// big centered dots, whose border + halo carry the state — accent on focus,
+// red (plus a shake) on a bad passphrase, green while a successful unlock
+// lands — while focus also cuts a touch deeper. Its only chrome is Touch ID
+// (primary) and reveal (secondary, only once there is something to reveal) on
+// the right edge.
 export default function Masterpass({
   error,
   touchID,
@@ -151,7 +153,10 @@ export default function Masterpass({
           // In-card icon buttons (reveal, Touch ID) share a softened hover
           // wash; the ! outranks IconButton's own hover:bg-hover, in this one
           // place instead of at every button.
-          'relative mx-auto flex h-12 max-w-[380px] items-stretch rounded-xl border bg-detail shadow-[var(--lockfield-shadow)] transition-all duration-300 [&_button:hover]:bg-hover/60!',
+          'relative mx-auto flex h-12 max-w-[380px] items-stretch rounded-xl border bg-detail transition-all duration-300 [&_button:hover]:bg-hover/60!',
+          // The inset shadow is the cut; focus goes a touch deeper. It and the
+          // state halo (ring) are both box-shadow, so Tailwind composes them.
+          'shadow-[var(--lockfield-shadow)] focus-within:shadow-[var(--lockfield-shadow-deep)]',
           bad
             ? 'border-bad/60 ring-4 ring-bad/10 animate-[nudge_420ms_ease_both]'
             : success

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -401,9 +401,20 @@
   --shadow: 0 24px 60px rgba(24, 26, 30, 0.16), 0 1px 3px rgba(24, 26, 30, 0.1);
   --scrim: rgba(40, 43, 48, 0.3);
   --thumb: rgba(20, 22, 26, 0.22);
-  /* The lock screen's signature field: soft, layered float (see Masterpass). */
-  --lockfield-shadow: 0 1px 2px rgba(20, 22, 26, 0.05),
-    0 14px 36px rgba(20, 22, 26, 0.1);
+  /*
+   * The lock screen's signature field (see Masterpass): a white surface set
+   * gently *into* the ground rather than floating on it. A faint shadow along
+   * the inside top (light from above) and a 1px highlight just under the
+   * bottom edge — the lip catching the light. `deep` is the focused cut, a
+   * touch deeper. The edge itself is the card's border; the state halo is a
+   * Tailwind ring, and all three compose as one box-shadow.
+   */
+  --lockfield-shadow:
+    inset 0 1.5px 3px rgba(20, 22, 26, 0.09),
+    0 1px 0 rgba(255, 255, 255, 0.7);
+  --lockfield-shadow-deep:
+    inset 0 2px 5px rgba(20, 22, 26, 0.13),
+    0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 :root[data-theme='dark'] {
@@ -441,6 +452,10 @@
   --shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
   --scrim: rgba(8, 9, 10, 0.7);
   --thumb: rgba(255, 255, 255, 0.14);
-  --lockfield-shadow: 0 1px 2px rgba(0, 0, 0, 0.45),
-    0 18px 44px rgba(0, 0, 0, 0.5);
+  --lockfield-shadow:
+    inset 0 1.5px 3px rgba(0, 0, 0, 0.5),
+    0 1px 0 rgba(255, 255, 255, 0.04);
+  --lockfield-shadow-deep:
+    inset 0 2px 5px rgba(0, 0, 0, 0.65),
+    0 1px 0 rgba(255, 255, 255, 0.05);
 }


### PR DESCRIPTION
## What

Replaces the lock screen passphrase card's floating drop shadow with a subtle inset, so the white card reads as gently set into the window ground rather than hovering over it.

- `--lockfield-shadow` is now an inset pair: a faint shadow along the inside top (light from above) and a 1px highlight just under the bottom edge (the lip catching the light). A `deep` variant cuts a touch further on focus. Both themes.
- The card keeps its white `bg-detail` surface and the original 1px border.
- Focus, bad, success and verifying keep their original border + halo treatment (accent / red + nudge / green / accent + orbit). Lockout still dims the card.

## Why

Exploring a "carved into the surface" feel for the lock field. Kept deliberately quiet: no colour washes, no rim tricks, just the shadow direction flipped.

## Verification

- `bun run typecheck`, `bun run lint`, full `vitest` suite pass.
- No test IDs or DOM structure changed, so e2e specs are unaffected.
- Screenshotted idle / focus / typing / error / verifying / success in light and dark via a throwaway harness (not committed).