### PR TITLE
feat(a11y): keyboard-operable dropdown menus and a stricter Enter guard

### DIFF
--- a/src/components/Main/Body/Aside/Show/Actions.tsx
+++ b/src/components/Main/Body/Aside/Show/Actions.tsx
@@ -89,6 +89,7 @@ export default function Actions({ type, revealed, onDelete }: Props) {
         <IconButton
           title={t('More actions')}
           active={menu}
+          expanded={menu}
           onClick={toggleMenu}
           className="border border-line2 hover:border-accent-line"
           testid="more-actions-button"

--- a/src/components/Main/Body/Aside/Show/Actions.tsx
+++ b/src/components/Main/Body/Aside/Show/Actions.tsx
@@ -17,8 +17,8 @@ interface Props {
 }
 
 // Enter is the detail pane's accelerator for the primary action, but only as a
-// bare press outside any text field or open dialog — anywhere else the key
-// belongs to whatever the user is typing in.
+// bare press outside any interactive control or open dialog — anywhere else
+// the key already belongs to whatever holds focus.
 const isPlainEnter = (e: KeyboardEvent) =>
   e.key === 'Enter' &&
   !e.metaKey &&
@@ -27,9 +27,14 @@ const isPlainEnter = (e: KeyboardEvent) =>
   !e.shiftKey &&
   !e.defaultPrevented
 
-const inTextField = (target: EventTarget | null) =>
+// Anything that owns Enter itself: a field the user is typing in, or a control
+// Enter already activates (a chip, the sort button, a menu item). Copying on
+// top of those would fire two actions from one press.
+const inInteractive = (target: EventTarget | null) =>
   target instanceof Element &&
-  !!target.closest('input, textarea, select, [contenteditable="true"]')
+  !!target.closest(
+    'input, textarea, select, [contenteditable="true"], button, a, [role="button"], [role="menuitem"]'
+  )
 
 const dialogOpen = () => !!document.querySelector('[role="dialog"], dialog[open]')
 
@@ -50,7 +55,7 @@ export default function Actions({ type, revealed, onDelete }: Props) {
   useEffect(() => {
     if (!secret) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (!isPlainEnter(e) || inTextField(e.target) || dialogOpen()) return
+      if (!isPlainEnter(e) || inInteractive(e.target) || dialogOpen()) return
       e.preventDefault()
       copy(secret)
     }

--- a/src/components/Main/Body/List/SortMenu.tsx
+++ b/src/components/Main/Body/List/SortMenu.tsx
@@ -27,6 +27,7 @@ export default function SortMenu() {
       <IconButton
         title={t('Sort')}
         active={open}
+        expanded={open}
         testid="sort-menu"
         onClick={() => setOpen(value => !value)}
       >

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -40,6 +40,10 @@ export function Dropdown({ onBlur, className, children }: DropdownProps) {
         move(-1)
         break
       case 'Escape':
+        // An open menu owns Escape. Modal and Generator listen on `window`
+        // and Sheet on `document` — all ancestors of the React root — so
+        // without this the one press would dismiss the overlay underneath too.
+        event.stopPropagation()
         onBlur()
         trigger.current?.focus()
         break
@@ -97,8 +101,10 @@ export function DropdownItem({
       data-testid={testid}
       onClick={onClick}
       className={cx(
-        'flex w-full cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-left text-base transition-colors hover:bg-hover',
-        danger ? 'text-bad' : 'text-text2 hover:text-text',
+        // The panel clips the global focus outline, so keyboard focus borrows
+        // the hover treatment instead of inventing a ring of its own.
+        'flex w-full cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-left text-base transition-colors hover:bg-hover focus-visible:bg-hover',
+        danger ? 'text-bad' : 'text-text2 hover:text-text focus-visible:text-text',
         separated && 'mt-1 border-t border-line pt-2.5'
       )}
     >

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 
 interface DropdownProps {
@@ -9,9 +9,52 @@ interface DropdownProps {
 }
 
 export function Dropdown({ onBlur, className, children }: DropdownProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const trigger = useRef<HTMLElement | null>(null)
+
+  const items = () =>
+    Array.from(ref.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [])
+
+  // Roving focus: unlike a radio group the arrows only *move*, they never
+  // activate, so the menu holds no selection of its own.
+  const move = (step: number) => {
+    const all = items()
+    if (all.length === 0) return
+    const from = all.indexOf(document.activeElement as HTMLElement)
+    all[(from + step + all.length) % all.length].focus()
+  }
+
+  // The menu takes focus on open so the keyboard lands inside it, and hands
+  // focus back to whatever opened it on Escape.
+  useEffect(() => {
+    trigger.current = document.activeElement as HTMLElement | null
+    items()[0]?.focus()
+  }, [])
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        move(1)
+        break
+      case 'ArrowUp':
+        move(-1)
+        break
+      case 'Escape':
+        onBlur()
+        trigger.current?.focus()
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+  }
+
   return (
     <>
       <div
+        ref={ref}
+        role="menu"
+        onKeyDown={onKeyDown}
         className={cx(
           'animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]',
           className
@@ -19,7 +62,11 @@ export function Dropdown({ onBlur, className, children }: DropdownProps) {
       >
         {children}
       </div>
-      <div className="fixed inset-0 z-10" onClick={onBlur} />
+      <div
+        data-testid="dropdown-scrim"
+        className="fixed inset-0 z-10"
+        onClick={onBlur}
+      />
     </>
   )
 }
@@ -43,17 +90,19 @@ export function DropdownItem({
   children
 }: ItemProps) {
   return (
-    <div
+    <button
+      type="button"
+      role="menuitem"
       id={id}
       data-testid={testid}
       onClick={onClick}
       className={cx(
-        'flex cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-base transition-colors hover:bg-hover',
+        'flex w-full cursor-pointer items-center gap-2.5 px-3.5 py-2.5 text-left text-base transition-colors hover:bg-hover',
         danger ? 'text-bad' : 'text-text2 hover:text-text',
         separated && 'mt-1 border-t border-line pt-2.5'
       )}
     >
       {children}
-    </div>
+    </button>
   )
 }

--- a/src/components/elements/IconButton.tsx
+++ b/src/components/elements/IconButton.tsx
@@ -11,6 +11,7 @@ export default function IconButton({
   label,
   active,
   muted,
+  expanded,
   className,
   testid,
   children
@@ -21,6 +22,9 @@ export default function IconButton({
   label?: string
   active?: boolean
   muted?: boolean
+  // Set only on a button that owns a popup menu: renders the disclosure pair
+  // (`aria-haspopup` + `aria-expanded`). Left undefined, neither appears.
+  expanded?: boolean
   className?: string
   testid?: string
   children: ReactNode
@@ -30,6 +34,8 @@ export default function IconButton({
       type="button"
       title={title}
       aria-label={label ?? title}
+      aria-haspopup={expanded === undefined ? undefined : 'menu'}
+      aria-expanded={expanded}
       data-testid={testid}
       onClick={onClick}
       className={cx(

--- a/src/test/dropdown.test.tsx
+++ b/src/test/dropdown.test.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Dropdown, DropdownItem } from '@/components/elements/Dropdown'
+
+const Harness = ({ onPick = vi.fn() }: { onPick?: (label: string) => void }) => {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative">
+      <button type="button" data-testid="trigger" onClick={() => setOpen(true)}>
+        Open
+      </button>
+      {open && (
+        <Dropdown onBlur={() => setOpen(false)}>
+          <DropdownItem testid="item-one" onClick={() => onPick('one')}>
+            One
+          </DropdownItem>
+          <DropdownItem testid="item-two" onClick={() => onPick('two')}>
+            Two
+          </DropdownItem>
+          <DropdownItem testid="item-three" onClick={() => onPick('three')}>
+            Three
+          </DropdownItem>
+        </Dropdown>
+      )}
+    </div>
+  )
+}
+
+const open = async () => {
+  render(<Harness />)
+  await userEvent.click(screen.getByTestId('trigger'))
+}
+
+describe('Dropdown', () => {
+  it('exposes menu semantics and focuses the first item on open', async () => {
+    await open()
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3)
+    expect(screen.getByTestId('item-one')).toHaveFocus()
+  })
+
+  it('moves focus with the arrow keys, wrapping around the ends', async () => {
+    await open()
+
+    await userEvent.keyboard('{ArrowDown}')
+    expect(screen.getByTestId('item-two')).toHaveFocus()
+
+    // Past the last item, focus wraps to the first.
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}')
+    expect(screen.getByTestId('item-one')).toHaveFocus()
+
+    // And back off the first end to the last.
+    await userEvent.keyboard('{ArrowUp}')
+    expect(screen.getByTestId('item-three')).toHaveFocus()
+  })
+
+  it('closes on Escape and hands focus back to the trigger', async () => {
+    await open()
+
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.getByTestId('trigger')).toHaveFocus()
+  })
+
+  it('activates the focused item with Enter and with Space', async () => {
+    const onPick = vi.fn()
+    render(<Harness onPick={onPick} />)
+    await userEvent.click(screen.getByTestId('trigger'))
+
+    await userEvent.keyboard('{Enter}')
+    expect(onPick).toHaveBeenLastCalledWith('one')
+
+    await userEvent.keyboard('{ArrowDown} ')
+    expect(onPick).toHaveBeenLastCalledWith('two')
+  })
+
+  it('closes when the scrim is clicked', async () => {
+    await open()
+
+    await userEvent.click(screen.getByTestId('dropdown-scrim'))
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/src/test/dropdown.test.tsx
+++ b/src/test/dropdown.test.tsx
@@ -65,6 +65,23 @@ describe('Dropdown', () => {
     expect(screen.getByTestId('trigger')).toHaveFocus()
   })
 
+  it('keeps Escape from reaching the overlay listeners underneath', async () => {
+    // Modal and Generator bind Escape on `window`, Sheet on `document`. A menu
+    // can be open beneath any of them (⌘G and ⌘N do not close it), and one
+    // press must dismiss only the menu.
+    const outer = vi.fn()
+    window.addEventListener('keydown', outer)
+    try {
+      await open()
+      await userEvent.keyboard('{Escape}')
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(outer).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('keydown', outer)
+    }
+  })
+
   it('activates the focused item with Enter and with Space', async () => {
     const onPick = vi.fn()
     render(<Harness onPick={onPick} />)

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -181,6 +181,18 @@ describe('Show', () => {
     expect(copyToClipboard).toHaveBeenCalledWith('hunter2', expect.any(Number))
   })
 
+  it('announces the more menu trigger as a disclosure', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry())
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    const trigger = screen.getByTestId('more-actions-button')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await userEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
   it('leaves Enter to whichever control holds focus', async () => {
     vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'hunter2' }))
     renderWithStore(<Show entry={loginMeta()} />)

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -181,6 +181,21 @@ describe('Show', () => {
     expect(copyToClipboard).toHaveBeenCalledWith('hunter2', expect.any(Number))
   })
 
+  it('leaves Enter to whichever control holds focus', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password: 'hunter2' }))
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    await waitFor(() => expect(screen.getByTestId('primary-action-button')).toBeEnabled())
+
+    // Enter on a focused button activates that button and nothing else — it
+    // used to open the more menu *and* copy the password.
+    screen.getByTestId('more-actions-button').focus()
+    await userEvent.keyboard('{Enter}')
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(copyToClipboard).not.toHaveBeenCalled()
+  })
+
   it('deletes from the more menu behind a two-press inline confirm', async () => {
     vi.mocked(revealEntry).mockResolvedValue(loginEntry())
     renderWithStore(<Show entry={loginMeta()} />)


### PR DESCRIPTION
Two small accessibility items from the UX redesign checklist (`docs/ux-redesign.md`, items 13 and 17).

### Dropdown and menu accessibility (item 13)

`elements/Dropdown.tsx` was a div stack: items were `<div onClick>`, so no menu was reachable by keyboard and screen readers saw no menu at all.

- panel is `role="menu"`; items are `<button role="menuitem">`
- focus lands on the first item on open, and shows it: the panel's `overflow-hidden` clips the global `:focus-visible` outline, so focus-visible borrows the existing hover treatment rather than inventing a ring
- Up/Down move focus and wrap at both ends
- Escape closes, hands focus back to the trigger, and stops there. Modal and Generator bind Escape on `window` and Sheet on `document`, and a menu can be open beneath any of them (⌘G and ⌘N have no open-dropdown guard), so one press used to dismiss the overlay behind the menu too
- the two triggers carry `aria-haspopup="menu"` + `aria-expanded` via one optional `expanded` prop on `IconButton`
- click-to-close scrim unchanged (now carries a testid)

The arrows only *move* focus, never activate, so `useRadioNav` (selection follows focus, per the radio-group pattern) is deliberately not reused. Both consumers, the detail-pane more menu and the list sort menu, pick up full keyboard operability with a one-line change each.

Every existing `data-testid` keeps its exact string as it moves from the div to the button, so the `list` and `logins-crud` e2e specs still resolve.

### Enter-to-copy fires on focused buttons (item 17)

The detail pane's window `keydown` listener skipped text fields and open dialogs but not buttons, so pressing Enter on a focused chip, the sort button or a menu item activated that control *and* copied the entry's password.

Widened the single `closest(...)` selector to the controls Enter already activates, and renamed `inTextField` to `inInteractive`.

### Tests

`src/test/dropdown.test.tsx` (new): open focuses the first item, arrows wrap both ways, Escape closes and restores trigger focus without reaching a `window` listener, Enter and Space activate, scrim click closes. `entry.test.tsx` gains the disclosure assertion and a case pinning the Enter guard. Both the Escape containment and the Enter guard tests fail on the pre-fix code.

Gates: `bun run typecheck`, `bun run lint` (0 warnings), `bun run test` (29 files, 215 tests) green. E2E not run in the sandbox; no e2e selectors changed.

### Known gap

`RadioList` has the same clipped-outline situation, since `elements/tokens.ts` documents `overflow-hidden` as part of the shared `CARD` surface. Left for a follow-up across `CARD` consumers.