### PR TITLE
fix(log): stop writing dependency trace output to stderr and the log dir

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,7 +45,12 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(
+            // The plugin defaults to Trace, which pulls in every dependency's
+            // tracing -- tao logs entry and exit of each NSWindowDelegate
+            // callback, so ordinary focus changes flood stderr and the log file.
             tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .level_for("swifty_lib", log::LevelFilter::Debug)
                 .target(tauri_plugin_log::Target::new(
                     tauri_plugin_log::TargetKind::Stderr,
                 ))


### PR DESCRIPTION
## Problem

Launching the app and clicking around floods stderr and the log file with tao tracing:

```
[TRACE] Triggered `windowDidResignKey:`
[TRACE] Completed `windowDidResignKey:`
[TRACE] Triggered `windowDidBecomeKey:`
```

`tauri-plugin-log` defaults to `LevelFilter::Trace` (documented in `tauri-plugin-log-2.9.0/src/lib.rs:557`) and our builder in `src-tauri/src/lib.rs` never narrowed it, so every `trace!` in the dependency tree was captured. tao instruments each `NSWindowDelegate` callback with entry/exit tracing (`tao-0.35.3/src/platform_impl/macos/window_delegate.rs:374-414`), which means two lines per focus change — and focus changes fire constantly on macOS via app switching, Cmd+Tab, tray clicks, and native dialogs.

## Change

Set the global filter to `Info` and keep our own crate at `Debug`:

```rust
tauri_plugin_log::Builder::new()
    .level(log::LevelFilter::Info)
    .level_for("swifty_lib", log::LevelFilter::Debug)
```

The target prefix is `swifty_lib`, matching `[lib] name` in `Cargo.toml`.

Both log targets benefit. Since one of them is `TargetKind::LogDir`, this also reduces how much dependency output a password manager writes to a plaintext file on disk.

## Testing

`cargo check` and `cargo fmt --check` both pass. No behavior change beyond log verbosity.

## Not included

`src-tauri/src/autolock.rs:42-47` spawns an OS thread per blur that sleeps the full 60s timeout. Because blur fires so often, an unlocked vault accumulates a sleeping thread per event for a minute. The generation token keeps it correct, but a single reusable timer would be better. Left for a separate PR.