### PR TITLE
feat(brand): one asterisk for the mascot and the rail mark

### DIFF
--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -1,27 +1,27 @@
+import AsteriskBody from '@/components/elements/Asterisk'
+
 // Single-vault app: the rail top is just a brand mark (no vault switcher).
 //
-// The mark is "Reveal": a masked-password asterisk with one arm detached as a
-// dot — the one secret in your hand. Five stadium arms at 60° plus the dot
-// where the sixth would be; arms overlap the center so the union fills solid.
-// Drawn plain in the graphite ink, no tile behind it — the mark is the brand.
-const ARM_ANGLES = [0, 60, 180, 240, 300]
-
+// The mark is the lock-screen mascot with the face taken off: same hub, same
+// flared spikes, same softened silhouette, same ink, so the sealed vault and
+// the open one read as a single character. Its own twist is "Reveal": the
+// lower-right spike is set free as a dot, the one secret taken out of the mask
+// and into your hand. With no face to carry, the hub is trimmed a step so the
+// notches open and it still reads as an asterisk at rail size.
 export default function Brand() {
   return (
-    <div className="grid h-10 w-10 flex-none place-items-center text-text2" title="Swifty">
-      <svg width="30" height="30" viewBox="0 0 24 24" fill="currentColor" aria-label="Swifty">
-        {ARM_ANGLES.map(angle => (
-          <rect
-            key={angle}
-            x="10.4"
-            y="3.4"
-            width="3.2"
-            height="9.6"
-            rx="1.6"
-            transform={`rotate(${angle} 12 12)`}
-          />
-        ))}
-        <circle cx="18.06" cy="15.5" r="2.1" />
+    <div
+      className="grid h-10 w-10 flex-none place-items-center text-brand"
+      title="Swifty"
+    >
+      <svg
+        width="28"
+        height="28"
+        viewBox="0 0 64 64"
+        fill="currentColor"
+        aria-label="Swifty"
+      >
+        <AsteriskBody dot={120} hub={11} />
       </svg>
     </div>
   )

--- a/src/components/elements/Asterisk.tsx
+++ b/src/components/elements/Asterisk.tsx
@@ -1,0 +1,74 @@
+import { useId, type CSSProperties } from 'react'
+
+// The brand asterisk: a masked character, the secret you can't read. One
+// silhouette shared by the lock-screen mascot (which puts a face on it) and
+// the rail mark (which sets one spike free as a dot), so the two always agree
+// on shape. Drawn in a 64-unit box centered at 32: a round hub and six flared
+// spikes at 60° whose tips reach 29 from center. Spike bases (corners 10 from
+// center) are buried under the hub so the union fills solid.
+const CENTER = 32
+// The mascot's hub is full enough to carry a face. Faceless uses can go
+// smaller to open up the notches; below ~10.5 the spike bases start to show.
+const HUB_RADIUS = 14
+const SPIKE_ANGLES = [0, 60, 120, 180, 240, 300]
+
+// One flared spike, pointing up: narrow at the base, wide at the tip, soft
+// outer corners. Rotated around the hub for the other five.
+const SPIKE = 'M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z'
+
+// The freed spike's dot: as wide as a spike head, floated a little past the
+// spike-tip circle (tips reach 29; the dot's outer edge reaches 31) so it
+// reads as clearly let go of the body. Set against an 11 hub that leaves a
+// 6-unit gap; the soften filter needs at least 4 or it bridges them.
+const DOT_RADIUS = 7
+const DOT_DISTANCE = 24
+
+interface Props {
+  // Angle (one of the six spike angles) to draw as a detached dot instead of
+  // a spike. The mascot draws all six; the rail mark frees the lower-right one.
+  dot?: number
+  // Hub radius; defaults to the mascot's.
+  hub?: number
+  style?: CSSProperties
+}
+
+// The body, to be rendered inside an `<svg viewBox="0 0 64 64">`. Fill comes
+// from `style` or the surrounding svg's `fill`. The blur + alpha threshold
+// rounds every corner of the combined silhouette, including the concave notch
+// bottoms, which per-shape stroke joins cannot fillet.
+export default function AsteriskBody({
+  dot,
+  hub = HUB_RADIUS,
+  style
+}: Props) {
+  const filterId = `asterisk-soften-${useId().replace(/\W/g, '')}`
+  const rad = ((dot ?? 0) * Math.PI) / 180
+  const dotX = CENTER + Math.sin(rad) * DOT_DISTANCE
+  const dotY = CENTER - Math.cos(rad) * DOT_DISTANCE
+
+  return (
+    <>
+      <defs>
+        <filter id={filterId} x="-15%" y="-15%" width="130%" height="130%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="1.8" result="b" />
+          <feColorMatrix
+            in="b"
+            type="matrix"
+            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -13"
+          />
+        </filter>
+      </defs>
+      <g filter={`url(#${filterId})`} style={style}>
+        {SPIKE_ANGLES.filter(angle => angle !== dot).map(angle => (
+          <path
+            key={angle}
+            d={SPIKE}
+            transform={angle ? `rotate(${angle} ${CENTER} ${CENTER})` : undefined}
+          />
+        ))}
+        <circle cx={CENTER} cy={CENTER} r={hub} />
+        {dot !== undefined && <circle cx={dotX} cy={dotY} r={DOT_RADIUS} />}
+      </g>
+    </>
+  )
+}

--- a/src/components/elements/Mascot.tsx
+++ b/src/components/elements/Mascot.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import AsteriskBody from './Asterisk'
 
 export type MascotState = 'idle' | 'typing' | 'checking' | 'success' | 'error'
 
@@ -7,18 +8,15 @@ interface Props {
   // Where the eyes look horizontally, -1 (left) .. 1 (right). The lock screen
   // maps the passphrase caret position onto this so the mascot reads along.
   gaze?: number
-  // Body color. Graphite by default; a vault-personalization setting will feed
-  // this eventually.
+  // Body color. The brand ink by default (shared with the rail mark, themed in
+  // theme.css); a vault-personalization setting will feed this eventually.
   color?: string
   size?: number
 }
 
-const GRAPHITE = '#34373e'
-
-// One flared spike: narrow at the base, wide at the tip, soft outer corners.
-// Rotated around the hub; the circle buries the bases.
-const SPIKE = 'M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z'
-const SPIKE_ANGLES = [0, 60, 120, 180, 240, 300]
+const BRAND_INK = 'var(--c-brand)'
+// Eyes and expression strokes: paper on ink, so they flip with the theme too.
+const EYE = 'var(--c-brand-eye)'
 
 // The Swifty mascot: the brand asterisk (a secret value, redacted) with eyes.
 // It sits still and blinks every once in a while, follows typing with its
@@ -28,7 +26,7 @@ const SPIKE_ANGLES = [0, 60, 120, 180, 240, 300]
 function Mascot({
   state = 'idle',
   gaze = 0,
-  color = GRAPHITE,
+  color = BRAND_INK,
   size = 96
 }: Props) {
   const ok = state === 'success'
@@ -62,32 +60,7 @@ function Mascot({
       data-state={state}
       className={bodyAnim}
     >
-      <defs>
-        {/* Blur + alpha threshold rounds every corner of the body's combined
-            silhouette — including the concave notch bottoms, which per-shape
-            stroke joins cannot fillet. */}
-        <filter id="mascot-soften" x="-15%" y="-15%" width="130%" height="130%">
-          <feGaussianBlur in="SourceGraphic" stdDeviation="1.8" result="b" />
-          <feColorMatrix
-            in="b"
-            type="matrix"
-            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -13"
-          />
-        </filter>
-      </defs>
-      <g
-        filter="url(#mascot-soften)"
-        style={{ fill, transition: 'fill 300ms ease' }}
-      >
-        {SPIKE_ANGLES.map(angle => (
-          <path
-            key={angle}
-            d={SPIKE}
-            transform={angle ? `rotate(${angle} 32 32)` : undefined}
-          />
-        ))}
-        <circle cx="32" cy="32" r="14" />
-      </g>
+      <AsteriskBody style={{ fill, transition: 'fill 300ms ease' }} />
 
       <g
         style={{
@@ -110,7 +83,7 @@ function Mascot({
               cy="27.4"
               rx="3.5"
               ry={eyeRy}
-              fill="#fff"
+              fill={EYE}
               style={{ transition: 'ry 300ms ease' }}
             />
             <ellipse
@@ -118,14 +91,14 @@ function Mascot({
               cy="26.8"
               rx="3.5"
               ry={eyeRy}
-              fill="#fff"
+              fill={EYE}
               style={{ transition: 'ry 300ms ease' }}
             />
           </g>
           {/* Happy arcs (success) */}
           <g
             style={{ opacity: ok ? 1 : 0, transition: 'opacity 190ms ease' }}
-            stroke="#fff"
+            stroke={EYE}
             strokeWidth="2.6"
             strokeLinecap="round"
             fill="none"
@@ -136,7 +109,7 @@ function Mascot({
           {/* Sad arcs (error) */}
           <g
             style={{ opacity: bad ? 1 : 0, transition: 'opacity 190ms ease' }}
-            stroke="#fff"
+            stroke={EYE}
             strokeWidth="2.6"
             strokeLinecap="round"
             fill="none"

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -257,6 +257,7 @@
   --color-bad: var(--c-bad);
   --color-accent-deep: var(--c-accent-deep);
   --color-touchid: var(--c-touchid);
+  --color-brand: var(--c-brand);
 }
 
 /*
@@ -393,6 +394,10 @@
   /* Deep end of the brand gradient; same in both themes (it sits under the
    * accent, which does adapt). */
   --c-accent-deep: #2b3a8f;
+  /* The brand asterisk's ink (mascot body + rail mark) and the paper its eyes
+   * are cut from. Graphite on light ground; flips to chalk on dark. */
+  --c-brand: #34373e;
+  --c-brand-eye: #ffffff;
 
   /* Design vars that aren't color utilities (gradients/shadows/scrims). */
   --card: linear-gradient(180deg, #ffffff, #fbfbfc);
@@ -430,6 +435,8 @@
   --c-warn: #e0a94e;
   --c-bad: #e4685d;
   --c-touchid: #ee5d6f;
+  --c-brand: #d6d8dc;
+  --c-brand-eye: #15161a;
 
   --card: linear-gradient(
     180deg,


### PR DESCRIPTION
## Summary

The lock-screen mascot and the sidebar brand mark were two different asterisks: different spike shapes, weights and colors. This makes them one character.

- **Shared silhouette.** The mascot's body (14-radius hub, six flared spikes, gooey fillet filter) moves into a new `AsteriskBody` in `src/components/elements/Asterisk.tsx`. `Mascot` and `Brand` both render it, so the two can no longer drift apart. Mascot loses 39 lines of duplicated geometry.
- **The mark keeps its twist.** `Brand` renders the body with the lower-right spike set free as a dot ("Reveal": the one secret taken out of the mask). The dot is sized to a spike head (r 7), floated a little past the spike-tip circle (gap 6 to the hub), and the faceless hub is trimmed to r 11 so the notches open and it still reads as an asterisk at 28px in the rail. Each of these was picked from side-by-side renders at rail and display sizes.
- **One brand ink.** New `--c-brand` / `--c-brand-eye` tokens (plus a `text-brand` utility). Light stays the existing graphite `#34373e` with white eyes, so the light lock screen is visually unchanged. Dark flips to chalk with near-black eyes: previously the fixed graphite mascot was a barely visible blob on the dark ground, and a mark in that color would have vanished on the dark rail.

## Notes

- Mascot geometry and animations are untouched; only the color source changed.
- The filter id now comes from `useId`, so multiple bodies in one tree don't collide.
- Follow-up worth doing: the app and tray icons still use the old fingerprint-and-padlock artwork.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run test` (21 files, 150 tests) all pass.
- Real `Brand` and `Mascot` components rendered headless in both themes and all mascot states to confirm output.