### PR TITLE
refactor(audit): binding validation, expiry round-trip, rotation stamp, labelled inputs, OTP fixes

### DIFF
--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -44,7 +44,7 @@ export default function Score({ audit }: Props) {
           data-testid="audit-score"
           className="text-[34px] font-semibold tracking-display text-text"
         >
-          {score}
+          {score.toFixed(1)}
         </div>
         <div className="font-mono text-xs uppercase tracking-label text-text3">
           {t('Overall Score')}

--- a/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
+++ b/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
@@ -53,11 +53,7 @@ export function useDraft(type: EntryType, revealed: Entry | null): Draft {
 
   const set = (name: string, value: string | string[]) => {
     setConfirmDiscard(false)
-    setModel(current => ({
-      ...current,
-      [name]: value,
-      ...(name === 'password' ? { password_updated_at: new Date().toISOString() } : {})
-    }))
+    setModel(current => ({ ...current, [name]: value }))
   }
 
   const close = () => {
@@ -81,8 +77,16 @@ export function useDraft(type: EntryType, revealed: Entry | null): Draft {
       return
     }
     setSaveError(null)
+    // The rotation stamp records a password *change*, not typing: stamping it
+    // per keystroke made "changed just now" true of a password that was typed
+    // back to what it already was.
+    const stamped =
+      model.password !== pristine.password
+        ? { ...model, password_updated_at: new Date().toISOString() }
+        : model
+    setModel(stamped)
     // Never imply success on a failed write: surface the error, stay in edit.
-    saveEntry(model).catch(() => setSaveError(t('Could not save. Please try again.')))
+    saveEntry(stamped).catch(() => setSaveError(t('Could not save. Please try again.')))
   }
 
   // Bound fresh every render: both handlers close over the current draft.

--- a/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
+++ b/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
@@ -27,27 +27,20 @@ export interface Draft {
  */
 export function useDraft(type: EntryType, revealed: Entry | null): Draft {
   const kind = kindOf(type)
-  const initial = (): EntryDraft => ({ ...kind.defaults })
+  // `Show` holds the editor back until an existing entry's reveal has landed,
+  // so the decrypted values are already here at mount. Seeding from them beats
+  // adopting them in an effect, which raced whatever was typed first — and
+  // means a later reveal (a sync merge moving `updatedAt`) cannot replace the
+  // draft. The baseline is the state at open; a concurrent change resolves
+  // through last-writer-wins on save.
+  const initial = (): EntryDraft => ({ ...(revealed ?? kind.defaults) })
 
   const [attempted, setAttempted] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [confirmDiscard, setConfirmDiscard] = useState(false)
   const [model, setModel] = useState<EntryDraft>(initial)
   // What the model looked like when it was loaded — the dirty baseline.
-  const [pristine, setPristine] = useState<EntryDraft>(initial)
-
-  // Secret fields arrive encrypted; swap in the decrypted values — once. The
-  // reveal refetches when the entry's `updatedAt` moves (e.g. a sync merge
-  // landing mid-edit), and adopting that refetch would silently replace
-  // whatever the user has typed. The baseline is the state at open; a
-  // concurrent change resolves through last-writer-wins on save.
-  const [adopted, setAdopted] = useState(false)
-  useEffect(() => {
-    if (!revealed || adopted) return
-    setAdopted(true)
-    setModel({ ...revealed })
-    setPristine({ ...revealed })
-  }, [revealed, adopted])
+  const [pristine] = useState<EntryDraft>(initial)
 
   const dirty = JSON.stringify(model) !== JSON.stringify(pristine)
 

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import type { EntryMeta, EntryType } from '@/lib/commands'
 import { useRevealed } from '@/hooks/useRevealed'
 import Read from './Read'
@@ -23,10 +24,24 @@ export default function Show({ entry, type, editing }: Props) {
   // change still carries the previous entry's secrets. Match it to the entry in
   // hand before passing it down — a draft (no entry) never gets one at all.
   const current = revealed && entry && revealed.id === entry.id ? revealed : null
+  // Once an entry's secrets have been served, the editor owns the draft: a
+  // later reveal (the refetch an `updatedAt` change triggers, e.g. a sync merge
+  // landing mid-edit) must not take the editor away and the draft with it.
+  const served = useRef<string | undefined>(undefined)
+  if (current) served.current = current.id
 
   if (!kindType) return null
-  // Keyed per entry: each editing session starts from a fresh draft.
-  if (editing) return <Edit key={entry?.id ?? 'new'} type={kindType} revealed={current} />
+  if (editing) {
+    // The draft is seeded from the reveal, so an editor mounted before it lands
+    // would discard whatever was typed in the meantime. Hold the pane's frame
+    // until the secrets are in hand — a tombstone never gets here, so this
+    // always resolves. (`reveal_entry` refuses deleted rows; `editEntry` does
+    // too.)
+    if (entry && !current && served.current !== entry.id)
+      return <div className="mx-auto min-h-[320px] w-full max-w-[860px]" />
+    // Keyed per entry: each editing session starts from a fresh draft.
+    return <Edit key={entry?.id ?? 'new'} type={kindType} revealed={current} />
+  }
   if (!entry) return null
   return <Read entry={entry} revealed={current} />
 }

--- a/src/components/elements/fields/Field.tsx
+++ b/src/components/elements/fields/Field.tsx
@@ -19,8 +19,6 @@ export interface FieldProps {
   secure?: boolean
   /** The row's headline secret: 2xl, letter-spaced for reading aloud. */
   big?: boolean
-  /** Character-by-character tracking without the size bump. */
-  secret?: boolean
   type?: string
   maxLength?: number
   placeholder?: string
@@ -28,10 +26,6 @@ export interface FieldProps {
   /** Trailing controls shown in both modes. */
   actions?: ReactNode
   below?: ReactNode
-  /** Stored → displayed, live (card-number grouping). */
-  format?: (value: string) => string
-  /** Typed → stored, live (a card number keeps only digits). */
-  parse?: (value: string) => string
   /** Stored → stored, on blur (a URL gains its missing scheme). */
   normalize?: (value: string) => string
   /** A format complaint about a non-empty value, or ''. */
@@ -50,15 +44,12 @@ export default function Field({
   required,
   secure,
   big,
-  secret,
   type = 'text',
   maxLength,
   placeholder,
   prefix,
   actions,
   below,
-  format,
-  parse,
   normalize,
   check
 }: FieldProps) {
@@ -79,7 +70,7 @@ export default function Field({
   const mask = masked ? MASK : undefined
   const ink = cx(
     'block h-6 w-full min-w-0 truncate font-mono leading-6 text-text',
-    big ? 'text-xl tracking-secret' : secret ? 'text-base tracking-secret' : 'text-base'
+    big ? 'text-xl tracking-secret' : 'text-base'
   )
 
   return (
@@ -108,13 +99,13 @@ export default function Field({
         <input
           name={name}
           type={type}
-          value={format ? format(value) : value}
+          value={value}
           placeholder={placeholder}
           maxLength={maxLength}
           autoComplete="off"
           spellCheck={false}
           style={mask}
-          onChange={event => set(parse ? parse(event.target.value) : event.target.value)}
+          onChange={event => set(event.target.value)}
           onBlur={normalize ? () => set(normalize(value)) : undefined}
           className={cx(
             ink,
@@ -124,7 +115,7 @@ export default function Field({
         />
       ) : (
         <span className={ink} style={mask} data-testid={`entry-value-${name}`}>
-          {format ? format(value) : value}
+          {value}
         </span>
       )}
     </FieldRow>

--- a/src/components/elements/fields/Field.tsx
+++ b/src/components/elements/fields/Field.tsx
@@ -95,8 +95,10 @@ export default function Field({
         </>
       }
     >
-      {editing ? (
+      {id =>
+        editing ? (
         <input
+          id={id}
           name={name}
           type={type}
           value={value}
@@ -113,11 +115,12 @@ export default function Field({
             error ? 'border-bad' : 'border-line2 focus:border-accent-line'
           )}
         />
-      ) : (
-        <span className={ink} style={mask} data-testid={`entry-value-${name}`}>
-          {value}
-        </span>
-      )}
+        ) : (
+          <span className={ink} style={mask} data-testid={`entry-value-${name}`}>
+            {value}
+          </span>
+        )
+      }
     </FieldRow>
   )
 }

--- a/src/components/elements/fields/NoteField.tsx
+++ b/src/components/elements/fields/NoteField.tsx
@@ -27,28 +27,34 @@ export default function NoteField({
 
   return (
     <FieldRow label={label} error={requiredError(value, required, attempted)}>
-      {editing ? (
-        <textarea
-          name={name}
-          value={value}
-          rows={1}
-          placeholder={t('Anything worth remembering')}
-          spellCheck={false}
-          ref={grow}
-          onChange={event => {
-            grow(event.currentTarget)
-            set(event.target.value)
-          }}
-          className="block min-h-6 w-full resize-none overflow-hidden border-b border-line2 bg-transparent text-base leading-relaxed text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
-        />
-      ) : (
-        <div
-          className="whitespace-pre-wrap break-words text-base leading-relaxed text-text2"
-          data-testid={`entry-value-${name}`}
-        >
-          {value}
-        </div>
-      )}
+      {id =>
+        editing ? (
+          <textarea
+            id={id}
+            name={name}
+            // A note entry's body is a full-bleed row: there is no label column
+            // to point at it, so it names itself.
+            aria-label={label === undefined ? t('Note') : undefined}
+            value={value}
+            rows={1}
+            placeholder={t('Anything worth remembering')}
+            spellCheck={false}
+            ref={grow}
+            onChange={event => {
+              grow(event.currentTarget)
+              set(event.target.value)
+            }}
+            className="block min-h-6 w-full resize-none overflow-hidden border-b border-line2 bg-transparent text-base leading-relaxed text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
+          />
+        ) : (
+          <div
+            className="whitespace-pre-wrap break-words text-base leading-relaxed text-text2"
+            data-testid={`entry-value-${name}`}
+          >
+            {value}
+          </div>
+        )
+      }
     </FieldRow>
   )
 }

--- a/src/components/elements/fields/Otp/index.tsx
+++ b/src/components/elements/fields/Otp/index.tsx
@@ -14,12 +14,13 @@ import { otpSecret } from './secret'
 export default function OtpField({ name = 'otp', label = 'OTP' }) {
   const { value, set, editing } = useField(name)
   const parsed = otpSecret(value)
-  // Reading, trust whatever the vault holds: the generator is the final judge,
-  // and refusing a legacy secret here would silently drop a working code.
-  const secret = editing ? parsed : parsed || value.trim()
-  const { code, time } = useOtp(secret)
+  const { code, time } = useOtp(parsed)
 
-  if (!editing && !secret) return null
+  // Reading, the panel is worth its column only once a code has arrived.
+  // Passing the raw value through when it failed to parse bought nothing but a
+  // dead dial and a "Copy code" button that copied '' — the backend rejects
+  // exactly what `otpSecret` rejects.
+  if (!editing && !code) return null
 
   return (
     <Panel className="flex flex-col items-center p-3.5">
@@ -45,7 +46,7 @@ export default function OtpField({ name = 'otp', label = 'OTP' }) {
         />
       )}
 
-      {secret && <Dial code={code} time={time} />}
+      {parsed && <Dial code={code} time={time} />}
 
       {editing && value !== '' && !parsed && (
         <div className="mt-3 text-base text-bad">{t('Not a one-time-password secret')}</div>

--- a/src/components/elements/fields/Otp/index.tsx
+++ b/src/components/elements/fields/Otp/index.tsx
@@ -28,6 +28,9 @@ export default function OtpField({ name = 'otp', label = 'OTP' }) {
       {editing && (
         <input
           name={name}
+          // The panel's heading is not a label element, so the input names
+          // itself rather than borrowing the row geometry it does not use.
+          aria-label={t(label)}
           value={value}
           placeholder={t('base32 secret or otpauth:// link')}
           autoComplete="off"

--- a/src/components/elements/fields/Otp/secret.test.ts
+++ b/src/components/elements/fields/Otp/secret.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { otpSecret } from './secret'
+
+const SECRET = 'JBSWY3DPEHPK3PXP'
+
+describe('otpSecret', () => {
+  const cases: [string, string, string][] = [
+    ['nothing', '', ''],
+    ['a bare secret', SECRET, SECRET],
+    ['a lower-case secret', SECRET.toLowerCase(), SECRET],
+    ['a secret typed in groups', 'JBSW Y3DP EHPK 3PXP', SECRET],
+    // The Rust decoder reads unpadded base32 only, so padding is dropped.
+    ['a padded secret', `${SECRET}======`, SECRET],
+    ['padding in the middle', 'JBSWY3DP=EHPK3PXP', ''],
+    ['an otpauth link', `otpauth://totp/Acme:me@acme.io?secret=${SECRET}&issuer=Acme`, SECRET],
+    // Some exporters capitalise the parameter; URI parameters are not keywords.
+    ['an otpauth link spelling it Secret', `otpauth://totp/Acme?Secret=${SECRET}`, SECRET],
+    ['an otpauth link spelling it SECRET', `otpauth://totp/Acme?SECRET=${SECRET}`, SECRET],
+    ['an otpauth link with a padded secret', `otpauth://totp/Acme?secret=${SECRET}%3D%3D`, SECRET],
+    ['an otpauth link with no secret', 'otpauth://totp/Acme?issuer=Acme', ''],
+    ['an otpauth link with no query at all', 'otpauth://totp/Acme', ''],
+    ['a too-short secret', 'JBSWY3D', ''],
+    ['a non-base32 string', 'not-a-secret', ''],
+    ['base32 with the digits base32 has no room for', 'JBSWY3DPEHPK3PX1', '']
+  ]
+
+  for (const [what, input, expected] of cases) {
+    it(`reads ${what}`, () => expect(otpSecret(input)).toBe(expected))
+  }
+})

--- a/src/components/elements/fields/Otp/secret.ts
+++ b/src/components/elements/fields/Otp/secret.ts
@@ -1,4 +1,12 @@
-const BASE32 = /^[A-Z2-7]{8,}=*$/
+const BASE32 = /^[A-Z2-7]{8,}$/
+
+/** The `secret` parameter of an otpauth:// URI, whatever case it was spelled in. */
+const secretParam = (query: string): string => {
+  for (const [key, value] of new URLSearchParams(query)) {
+    if (key.toLowerCase() === 'secret') return value
+  }
+  return ''
+}
 
 /**
  * The TOTP secret carried by whatever was pasted: a bare base32 string, or the
@@ -9,9 +17,11 @@ export const otpSecret = (value: string): string => {
   const raw = value.trim().replace(/\s+/g, '')
   if (!raw) return ''
   if (/^otpauth:\/\//i.test(raw)) {
-    const query = raw.slice(raw.indexOf('?') + 1)
-    return otpSecret(new URLSearchParams(query).get('secret') ?? '')
+    return otpSecret(secretParam(raw.slice(raw.indexOf('?') + 1)))
   }
-  const upper = raw.toUpperCase()
+  // The backend decodes with base32 RFC4648 padding *off* (totp-rs
+  // `Secret::Encoded`), which rejects '=' outright — so padding is dropped
+  // here rather than stored and refused later.
+  const upper = raw.toUpperCase().replace(/=+$/, '')
   return BASE32.test(upper) ? upper : ''
 }

--- a/src/components/elements/fields/PasswordField.tsx
+++ b/src/components/elements/fields/PasswordField.tsx
@@ -1,6 +1,6 @@
 import { openGenerator } from '@/store'
 import { t } from '@/i18n'
-import { relativeTime } from '@/utils/time'
+import { relativeDuration, shortDate, toTime } from '@/utils/time'
 import { RefreshGlyph } from '../../Main/icons'
 import StrengthBar from '../StrengthBar'
 import { MONO_LABEL } from '../tokens'
@@ -8,14 +8,16 @@ import Field from './Field'
 import { useField, useFields } from './context'
 
 // How long this password has been in place. `now` reads as "just now" rather
-// than "changed now ago".
+// than "changed now ago", and past a week — where the duration runs out — the
+// date goes in a sentence of its own rather than "changed 05/06/2026 ago".
 const rotationStamp = (iso?: string | string[]): string => {
   if (typeof iso !== 'string') return ''
-  const ago = relativeTime(iso)
-  if (!ago) return ''
-  return ago === 'now'
-    ? t('changed just now')
-    : t('changed {t} ago').replace('{t}', ago)
+  const at = toTime(iso)
+  if (at === null) return ''
+  const ago = relativeDuration(iso)
+  if (ago === 'now') return t('changed just now')
+  if (ago) return t('changed {t} ago').replace('{t}', ago)
+  return t('changed on {d}').replace('{d}', shortDate(at))
 }
 
 export default function PasswordField({

--- a/src/components/elements/fields/PasswordField.tsx
+++ b/src/components/elements/fields/PasswordField.tsx
@@ -46,11 +46,11 @@ export default function PasswordField({
         editing ? (
           <button
             type="button"
+            data-testid="generate-password-link"
             onClick={() => openGenerator(set)}
             className="flex cursor-pointer items-center gap-1.5 text-base text-accent hover:brightness-110"
           >
             <RefreshGlyph size={13} />
-            {/* The word is its own element: the generator spec clicks it by text. */}
             <span>generate</span>
           </button>
         ) : undefined

--- a/src/components/elements/fields/Row.tsx
+++ b/src/components/elements/fields/Row.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useId, type ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import { t } from '@/i18n'
 import { MONO_LABEL, ROW_HAIRLINE } from '../tokens'
@@ -14,7 +14,12 @@ interface Props {
   below?: ReactNode
   /** Rendered under the value once there is something to complain about. */
   error?: string
-  children: ReactNode
+  /**
+   * Given the id the row's `<label>` points at, so the control it renders
+   * carries an accessible name. A full-bleed row has no label to hand over and
+   * names its own control instead.
+   */
+  children: (id: string) => ReactNode
 }
 
 // THE detail-row geometry: a w-24 mono label column, the value, trailing
@@ -22,13 +27,18 @@ interface Props {
 // editors both render through it, so switching modes never moves a row.
 export default function FieldRow({ label, prefix, actions, below, error, children }: Props) {
   const labelled = label !== undefined
+  const id = useId()
 
   return (
     <div className={cx('item px-3.5 py-3', ROW_HAIRLINE)}>
       <div className="flex items-center gap-3">
-        {labelled && <span className={`w-24 flex-none ${MONO_LABEL}`}>{t(label)}</span>}
+        {labelled && (
+          <label htmlFor={id} className={`w-24 flex-none ${MONO_LABEL}`}>
+            {t(label)}
+          </label>
+        )}
         {prefix && <span className="flex-none text-text3">{prefix}</span>}
-        <div className="min-w-0 flex-1">{children}</div>
+        <div className="min-w-0 flex-1">{children(id)}</div>
         {actions}
       </div>
       {(below || error) && (

--- a/src/components/elements/fields/formats.ts
+++ b/src/components/elements/fields/formats.ts
@@ -20,6 +20,13 @@ export const emailError = (value: string): string =>
   EMAIL.test(value.trim()) ? '' : t('Not an email address')
 
 /**
+ * What every kind's `isValid` counts as a value: present, and not just spaces.
+ * A type guard, so the same test narrows a draft key for the format checks.
+ */
+export const filled = (value?: string | string[]): value is string =>
+  typeof value === 'string' && value.trim() !== ''
+
+/**
  * The one rule behind every "Required" message: a field the kind's `isValid`
  * needs only complains once the user has actually tried to save.
  */

--- a/src/hooks/useOtp.test.tsx
+++ b/src/hooks/useOtp.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { generateOtp } from '@/lib/commands'
+import { useOtp } from './useOtp'
+
+type Otp = { code: string; time: number }
+
+/** A promise the test resolves by hand, to hold one fetch in flight. */
+const deferred = () => {
+  let resolve: (otp: Otp) => void = () => {}
+  const promise = new Promise<Otp>(r => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('useOtp', () => {
+  // The rollover refetch outlives the secret it was asked for: a slow answer
+  // for the old secret must not overwrite the new secret's code.
+  it('discards a rollover fetch for a secret that is no longer current', async () => {
+    const stale = deferred()
+    let asked = 0
+    vi.mocked(generateOtp).mockImplementation(secret => {
+      if (secret !== 'AAAAAAAA') return Promise.resolve({ code: '222222', time: 30 })
+      // The first code for AAAAAAAA arrives with its window already spent, so
+      // the rollover fetch fires straight away — and then hangs.
+      asked += 1
+      return asked === 1 ? Promise.resolve({ code: '111111', time: 0 }) : stale.promise
+    })
+
+    const { result, rerender } = renderHook(({ secret }) => useOtp(secret), {
+      initialProps: { secret: 'AAAAAAAA' }
+    })
+
+    await waitFor(() => expect(result.current.code).toBe('111111'))
+    await waitFor(() => expect(asked).toBe(2))
+
+    rerender({ secret: 'BBBBBBBB' })
+    await waitFor(() => expect(result.current.code).toBe('222222'))
+
+    await act(async () => {
+      stale.resolve({ code: '999999', time: 27 })
+    })
+
+    expect(result.current.code).toBe('222222')
+    expect(result.current.time).toBe(30)
+  })
+})

--- a/src/hooks/useOtp.ts
+++ b/src/hooks/useOtp.ts
@@ -31,15 +31,22 @@ export function useOtp(secret: string): { code: string; time: number } {
     }
   }, [secret])
 
-  // The window rolled over while we were watching: ask for the next code.
+  // The window rolled over while we were watching: ask for the next code. Same
+  // guard as the first fetch — without it a rollover left in flight when the
+  // field switches secrets lands on top of the new secret's code.
   useEffect(() => {
     if (!secret || time !== 0 || code === '') return
+    let cancelled = false
     generateOtp(secret)
       .then(otp => {
+        if (cancelled) return
         setCode(otp.code)
         setTime(otp.time)
       })
       .catch(() => {})
+    return () => {
+      cancelled = true
+    }
   }, [secret, time, code])
 
   return { code, time }

--- a/src/kinds/card/Fields/Value.tsx
+++ b/src/kinds/card/Fields/Value.tsx
@@ -40,6 +40,12 @@ interface Props {
   ink: string
   /** Blocks the save while empty and marks the box after the first attempt. */
   required?: boolean
+  /**
+   * Overrides the box's own emptiness test, for a slot whose contents are more
+   * than one draft key: a half-typed "MM" is not an empty box, but it is not a
+   * saveable expiry either.
+   */
+  invalid?: boolean
   zone?: 'top' | 'base'
   className?: string
 }
@@ -61,6 +67,7 @@ export default function Value({
   maxLength,
   ink,
   required,
+  invalid: invalidOverride,
   zone = 'base',
   className
 }: Props) {
@@ -74,7 +81,7 @@ export default function Value({
   if (set) {
     // The face's own error ink: `text-bad` is tuned for the app ground, not for
     // dark plastic, so the card uses a lighter red like every other hex on it.
-    const invalid = required && attempted && !value.trim()
+    const invalid = invalidOverride ?? (required && attempted && !value.trim())
     return (
       <label className={cx('block min-w-0 px-1.5 py-1', className)}>
         {caption}

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -9,7 +9,7 @@ import { formatExpiry, splitExpiry } from '../expiry'
 import Value from './Value'
 
 export default function Fields() {
-  const { set } = useFields()
+  const { set, attempted } = useFields()
   const editing = !!set
   const [show, setShow] = useState(false)
   // Editing shows what is being typed; reading hides it until asked.
@@ -95,6 +95,9 @@ export default function Fields() {
               testid="entry-value-expires"
               placeholder="MM/YY"
               required
+              // One box, two draft keys: "12" fills the box but not the pair,
+              // and `isValid` wants both — so the box has to say so itself.
+              invalid={attempted && !(month.value && year.value)}
               maxLength={5}
               ink="text-[13px]"
             />

--- a/src/kinds/card/expiry.test.ts
+++ b/src/kinds/card/expiry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { formatExpiry, splitExpiry } from './expiry'
+
+describe('formatExpiry', () => {
+  it('joins the stored pair, dropping a legacy 4-digit year', () => {
+    expect(formatExpiry('04', '29')).toBe('04/29')
+    expect(formatExpiry('04', '2029')).toBe('04/29')
+  })
+
+  it('leaves a month that is still being typed alone', () => {
+    expect(formatExpiry('', '')).toBe('')
+    expect(formatExpiry('1', '')).toBe('1')
+    expect(formatExpiry('12', '')).toBe('12')
+  })
+})
+
+describe('splitExpiry', () => {
+  it('splits the box back into the pair', () => {
+    expect(splitExpiry('12/30')).toEqual({ month: '12', year: '30' })
+    expect(splitExpiry('1')).toEqual({ month: '1', year: '' })
+  })
+
+  // A pre-redesign card stores month "3" / year "2027". Without the pad the box
+  // showed "3/27", which split back into month "32" on the first keystroke.
+  it('round-trips a legacy unpadded month', () => {
+    expect(splitExpiry(formatExpiry('3', '2027'))).toEqual({ month: '03', year: '27' })
+  })
+})

--- a/src/kinds/card/expiry.ts
+++ b/src/kinds/card/expiry.ts
@@ -8,7 +8,11 @@
 export const formatExpiry = (month: string, year: string): string => {
   const mm = month.replace(/\D/g, '').slice(0, 2)
   const yy = year.replace(/\D/g, '').slice(-2)
-  return yy ? `${mm}/${yy}` : mm
+  // Pre-redesign cards stored an unpadded month ("3"), which `splitExpiry`
+  // would re-read positionally as month "32" on the first keystroke. Padding
+  // the complete form makes the round-trip lossless. A month still being typed
+  // has no year yet, so this never fights the caret.
+  return yy ? `${mm.padStart(2, '0')}/${yy}` : mm
 }
 
 /** Splits whatever is in the box back into the pair, digit by typed digit. */

--- a/src/kinds/card/meta.ts
+++ b/src/kinds/card/meta.ts
@@ -1,5 +1,6 @@
 import type { Entry } from '@/lib/commands'
 import type { EntryDraft } from '@/defaults/entries'
+import { filled } from '@/components/elements/fields/formats'
 
 export const defaults: EntryDraft = {
   type: 'card',
@@ -14,7 +15,11 @@ export const defaults: EntryDraft = {
 
 // Cards do not require a PIN — most cards have none.
 export const isValid = (draft: EntryDraft): boolean =>
-  !!(draft.title && draft.number && draft.cvc && draft.month && draft.year)
+  filled(draft.title) &&
+  filled(draft.number) &&
+  filled(draft.cvc) &&
+  filled(draft.month) &&
+  filled(draft.year)
 
 export const primarySecret = (entry: Entry): string =>
   entry.type === 'card' ? entry.number : ''

--- a/src/kinds/login/meta.ts
+++ b/src/kinds/login/meta.ts
@@ -1,5 +1,6 @@
 import type { Entry, EntryMeta } from '@/lib/commands'
 import type { EntryDraft } from '@/defaults/entries'
+import { emailError, filled } from '@/components/elements/fields/formats'
 
 export const defaults: EntryDraft = {
   type: 'login',
@@ -13,7 +14,12 @@ export const defaults: EntryDraft = {
 }
 
 export const isValid = (draft: EntryDraft): boolean =>
-  !!(draft.title && draft.username && draft.password)
+  filled(draft.title) &&
+  filled(draft.username) &&
+  filled(draft.password) &&
+  // The email is optional, but the row's "Not an email address" complaint is
+  // binding: showing it in red and saving anyway is not a check.
+  (!filled(draft.email) || !emailError(draft.email))
 
 export const primarySecret = (entry: Entry): string =>
   entry.type === 'login' ? entry.password : ''

--- a/src/kinds/meta.test.ts
+++ b/src/kinds/meta.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { kindOf } from '.'
+import type { EntryDraft } from '@/defaults/entries'
+
+// What each kind will let through to `saveEntry` — the only thing standing
+// between a typed draft and the vault.
+
+const login = (overrides: Partial<EntryDraft> = {}): EntryDraft => ({
+  type: 'login',
+  title: 'Acme',
+  username: 'octocat',
+  password: 'hunter2',
+  ...overrides
+})
+
+const card = (overrides: Partial<EntryDraft> = {}): EntryDraft => ({
+  type: 'card',
+  title: 'Visa',
+  number: '4111111111111111',
+  cvc: '123',
+  month: '04',
+  year: '29',
+  ...overrides
+})
+
+const note = (overrides: Partial<EntryDraft> = {}): EntryDraft => ({
+  type: 'note',
+  title: 'Wifi',
+  note: 'the code is on the router',
+  ...overrides
+})
+
+describe('isValid', () => {
+  it('accepts a complete draft of every kind', () => {
+    expect(kindOf('login').isValid(login())).toBe(true)
+    expect(kindOf('card').isValid(card())).toBe(true)
+    expect(kindOf('note').isValid(note())).toBe(true)
+  })
+
+  // A field holding only spaces reads as empty and saves as empty, so it is
+  // not a value — for any kind, in any required field.
+  it('refuses a whitespace-only required field', () => {
+    expect(kindOf('login').isValid(login({ title: '   ' }))).toBe(false)
+    expect(kindOf('login').isValid(login({ username: ' ' }))).toBe(false)
+    expect(kindOf('login').isValid(login({ password: '\t' }))).toBe(false)
+    expect(kindOf('card').isValid(card({ number: '  ' }))).toBe(false)
+    expect(kindOf('card').isValid(card({ month: ' ' }))).toBe(false)
+    expect(kindOf('note').isValid(note({ note: '  \n ' }))).toBe(false)
+  })
+
+  it('holds the login to the email complaint the row already shows', () => {
+    expect(kindOf('login').isValid(login({ email: 'me@example.com' }))).toBe(true)
+    // Optional stays optional.
+    expect(kindOf('login').isValid(login({ email: '' }))).toBe(true)
+    expect(kindOf('login').isValid(login({ email: 'me@example' }))).toBe(false)
+  })
+})

--- a/src/kinds/note/meta.ts
+++ b/src/kinds/note/meta.ts
@@ -1,5 +1,6 @@
 import type { Entry, EntryMeta } from '@/lib/commands'
 import type { EntryDraft } from '@/defaults/entries'
+import { filled } from '@/components/elements/fields/formats'
 
 export const defaults: EntryDraft = {
   type: 'note',
@@ -7,7 +8,8 @@ export const defaults: EntryDraft = {
   note: ''
 }
 
-export const isValid = (draft: EntryDraft): boolean => !!(draft.title && draft.note)
+export const isValid = (draft: EntryDraft): boolean =>
+  filled(draft.title) && filled(draft.note)
 
 export const primarySecret = (entry: Entry): string =>
   entry.type === 'note' ? entry.note : ''

--- a/src/test/audit.test.tsx
+++ b/src/test/audit.test.tsx
@@ -57,4 +57,18 @@ describe('Audit aside', () => {
     expect(screen.getByText('Password Audit')).toBeInTheDocument()
     expect(screen.getByText('Overall Score')).toBeInTheDocument()
   })
+
+  // The dial numeral is on a 0-10 scale with one decimal — always one, or the
+  // numeral changes width as the vault improves.
+  it('always shows the score to one decimal', () => {
+    renderWithStore(<AuditAside />, { store: seed() })
+    expect(screen.getByTestId('audit-score')).toHaveTextContent('0.0')
+
+    const store = makeStore()
+    withEntries(store, [loginMeta()], {
+      l1: { score: 4, isWeak: false, isRepeating: false, breached: false }
+    })
+    renderWithStore(<AuditAside />, { store })
+    expect(screen.getAllByTestId('audit-score')[1]).toHaveTextContent('10.0')
+  })
 })

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -174,6 +174,13 @@ describe('Type-aware fields', () => {
     expect(input('title').value).toBe('Google!')
   })
 
+  // The e2e suite opens the generator through this link; a testid survives a
+  // rewording of the label, which matching on its text did not.
+  it('marks the generator link with a testid', () => {
+    renderWithStore(<Show type="login" editing />)
+    expect(screen.getByTestId('generate-password-link')).toBeInTheDocument()
+  })
+
   it('counts a recent rotation as a duration', async () => {
     const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString()
     vi.mocked(revealEntry).mockResolvedValue(

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -42,6 +42,19 @@ describe('Type-aware fields', () => {
     expect(screen.queryByText('Not an email address')).not.toBeInTheDocument()
   })
 
+  it('refuses to save a login whose email is not one', async () => {
+    renderWithStore(<Show type="login" editing />)
+    await userEvent.type(input('title'), 'Acme')
+    await userEvent.type(input('username'), 'octocat')
+    await userEvent.type(input('password'), 'hunter2')
+    await userEvent.type(input('email'), 'me@example')
+
+    await userEvent.click(screen.getByText('Save'))
+
+    expect(saveEntry).not.toHaveBeenCalled()
+    expect(screen.getByText('Not an email address')).toBeInTheDocument()
+  })
+
   it('groups a card number as it is typed and names the network', async () => {
     renderWithStore(<Show type="card" editing />)
     await userEvent.type(input('number'), '4111111111111111')

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -109,6 +109,27 @@ describe('Type-aware fields', () => {
     expect(screen.getByText('refreshes in 25s')).toBeInTheDocument()
   })
 
+  it('counts a recent rotation as a duration', async () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString()
+    vi.mocked(revealEntry).mockResolvedValue(
+      loginEntry({ password_updated_at: threeHoursAgo })
+    )
+    renderWithStore(<Show entry={loginMeta()} editing />)
+
+    expect(await screen.findByText('changed 3h ago')).toBeInTheDocument()
+  })
+
+  // Past a week the duration runs out; a date belongs in its own sentence and
+  // not inside "changed ... ago".
+  it('names the date once the rotation is older than a week', async () => {
+    const longAgo = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password_updated_at: longAgo }))
+    renderWithStore(<Show entry={loginMeta()} editing />)
+
+    const stamp = await screen.findByText(/^changed /)
+    expect(stamp.textContent).toMatch(/^changed on /)
+  })
+
   it('rates the password being typed and stamps when it changed', async () => {
     renderWithStore(<Show type="login" editing />)
     await userEvent.type(input('password'), 'correct horse battery staple')

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -109,6 +109,26 @@ describe('Type-aware fields', () => {
     expect(screen.getByText('refreshes in 25s')).toBeInTheDocument()
   })
 
+  // The draft is seeded from the reveal, so an editor offered before the reveal
+  // lands takes typing it is about to throw away.
+  it('offers no editor until an existing entry has been decrypted', async () => {
+    let resolveReveal: (entry: ReturnType<typeof loginEntry>) => void = () => {}
+    vi.mocked(revealEntry).mockReturnValue(
+      new Promise(resolve => {
+        resolveReveal = resolve
+      })
+    )
+    renderWithStore(<Show entry={loginMeta()} editing />)
+
+    expect(document.querySelector('input[name="title"]')).toBeNull()
+
+    resolveReveal(loginEntry())
+    await waitFor(() => expect(input('title').value).toBe('Google'))
+
+    await userEvent.type(input('title'), '!')
+    expect(input('title').value).toBe('Google!')
+  })
+
   it('counts a recent rotation as a duration', async () => {
     const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString()
     vi.mocked(revealEntry).mockResolvedValue(
@@ -170,8 +190,9 @@ describe('Type-aware fields', () => {
     await userEvent.type(input('password'), '2')
 
     await userEvent.click(screen.getByText('Save'))
-    const saved = vi.mocked(saveEntry).mock.calls[0][0]
-    expect(saved.password).toBe('secret2')
-    expect(saved.password_updated_at).not.toBe(stamp)
+    expect(saveEntry).toHaveBeenCalledWith(expect.objectContaining({ password: 'secret2' }))
+    expect(saveEntry).not.toHaveBeenCalledWith(
+      expect.objectContaining({ password_updated_at: stamp })
+    )
   })
 })

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -16,6 +16,27 @@ beforeEach(() => {
 // One behaviour per type-aware field: the thing that field knows and a plain
 // text box doesn't.
 describe('Type-aware fields', () => {
+  // Every editor input is reachable by the name the row shows, so a screen
+  // reader (and a test) can name what it is typing into.
+  it('names its inputs after their labels', () => {
+    renderWithStore(<Show type="login" editing />)
+
+    expect(screen.getByLabelText('Password')).toBe(input('password'))
+    expect(screen.getByLabelText('Username')).toBe(input('username'))
+    // The label is the translated one the row shows, not the draft key.
+    expect(screen.getByLabelText('URL')).toBe(input('website'))
+    expect(screen.getByLabelText('Email')).toBe(input('email'))
+    expect(screen.getByLabelText('OTP')).toBe(input('otp'))
+  })
+
+  it('names a full-bleed note body, which has no label column', () => {
+    renderWithStore(<Show type="note" editing />)
+
+    expect(screen.getByLabelText('Note')).toBe(
+      document.querySelector('textarea[name="note"]')
+    )
+  })
+
   it('gives a URL the scheme the user left out', async () => {
     renderWithStore(<Show type="login" editing />)
     await userEvent.type(input('website'), 'example.com')

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -133,6 +133,17 @@ describe('Type-aware fields', () => {
     expect(generateOtp).not.toHaveBeenCalled()
   })
 
+  // A pre-redesign vault can hold something `otpSecret` cannot read. The
+  // backend would reject it too, so there is no code to offer and no panel.
+  it('shows no dial for a stored secret it cannot read', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ otp: 'legacy-garbage' }))
+    renderWithStore(<Show entry={loginMeta()} />)
+
+    await waitFor(() => expect(screen.getByTestId('entry-value-username')).toBeInTheDocument())
+    expect(screen.queryByText('Copy code')).not.toBeInTheDocument()
+    expect(generateOtp).not.toHaveBeenCalled()
+  })
+
   it('previews the live code for a secret that is already saved', async () => {
     vi.mocked(generateOtp).mockResolvedValue({ code: '123456', time: 25 })
     vi.mocked(revealEntry).mockResolvedValue(loginEntry({ otp: 'JBSWY3DPEHPK3PXP' }))

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -132,10 +132,46 @@ describe('Type-aware fields', () => {
 
   it('rates the password being typed and stamps when it changed', async () => {
     renderWithStore(<Show type="login" editing />)
+    await userEvent.type(input('title'), 'Acme')
+    await userEvent.type(input('username'), 'octocat')
     await userEvent.type(input('password'), 'correct horse battery staple')
 
     // The strength meter is debounced through a timeout.
     expect(await screen.findByText('Very strong')).toBeInTheDocument()
+    // The stamp belongs to the saved password, so it lands on Save.
+    expect(screen.queryByText('changed just now')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Save'))
     expect(screen.getByText('changed just now')).toBeInTheDocument()
+  })
+
+  it('leaves the rotation stamp alone when the password ends up unchanged', async () => {
+    const stamp = '2024-01-01T00:00:00.000Z'
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password_updated_at: stamp }))
+    renderWithStore(<Show entry={loginMeta()} editing />)
+
+    await waitFor(() => expect(input('password').value).toBe('secret'))
+    // Typed and taken back: the password never moved.
+    await userEvent.type(input('password'), 'x')
+    await userEvent.type(input('password'), '{backspace}')
+
+    await userEvent.click(screen.getByText('Save'))
+    expect(saveEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ password: 'secret', password_updated_at: stamp })
+    )
+  })
+
+  it('moves the rotation stamp when the password really changed', async () => {
+    const stamp = '2024-01-01T00:00:00.000Z'
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ password_updated_at: stamp }))
+    renderWithStore(<Show entry={loginMeta()} editing />)
+
+    await waitFor(() => expect(input('password').value).toBe('secret'))
+    await userEvent.type(input('password'), '2')
+
+    await userEvent.click(screen.getByText('Save'))
+    const saved = vi.mocked(saveEntry).mock.calls[0][0]
+    expect(saved.password).toBe('secret2')
+    expect(saved.password_updated_at).not.toBe(stamp)
   })
 })

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -65,6 +65,21 @@ describe('Type-aware fields', () => {
     )
   })
 
+  it('says so when only half of the MM/YY box has been typed', async () => {
+    renderWithStore(<Show type="card" editing />)
+    await userEvent.type(input('title'), 'Visa')
+    await userEvent.type(input('number'), '4111111111111111')
+    await userEvent.type(input('cvc'), '123')
+    await userEvent.type(input('expiry'), '12')
+
+    await userEvent.click(screen.getByText('Save'))
+
+    // The box is not empty, so only the pair-aware check can complain — and
+    // without it the refusal to save was silent.
+    expect(screen.getByText('Required')).toBeInTheDocument()
+    expect(saveEntry).not.toHaveBeenCalled()
+  })
+
   it('takes an otpauth:// link and keeps only the secret inside it', async () => {
     renderWithStore(<Show type="login" editing />)
     await userEvent.click(input('otp'))

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { relativeTime, toTime } from './time'
+import { relativeDuration, relativeTime, toTime } from './time'
 
 // A fixed "now" so every case is deterministic: 2024-03-14, midday local time.
 const now = new Date(2024, 2, 14, 12, 0, 0).getTime()
@@ -37,6 +37,23 @@ describe('relativeTime', () => {
 
   it('keeps the year on dates outside the current one', () => {
     expect(relativeTime(new Date(2023, 0, 12, 9).toISOString(), now)).toBe('01/12/2023')
+  })
+})
+
+describe('relativeDuration', () => {
+  it('counts the same ladder as relativeTime inside the week', () => {
+    expect(relativeDuration(ago(0), now)).toBe('now')
+    expect(relativeDuration(ago(3 * MINUTE), now)).toBe('3m')
+    expect(relativeDuration(ago(3 * HOUR), now)).toBe('3h')
+    expect(relativeDuration(ago(6 * DAY), now)).toBe('6d')
+  })
+
+  // A duration is all this returns, so past the week it returns nothing and
+  // the caller phrases it as a date instead.
+  it('is empty past a week, and without a timestamp', () => {
+    expect(relativeDuration(ago(120 * DAY), now)).toBe('')
+    expect(relativeDuration(undefined, now)).toBe('')
+    expect(relativeDuration('not-a-date', now)).toBe('')
   })
 })
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -11,7 +11,12 @@ export const toTime = (iso?: string): number | null => {
   return Number.isNaN(at) ? null : at
 }
 
-export const relativeTime = (iso?: string, now: number = Date.now()): string => {
+/**
+ * How long ago, as a duration and nothing else — '' past a week, where a
+ * duration stops being worth counting. For callers that put the value in a
+ * sentence ("changed {t} ago") and need to pick another phrasing instead.
+ */
+export const relativeDuration = (iso?: string, now: number = Date.now()): string => {
   const at = toTime(iso)
   if (at === null) return ''
 
@@ -20,7 +25,13 @@ export const relativeTime = (iso?: string, now: number = Date.now()): string => 
   if (elapsed < HOUR) return `${Math.floor(elapsed / MINUTE)}m`
   if (elapsed < DAY) return `${Math.floor(elapsed / HOUR)}h`
   if (elapsed < 7 * DAY) return `${Math.floor(elapsed / DAY)}d`
-  return shortDate(at)
+  return ''
+}
+
+export const relativeTime = (iso?: string, now: number = Date.now()): string => {
+  const at = toTime(iso)
+  if (at === null) return ''
+  return relativeDuration(iso, now) || shortDate(at)
 }
 
 const pad = (value: number) => String(value).padStart(2, '0')

--- a/tests/e2e/specs/generator.spec.ts
+++ b/tests/e2e/specs/generator.spec.ts
@@ -120,7 +120,7 @@ describe("password generator", () => {
 
     // The link on the password row (`src/components/elements/fields/PasswordField.tsx`)
     // — it opens the same dialog with a callback bound to this field.
-    await $('[data-testid="entry-sheet"]').$("span*=generate").click();
+    await $('[data-testid="generate-password-link"]').click();
     await waitFor("generator-dialog");
     await browser.waitUntil(async () => (await output().getText()) !== "", {
       timeout: 10_000,


### PR DESCRIPTION
Audit fixes, detail pane / editor / fields / kinds stream. Stacked on `audit/elements-i18n`; retargets as the stack lands.

### Bugs
- **A half-typed card expiry made Save a dead button** with no message; the MM/YY slot now reports `Required` on its own pair.
- **Legacy cards with `month:"3"` corrupted on the first keystroke** (`3/27` re-split as `32/`); the format side is canonical (`03/27`) so the round-trip closes.
- **The rotation stamp read "changed 05/06/2026 ago"** past a week; older stamps say `changed on <date>`.
- **`password_updated_at` was rewritten on every keystroke**; it moves on save, only when the password changed.
- **Typing before the decrypt landed was discarded**; the editor waits for the reveal and seeds the draft from it, which also removes the adopt-once race.
- **"Not an email address" was decorative**; format and whitespace checks are binding on save for all three kinds.
- **No editor input had an accessible name**; `FieldRow` owns `<label htmlFor>`.
- OTP: an unreadable stored secret rendered a dead dial; `=` padding is stripped (the Rust decoder rejects padded base32) and `SECRET=` is read case-insensitively; the rollover refetch is cancellable.
- The audit dial score renders to one decimal as documented.

### Cleanup
`Field`'s unused `format`/`parse`/`secret` props and their misleading comments removed; the generator link has a testid and `generator.spec.ts` uses it.

### Verified
`bun run typecheck`, `bun run lint`, `bun run test` (322), e2e typecheck. Each fix has a test verified red without it.