### PR TITLE
ci: restore Rust cache on every PR run, save only on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, v1-0-0]
+    branches: [master, main, v1-0-0]
   pull_request:
 
 # Cancel superseded PR runs (rapid pushes stack full matrices otherwise);
@@ -47,6 +47,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Restore everywhere, save only on push. A PR run that also saved
+          # wrote a second ~1 GB copy of every cache under refs/pull/N/merge;
+          # with five cached jobs that doubled storage past the 10 GB repo
+          # limit, GitHub evicted by LRU, and PRs then restored nothing at all
+          # ("No cache found." -> ~14 min of cold compile, worst on Windows).
+          # Push runs on the trunk keep one authoritative copy per job+OS that
+          # every PR, from any branch, restores.
+          save-if: ${{ github.event_name == 'push' }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -120,6 +128,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Restore everywhere, save only on push. A PR run that also saved
+          # wrote a second ~1 GB copy of every cache under refs/pull/N/merge;
+          # with five cached jobs that doubled storage past the 10 GB repo
+          # limit, GitHub evicted by LRU, and PRs then restored nothing at all
+          # ("No cache found." -> ~14 min of cold compile, worst on Windows).
+          # Push runs on the trunk keep one authoritative copy per job+OS that
+          # every PR, from any branch, restores.
+          save-if: ${{ github.event_name == 'push' }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -171,6 +187,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Restore everywhere, save only on push. A PR run that also saved
+          # wrote a second ~1 GB copy of every cache under refs/pull/N/merge;
+          # with five cached jobs that doubled storage past the 10 GB repo
+          # limit, GitHub evicted by LRU, and PRs then restored nothing at all
+          # ("No cache found." -> ~14 min of cold compile, worst on Windows).
+          # Push runs on the trunk keep one authoritative copy per job+OS that
+          # every PR, from any branch, restores.
+          save-if: ${{ github.event_name == 'push' }}
 
       - run: bun install --frozen-lockfile
 


### PR DESCRIPTION
Cuts `Rust (windows-latest)` on PRs from **17m26s to ~3m30s**, and the PR critical path from ~17.5 min to ~5 min.

## Problem

PR runs were doing a full cold Rust compile. Same job, same cache key, PR vs push:

| step | PR #300 run `33642403151` | push run `33648216876` |
|---|---|---|
| `Swatinem/rust-cache` restore | **7s — `No cache found.`** | 39s (hit) |
| Clippy | **11m 06s** | 42s |
| Build | **3m 14s** | 30s |
| Post rust-cache (save) | 63s | 0s |
| **total** | **17m 26s** | **3m 22s** |

Not Windows-specific — every Rust leg on that run was cold (ubuntu 7m vs 1m48s, macos 7m vs 1m36s). Windows just pays the most for a cold build, so it became the critical path.

## Cause

Cache storage, not the build. Every PR run saved a second full copy of all five Rust caches under `refs/pull/N/merge`, on top of the copies already on the trunk ref — 0.85–1.2 GB each. That took the repo to **11.2 GB against GitHub's 10 GB limit**, at which point entries are evicted LRU and PR runs stopped resolving any cache at all.

## Fix

`save-if: ${{ github.event_name == 'push' }}` on all three cached jobs — `rust` (all three OSes via the matrix), `crypto-compat`, `e2e`. Every run from any branch restores; only trunk push runs write. Nothing keys off a specific branch name.

Also adds `main` to the push trigger list. It was absent, so with `save-if` gating on push events, no run would ever have written a cache for PRs targeting `main` — which would have left every PR cold and made this change a regression.

## Out of band

Purged the 8 stale `refs/pull/301/merge` duplicates (~4.7 GB) so the fix can take effect immediately rather than waiting out eviction. Every deleted key still exists on the trunk ref. Storage is now ~5.9 GB across 8 entries.

## Verifying

The signal is this PR's own run: the rust-cache step should log `Restored from cache key ...` instead of `No cache found.`

If it still misses, the cause is scoping rather than eviction — `main` is not the repository default branch (`master` is, still holding the old Electron tree), and only default-branch caches are visible to all refs unconditionally. The fix there is flipping the default branch, which is a repo setting rather than a CI change.

## Not addressed

`cargo clippy --all-targets` followed by `cargo build --locked` compiles the dependency graph twice (~3 min cold, ~30s warm on Windows). Separate concern — it changes what the build gate actually checks.