### PR TITLE
feat(brand): slim the rail mark's spikes

### DIFF
--- a/src/components/Main/Sidebar/Brand.tsx
+++ b/src/components/Main/Sidebar/Brand.tsx
@@ -6,8 +6,9 @@ import AsteriskBody from '@/components/elements/Asterisk'
 // flared spikes, same softened silhouette, same ink, so the sealed vault and
 // the open one read as a single character. Its own twist is "Reveal": the
 // lower-right spike is set free as a dot, the one secret taken out of the mask
-// and into your hand. With no face to carry, the hub is trimmed a step so the
-// notches open and it still reads as an asterisk at rail size.
+// and into your hand. With no face to carry, the hub is trimmed a step and the
+// spikes slimmed a touch, so the notches open and it still reads as an
+// asterisk at rail size.
 export default function Brand() {
   return (
     <div
@@ -21,7 +22,7 @@ export default function Brand() {
         fill="currentColor"
         aria-label="Swifty"
       >
-        <AsteriskBody dot={120} hub={11} />
+        <AsteriskBody dot={120} hub={11} spike={0.85} />
       </svg>
     </div>
   )

--- a/src/components/elements/Asterisk.tsx
+++ b/src/components/elements/Asterisk.tsx
@@ -29,6 +29,9 @@ interface Props {
   dot?: number
   // Hub radius; defaults to the mascot's.
   hub?: number
+  // Spike width as a factor of the mascot's; scaled about each spike's axis
+  // so the flare, tip rounding and reach stay the same.
+  spike?: number
   style?: CSSProperties
 }
 
@@ -39,12 +42,17 @@ interface Props {
 export default function AsteriskBody({
   dot,
   hub = HUB_RADIUS,
+  spike = 1,
   style
 }: Props) {
   const filterId = `asterisk-soften-${useId().replace(/\W/g, '')}`
   const rad = ((dot ?? 0) * Math.PI) / 180
   const dotX = CENTER + Math.sin(rad) * DOT_DISTANCE
   const dotY = CENTER - Math.cos(rad) * DOT_DISTANCE
+  const narrow =
+    spike !== 1
+      ? ` translate(${CENTER} 0) scale(${spike} 1) translate(${-CENTER} 0)`
+      : ''
 
   return (
     <>
@@ -63,7 +71,11 @@ export default function AsteriskBody({
           <path
             key={angle}
             d={SPIKE}
-            transform={angle ? `rotate(${angle} ${CENTER} ${CENTER})` : undefined}
+            transform={
+              angle || narrow
+                ? `rotate(${angle} ${CENTER} ${CENTER})${narrow}`
+                : undefined
+            }
           />
         ))}
         <circle cx={CENTER} cy={CENTER} r={hub} />


### PR DESCRIPTION
## Summary

Follow-up to the brand unification (#299): the rail mark's spikes are slimmed to 0.85 of the mascot's width, so the faceless mark reads a touch lighter in the 28px rail tile.

- `AsteriskBody` gains a `spike` width factor. It scales each spike about its own axis, so the flare, tip rounding and reach stay identical to the mascot.
- `Brand` passes `spike={0.85}`. The freed dot (r 7) still matches the spike heads in width.
- The mascot is unchanged; it keeps the default factor of 1.

Picked from side-by-side renders at rail and display size: 0.85 is visibly slimmer without turning into a different, thinner asterisk (0.8 and below does).

## Verification

`bun run typecheck`, `bun run lint`, `bun run test` (21 files, 150 tests) pass.