### PR TITLE
feat(elements): shared settings, toggle, segmented, radio-list and empty-state primitives

### DIFF
--- a/src/components/Main/Body/Aside/ui.tsx
+++ b/src/components/Main/Body/Aside/ui.tsx
@@ -5,19 +5,18 @@ import { useStrength } from '@/hooks/useStrength'
 import { t } from '@/i18n'
 import IconButton from '@/components/elements/IconButton'
 import Meter from '@/components/elements/Meter'
+import { CARD, MONO_LABEL } from '@/components/elements/tokens'
 import { CheckGlyph, CopyGlyph } from '../../icons'
 
 // Re-export so existing detail-pane imports keep working; the primitive itself
 // now lives in elements/ and is shared with the header and Masterpass.
-export { IconButton }
+export { IconButton, MONO_LABEL }
 
 const STRENGTH_LABELS = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
 // Shared presentation primitives for the detail pane. Every card, ledger cell,
 // mono label and copy affordance in Show / Form / Audit routes through these so
 // the token styling lives in one place.
-
-export const MONO_LABEL = 'font-mono text-xs uppercase tracking-label text-text3'
 
 // A bordered card surface on the gradient `--card` background.
 export function Panel({
@@ -28,12 +27,7 @@ export function Panel({
   className?: string
 }) {
   return (
-    <div
-      className={cx(
-        'overflow-hidden rounded-lg border border-line bg-[image:var(--card)]',
-        className
-      )}
-    >
+    <div className={cx(CARD, className)}>
       {children}
     </div>
   )

--- a/src/components/Main/Generator/Tabs.tsx
+++ b/src/components/Main/Generator/Tabs.tsx
@@ -1,10 +1,10 @@
-import { cx } from '@/utils/cx'
 import { t } from '@/i18n'
+import Segmented from '@/components/elements/Segmented'
 import type { GeneratorMode } from '@/services/generator'
 
-const TABS: { mode: GeneratorMode; label: string }[] = [
-  { mode: 'random', label: 'Random' },
-  { mode: 'memorable', label: 'Memorable' }
+const TABS: { value: GeneratorMode; label: string }[] = [
+  { value: 'random', label: 'Random' },
+  { value: 'memorable', label: 'Memorable' }
 ]
 
 interface Props {
@@ -12,26 +12,15 @@ interface Props {
   onChange: (mode: GeneratorMode) => void
 }
 
-// Segmented control in the dialog header: the active tab wears the accent wash.
+// Mode switch in the dialog header — the shared Segmented control.
 export default function Tabs({ mode, onChange }: Props) {
   return (
-    <div className="flex flex-none gap-0.5 rounded-sm border border-line2 p-0.5">
-      {TABS.map(tab => (
-        <button
-          key={tab.mode}
-          type="button"
-          data-testid={`generator-mode-${tab.mode}`}
-          onClick={() => onChange(tab.mode)}
-          className={cx(
-            'cursor-pointer rounded-sm px-2.5 py-[3px] text-base transition-colors',
-            mode === tab.mode
-              ? 'bg-accent-soft text-text'
-              : 'text-text3 hover:text-text'
-          )}
-        >
-          {t(tab.label)}
-        </button>
-      ))}
-    </div>
+    <Segmented
+      options={TABS.map(tab => ({ value: tab.value, label: t(tab.label) }))}
+      value={mode}
+      onChange={onChange}
+      testidPrefix="generator-mode"
+      className="flex-none"
+    />
   )
 }

--- a/src/components/Main/icons.tsx
+++ b/src/components/Main/icons.tsx
@@ -4,12 +4,13 @@
 // System rules (from the Keyring design system):
 //   · stroke 1.75 — tracks the prototype's 1.7 hairline look (lucide's
 //     default 2 reads too heavy at our sizes)
-//   · two sizes — 14 inside 24–28px controls, 16 everywhere else
-//     (rows, tiles, rail); call sites may override for hero surfaces
+//   · three sizes — 14 inside 24–28px controls, 16 for rows and tiles, 20 for
+//     the rail; call sites may override for hero surfaces
 //
 // Components keep the historical `*Glyph` names so this module stays the one
 // place an icon choice lives.
 import {
+  Activity,
   ArrowDownWideNarrow,
   Check,
   ChevronDown,
@@ -21,6 +22,7 @@ import {
   FileText,
   Fingerprint,
   Globe,
+  LayoutGrid,
   Lock,
   Moon,
   MoreHorizontal,
@@ -30,6 +32,7 @@ import {
   Search,
   Settings,
   ShieldCheck,
+  Star,
   Sun,
   Trash2,
   X,
@@ -42,7 +45,7 @@ interface IconProps {
 }
 
 const glyph =
-  (Icon: LucideIcon, defaultSize: 14 | 16) =>
+  (Icon: LucideIcon, defaultSize: 14 | 16 | 20) =>
   ({ size = defaultSize, className }: IconProps) => (
     <Icon size={size} strokeWidth={1.75} className={className} />
   )
@@ -73,3 +76,13 @@ export const LoginGlyph = glyph(Globe, 16)
 export const NoteGlyph = glyph(FileText, 16)
 export const CardGlyph = glyph(CreditCard, 16)
 export const ShieldGlyph = glyph(ShieldCheck, 16)
+export const GlobeGlyph = glyph(Globe, 16)
+export const ActivityGlyph = glyph(Activity, 16)
+
+// Rail tier (20px, for the 40px+ rail hit areas and Settings nav headers)
+export const PlusRailGlyph = glyph(Plus, 20)
+export const GearRailGlyph = glyph(Settings, 20)
+export const GridRailGlyph = glyph(LayoutGrid, 20)
+export const StarRailGlyph = glyph(Star, 20)
+export const TrashRailGlyph = glyph(Trash2, 20)
+export const ActivityRailGlyph = glyph(Activity, 20)

--- a/src/components/elements/EmptyState.tsx
+++ b/src/components/elements/EmptyState.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+import Button from './Button'
+import Kbd from './Kbd'
+
+interface Action {
+  label: string
+  onClick: () => void
+  testid?: string
+}
+
+interface Props {
+  // A glyph or SVG; the caller picks the size (16 compact, 24–28 in the tile).
+  mark: ReactNode
+  title: string
+  body?: string
+  primary?: Action
+  secondary?: { label: string; onClick: () => void }
+  hints?: { keys: string; label: string }[]
+  // Tint override for the mark tile, e.g. a per-type wash.
+  markClassName?: string
+  // Single-line variant for a list column: no tile, no title tier.
+  compact?: boolean
+  className?: string
+}
+
+// THE nothing-here surface: one mark, one title, one line, one action. Every
+// empty list, filtered result and unconfigured panel uses it so "empty" reads
+// the same everywhere.
+export default function EmptyState({
+  mark,
+  title,
+  body,
+  primary,
+  secondary,
+  hints,
+  markClassName,
+  compact,
+  className
+}: Props) {
+  if (compact)
+    return (
+      <div
+        className={cx(
+          'flex items-center justify-center gap-2 px-3 py-6 text-base text-text3',
+          className
+        )}
+      >
+        <span className="flex-none">{mark}</span>
+        <span className="min-w-0 truncate">{body ?? title}</span>
+        {secondary && (
+          <button
+            type="button"
+            onClick={secondary.onClick}
+            className="flex-none cursor-pointer text-accent hover:underline"
+          >
+            {secondary.label}
+          </button>
+        )}
+      </div>
+    )
+
+  return (
+    <div
+      className={cx(
+        'flex max-w-[320px] flex-col items-center gap-5 text-center animate-pop',
+        className
+      )}
+    >
+      <div
+        className={cx(
+          'grid h-16 w-16 place-items-center rounded-lg',
+          markClassName ?? 'bg-accent-soft text-accent'
+        )}
+      >
+        {mark}
+      </div>
+
+      <div>
+        <div className="text-2xl font-semibold tracking-display text-text">{title}</div>
+        {body && <div className="mt-2 text-base text-text2">{body}</div>}
+
+        {(primary || secondary) && (
+          <div className="mt-6 flex items-center justify-center gap-3">
+            {primary && (
+              <Button onClick={primary.onClick} testid={primary.testid}>
+                {primary.label}
+              </Button>
+            )}
+            {secondary && (
+              <Button variant="pale" onClick={secondary.onClick}>
+                {secondary.label}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {hints && hints.length > 0 && (
+          <div className="mt-4 flex items-center justify-center gap-3">
+            {hints.map(hint => (
+              <span key={hint.keys} className="flex items-center gap-1.5">
+                <Kbd>{hint.keys}</Kbd>
+                <span className="font-mono text-xs text-text3">{hint.label}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/elements/RadioList.tsx
+++ b/src/components/elements/RadioList.tsx
@@ -1,0 +1,73 @@
+import { cx } from '@/utils/cx'
+import { useRadioNav } from '@/hooks/useRadioNav'
+import { CARD, ROW_HAIRLINE } from './tokens'
+
+interface Props {
+  options: { value: string; label: string; meta?: string }[]
+  value: string
+  onChange: (value: string) => void
+  name?: string
+  testidPrefix?: string
+  className?: string
+}
+
+// A single-choice list on the card surface — the long-form alternative to
+// Segmented, when options need room or a mono value on the right (languages,
+// timeouts, sort orders).
+export default function RadioList({
+  options,
+  value,
+  onChange,
+  name,
+  testidPrefix,
+  className
+}: Props) {
+  const nav = useRadioNav(
+    options.map(option => option.value),
+    value,
+    onChange
+  )
+
+  return (
+    <div
+      ref={nav.ref}
+      role="radiogroup"
+      aria-label={name}
+      onKeyDown={nav.onKeyDown}
+      className={cx(CARD, className)}
+    >
+      {options.map(option => {
+        const selected = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            name={name}
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            data-testid={testidPrefix && `${testidPrefix}-${option.value}`}
+            onClick={() => onChange(option.value)}
+            className={cx(
+              'flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-hover',
+              ROW_HAIRLINE
+            )}
+          >
+            <span
+              className={cx(
+                'grid h-4 w-4 flex-none place-items-center rounded-full border transition-colors',
+                selected ? 'border-accent' : 'border-line2'
+              )}
+            >
+              {selected && <span className="h-1.5 w-1.5 rounded-full bg-accent" />}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-base text-text">{option.label}</span>
+            {option.meta && (
+              <span className="flex-none font-mono text-xs text-text3">{option.meta}</span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/elements/Segmented.tsx
+++ b/src/components/elements/Segmented.tsx
@@ -1,0 +1,61 @@
+import { cx } from '@/utils/cx'
+import { useRadioNav } from '@/hooks/useRadioNav'
+
+interface Props<T extends string> {
+  options: { value: T; label: string }[]
+  value: T
+  onChange: (value: T) => void
+  // Mono labels, for numeric/unit values like "10 m".
+  mono?: boolean
+  testidPrefix?: string
+  className?: string
+}
+
+// THE two-to-four-way switch (generator mode, timeout, theme): a hairline
+// trough with the active segment in the accent wash. Labels arrive already
+// translated.
+export default function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  mono,
+  testidPrefix,
+  className
+}: Props<T>) {
+  const nav = useRadioNav(
+    options.map(option => option.value),
+    value,
+    onChange
+  )
+
+  return (
+    <div
+      ref={nav.ref}
+      role="radiogroup"
+      onKeyDown={nav.onKeyDown}
+      className={cx('flex gap-0.5 rounded-sm border border-line2 p-0.5', className)}
+    >
+      {options.map(option => {
+        const active = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            data-testid={testidPrefix && `${testidPrefix}-${option.value}`}
+            onClick={() => onChange(option.value)}
+            className={cx(
+              'cursor-pointer rounded-sm px-2.5 py-[3px] text-base transition-colors',
+              mono && 'font-mono',
+              active ? 'bg-accent-soft text-text' : 'text-text3 hover:text-text'
+            )}
+          >
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/elements/SettingsGroup.tsx
+++ b/src/components/elements/SettingsGroup.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+import { CARD, MONO_LABEL } from './tokens'
+
+interface Props {
+  label: string
+  children: ReactNode
+  className?: string
+}
+
+// A titled block of SettingsRows: mono uppercase heading above one card. Groups
+// own the gap below them so a settings page is just a stack of these.
+export default function SettingsGroup({ label, children, className }: Props) {
+  return (
+    <section className={cx('mb-7', className)}>
+      <div className={cx(MONO_LABEL, 'mb-2')}>{label}</div>
+      <div className={CARD}>{children}</div>
+    </section>
+  )
+}

--- a/src/components/elements/SettingsRow.tsx
+++ b/src/components/elements/SettingsRow.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+import { ROW_HAIRLINE } from './tokens'
+
+interface Props {
+  label: string
+  description?: string
+  // Right-aligned control (Toggle, Segmented, Button, Select, ...).
+  control?: ReactNode
+  // Full-width content below the label/control line, inside the same row — for
+  // expandable extras such as an inline change-password form.
+  children?: ReactNode
+  testid?: string
+}
+
+// One row inside a SettingsGroup card: label (+ optional grey description) on
+// the left, one control on the right, hairline below.
+export default function SettingsRow({
+  label,
+  description,
+  control,
+  children,
+  testid
+}: Props) {
+  return (
+    <div data-testid={testid} className={cx('px-4 py-3', ROW_HAIRLINE)}>
+      <div className="flex items-center gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="text-base text-text">{label}</div>
+          {description && <div className="text-base text-text2">{description}</div>}
+        </div>
+        {control && <div className="flex-none">{control}</div>}
+      </div>
+      {children && <div className="mt-3">{children}</div>}
+    </div>
+  )
+}

--- a/src/components/elements/Toggle.tsx
+++ b/src/components/elements/Toggle.tsx
@@ -1,0 +1,47 @@
+import { cx } from '@/utils/cx'
+
+interface Props {
+  checked: boolean
+  onChange: (next: boolean) => void
+  disabled?: boolean
+  name?: string
+  testid?: string
+  'aria-label'?: string
+}
+
+// THE on/off control for settings rows: a 40x22 pill whose track carries the
+// accent when on. A native `button role="switch"` handles Space/Enter and the
+// global `:focus-visible` ring for free.
+export default function Toggle({
+  checked,
+  onChange,
+  disabled,
+  name,
+  testid,
+  'aria-label': ariaLabel
+}: Props) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      name={name}
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      data-testid={testid}
+      onClick={() => onChange(!checked)}
+      className={cx(
+        'relative h-[22px] w-10 flex-none cursor-pointer rounded-full transition-colors',
+        checked ? 'bg-accent' : 'bg-line2',
+        disabled && 'cursor-default opacity-50'
+      )}
+    >
+      <span
+        className={cx(
+          'absolute top-[2px] left-[2px] h-[18px] w-[18px] rounded-full bg-white transition-transform',
+          checked && 'translate-x-[18px]'
+        )}
+      />
+    </button>
+  )
+}

--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -1,0 +1,16 @@
+// Class strings for the three surface conventions shared by more than one
+// element: the card surface, the row hairline that separates stacked rows
+// inside it, and the mono uppercase label tier. Kept here (not in a screen
+// module) so `elements/` never has to reach upward for them.
+
+// A bordered card on the gradient `--card` background. `overflow-hidden` is
+// part of the surface: rows clipped by the radius are what make the hairlines
+// stop cleanly at the corners.
+export const CARD = 'overflow-hidden rounded-lg border border-line bg-[image:var(--card)]'
+
+// Bottom hairline for a row in a stack; the last row drops it so the card edge
+// is the only line.
+export const ROW_HAIRLINE = 'shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none'
+
+// Mono uppercase micro label (group headings, field labels, meta).
+export const MONO_LABEL = 'font-mono text-xs uppercase tracking-label text-text3'

--- a/src/hooks/useRadioNav.ts
+++ b/src/hooks/useRadioNav.ts
@@ -1,0 +1,35 @@
+import { useRef, type KeyboardEvent } from 'react'
+
+// Arrow-key navigation for a single-select group (`role="radiogroup"`), shared
+// by Segmented and RadioList. Per the ARIA pattern the arrows *select* as they
+// move, so the group holds one tab stop and selection follows focus.
+export function useRadioNav<T>(values: T[], value: T, onChange: (next: T) => void) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  const move = (step: number) => {
+    if (values.length === 0) return
+    const from = values.indexOf(value)
+    const next = (from + step + values.length) % values.length
+    onChange(values[next])
+    // Selection follows focus, so pull focus along with it.
+    ref.current?.querySelectorAll('button')[next]?.focus()
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        move(1)
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        move(-1)
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+  }
+
+  return { ref, onKeyDown }
+}

--- a/src/test/emptyState.test.tsx
+++ b/src/test/emptyState.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EmptyState from '@/components/elements/EmptyState'
+import { PlusGlyph } from '@/components/Main/icons'
+
+describe('EmptyState', () => {
+  it('renders the title, body, actions and hints, and runs the primary action', async () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyState
+        mark={<PlusGlyph />}
+        title="No entries yet"
+        body="Add your first login to get started."
+        primary={{ label: 'New entry', onClick, testid: 'empty-new' }}
+        secondary={{ label: 'Import', onClick: vi.fn() }}
+        hints={[{ keys: '⌘N', label: 'new' }]}
+      />
+    )
+
+    expect(screen.getByText('No entries yet')).toBeInTheDocument()
+    expect(screen.getByText('Add your first login to get started.')).toBeInTheDocument()
+    expect(screen.getByText('⌘N')).toBeInTheDocument()
+    expect(screen.getByText('Import')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('empty-new'))
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('drops the title tier in the compact variant and links the secondary', async () => {
+    const onClick = vi.fn()
+    render(
+      <EmptyState
+        compact
+        mark={<PlusGlyph />}
+        title="No matches"
+        body="Nothing matches this filter"
+        secondary={{ label: 'Clear', onClick }}
+      />
+    )
+
+    expect(screen.getByText('Nothing matches this filter')).toBeInTheDocument()
+    expect(screen.queryByText('No matches')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Clear'))
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/src/test/radioList.test.tsx
+++ b/src/test/radioList.test.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RadioList from '@/components/elements/RadioList'
+
+const OPTIONS = [
+  { value: '60', label: 'One minute', meta: '1 m' },
+  { value: '300', label: 'Five minutes', meta: '5 m' },
+  { value: '0', label: 'Never' }
+]
+
+describe('RadioList', () => {
+  it('renders one radio per option with its mono meta', () => {
+    render(<RadioList options={OPTIONS} value="60" onChange={vi.fn()} testidPrefix="lock" />)
+
+    expect(screen.getAllByRole('radio')).toHaveLength(3)
+    expect(screen.getByTestId('lock-60')).toBeChecked()
+    expect(screen.getByTestId('lock-0')).not.toBeChecked()
+    expect(screen.getByText('5 m')).toBeInTheDocument()
+  })
+
+  it('selects on click', async () => {
+    const onChange = vi.fn()
+    render(<RadioList options={OPTIONS} value="60" onChange={onChange} />)
+
+    await userEvent.click(screen.getByText('Never'))
+    expect(onChange).toHaveBeenCalledWith('0')
+  })
+
+  it('moves selection with the arrow keys', async () => {
+    const Harness = () => {
+      const [value, setValue] = useState('60')
+      return <RadioList options={OPTIONS} value={value} onChange={setValue} testidPrefix="lock" />
+    }
+    render(<Harness />)
+
+    screen.getByTestId('lock-60').focus()
+    await userEvent.keyboard('{ArrowDown}')
+    expect(screen.getByTestId('lock-300')).toBeChecked()
+
+    await userEvent.keyboard('{ArrowUp}')
+    expect(screen.getByTestId('lock-60')).toBeChecked()
+  })
+})

--- a/src/test/segmented.test.tsx
+++ b/src/test/segmented.test.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Segmented from '@/components/elements/Segmented'
+
+const OPTIONS = [
+  { value: 'random', label: 'Random' },
+  { value: 'memorable', label: 'Memorable' }
+]
+
+describe('Segmented', () => {
+  it('marks the active segment and keys testids off the prefix', () => {
+    render(<Segmented options={OPTIONS} value="random" onChange={vi.fn()} testidPrefix="mode" />)
+
+    expect(screen.getByTestId('mode-random')).toBeChecked()
+    expect(screen.getByTestId('mode-memorable')).not.toBeChecked()
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument()
+  })
+
+  it('selects on click', async () => {
+    const onChange = vi.fn()
+    render(<Segmented options={OPTIONS} value="random" onChange={onChange} />)
+
+    await userEvent.click(screen.getByText('Memorable'))
+    expect(onChange).toHaveBeenCalledWith('memorable')
+  })
+
+  it('moves selection with the arrow keys, wrapping around the ends', async () => {
+    const Harness = () => {
+      const [value, setValue] = useState('random')
+      return <Segmented options={OPTIONS} value={value} onChange={setValue} testidPrefix="mode" />
+    }
+    render(<Harness />)
+
+    screen.getByTestId('mode-random').focus()
+    await userEvent.keyboard('{ArrowRight}')
+    expect(screen.getByTestId('mode-memorable')).toBeChecked()
+
+    // Past the last segment, selection wraps to the first.
+    await userEvent.keyboard('{ArrowRight}')
+    expect(screen.getByTestId('mode-random')).toBeChecked()
+  })
+})

--- a/src/test/settingsRow.test.tsx
+++ b/src/test/settingsRow.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SettingsGroup from '@/components/elements/SettingsGroup'
+import SettingsRow from '@/components/elements/SettingsRow'
+import Toggle from '@/components/elements/Toggle'
+
+describe('SettingsGroup / SettingsRow', () => {
+  it('renders the group label above rows with label, description and control', () => {
+    render(
+      <SettingsGroup label="Security">
+        <SettingsRow
+          label="Biometric unlock"
+          description="Use Touch ID instead of the passphrase"
+          control={<Toggle checked onChange={vi.fn()} aria-label="Biometric unlock" />}
+          testid="row-biometrics"
+        />
+      </SettingsGroup>
+    )
+
+    expect(screen.getByText('Security')).toBeInTheDocument()
+    expect(screen.getByTestId('row-biometrics')).toBeInTheDocument()
+    expect(screen.getByText('Use Touch ID instead of the passphrase')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Biometric unlock' })).toBeChecked()
+  })
+
+  it('renders expandable children beneath the row and keeps the control live', async () => {
+    const onChange = vi.fn()
+    render(
+      <SettingsRow
+        label="Master password"
+        control={<Toggle checked={false} onChange={onChange} testid="row-toggle" />}
+      >
+        <input aria-label="New password" />
+      </SettingsRow>
+    )
+
+    expect(screen.getByLabelText('New password')).toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('row-toggle'))
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/test/toggle.test.tsx
+++ b/src/test/toggle.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Toggle from '@/components/elements/Toggle'
+
+describe('Toggle', () => {
+  it('exposes its state as a switch', () => {
+    render(<Toggle checked onChange={vi.fn()} aria-label="Biometrics" />)
+    expect(screen.getByRole('switch', { name: 'Biometrics' })).toBeChecked()
+  })
+
+  it('reports the flipped value on click and on space', async () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} testid="t" />)
+
+    await userEvent.click(screen.getByTestId('t'))
+    expect(onChange).toHaveBeenCalledWith(true)
+
+    screen.getByTestId('t').focus()
+    await userEvent.keyboard(' ')
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fire while disabled', async () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} disabled testid="t" />)
+
+    await userEvent.click(screen.getByTestId('t'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Shared UI primitives for the upcoming Settings redesign, empty-state system and rail polish. No screen changes except the Generator mode tabs, which now render through the new `Segmented` control with their testids intact.

## What's added (`src/components/elements/`)

- `Toggle` — 40×22 accent switch, `role="switch"`.
- `Segmented` — generic 2–4 way control, `radiogroup` with arrow-key navigation, optional mono labels.
- `SettingsGroup` + `SettingsRow` — mono group label over a card; rows with label, optional description, right-aligned control and optional expandable children.
- `RadioList` — radio rows with a right-aligned mono value.
- `EmptyState` — mark tile, title, one line, primary/secondary action, kbd hints; plus a compact single-line variant for the list column.
- `tokens.ts` — the card surface, row hairline and mono label class strings, now shared with `Aside/ui.tsx`.
- `hooks/useRadioNav` — roving-tabindex arrow navigation shared by `Segmented` and `RadioList`.
- `icons.tsx` — a 20px rail tier (`*RailGlyph`) and `GlobeGlyph` / `ActivityGlyph` at 16.

## Tests

One vitest file per element covering render, interaction and ARIA state. `typecheck`, `lint` (0 warnings) and `test` green.