### PR TITLE
fix(window): show the main window only once the webview has painted

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Swifty</title>
+    <!--
+      Pre-paint ground, so the very first frame the webview draws is already
+      themed instead of a white flash (matters on reload and on the startup
+      fallback path in window.rs). Values mirror `--c-app` in styles/theme.css;
+      they have to be literal here because this paints before any CSS loads.
+      Keyed off the OS rather than the stored preference — reading localStorage
+      would need an inline script, which the CSP rightly forbids.
+    -->
+    <style>
+      html {
+        background: #e7e8ea;
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
+          background: #0f1011;
+        }
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -4,6 +4,11 @@ use tauri_plugin_opener::OpenerExt;
 
 const MAIN: &str = "main";
 
+// How long to wait for the first page load before showing the window anyway, so
+// a webview that never finishes (dev server down, a throwing bundle) degrades to
+// a blank window rather than no window at all.
+const SHOW_FALLBACK: std::time::Duration = std::time::Duration::from_secs(3);
+
 // Build the main window from the frozen config, adding the per-OS chrome and
 // navigation locking that tauri.conf.json can't express (config sets create:false).
 pub fn create(app: &AppHandle) -> tauri::Result<()> {
@@ -16,10 +21,26 @@ pub fn create(app: &AppHandle) -> tauri::Result<()> {
         .expect("main window missing from tauri.conf.json")
         .clone();
 
+    // One-shot latch: whichever of the two reveal paths (page load, fallback
+    // timer) wins, the other becomes a no-op, so a window the user has since
+    // closed to the tray never pops back up on its own.
+    let revealed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
     let handle = app.clone();
+    let ready = app.clone();
+    let ready_latch = revealed.clone();
     #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::from_config(app, &config)?
-        .on_navigation(move |url| navigate(&handle, url));
+        .on_navigation(move |url| navigate(&handle, url))
+        // Config creates the window hidden: an empty window would otherwise sit
+        // on screen through the whole bundle load, and with an overlay title bar
+        // that reads as bare traffic lights floating over nothing. Reveal it once
+        // the webview has painted the first frame instead.
+        .on_page_load(move |_, payload| {
+            if matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                reveal(&ready, &ready_latch);
+            }
+        });
 
     // Frameless on Windows; macOS keeps the hidden-inset title bar from config.
     #[cfg(target_os = "windows")]
@@ -30,6 +51,13 @@ pub fn create(app: &AppHandle) -> tauri::Result<()> {
     let window = builder.build()?;
     let handle = app.clone();
     window.on_window_event(move |event| autolock::handle_event(&handle, event));
+
+    let fallback = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(SHOW_FALLBACK);
+        reveal(&fallback, &revealed);
+    });
+
     Ok(())
 }
 
@@ -42,6 +70,13 @@ fn navigate(app: &AppHandle, url: &tauri::Url) -> bool {
         return false;
     }
     true
+}
+
+// First reveal at startup, run at most once (see the latch in `create`).
+fn reveal(app: &AppHandle, revealed: &std::sync::atomic::AtomicBool) {
+    if !revealed.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        show(app);
+    }
 }
 
 // Show and focus the main window (tray "Open Swifty" and second-instance launch).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,6 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "main",
@@ -22,7 +21,7 @@
         "minHeight": 640,
         "center": true,
         "resizable": true,
-        "transparent": true,
+        "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "decorations": true


### PR DESCRIPTION
## Problem

On launch you'd see the traffic-light buttons appear on their own, with no window frame around them, and only after a delay would the actual window show up.

Two things combined to cause it:

1. **The window was created already-visible.** `window::create` runs in `setup()` and the config had no `"visible": false`, so AppKit put the NSWindow on screen the moment the Rust setup hook ran — several hundred ms before WebKit finished loading the bundle.
2. **That empty window was `transparent: true`.** With a clear, non-opaque NSWindow there is nothing to draw until web content paints. The traffic lights are native AppKit subviews, and `titleBarStyle: Overlay` + `hiddenTitle` strip the bar and title away, so those buttons were the only pixels on screen.

The gap lasted as long as it did because the first opaque pixel came from `body { background: var(--c-app) }` in `theme.css` — i.e. only after the JS bundle loaded and React mounted. `index.html` carried no styles at all.

## Changes

- **Show when ready.** The window is created hidden and revealed on `PageLoadEvent::Finished`. A 3s fallback thread shows it regardless, so a dead dev server or a throwing bundle degrades to a blank window rather than *no* window. Both paths go through a one-shot `AtomicBool` latch, so closing to the tray within those 3s doesn't get undone by the timer. `show()` is untouched — tray and second-instance launch still use it.
- **Drop `transparent` / `macOSPrivateApi`** (and the `macos-private-api` Cargo feature). Nothing in the UI used transparency: no `backdrop-filter` or vibrancy anywhere in `theme.css`, and every shell root paints opaque `bg-app`. `Overlay` + `hiddenTitle` work fine on an opaque window.
- **Pre-paint ground in `index.html`.** An inline `<style>` mirroring `--c-app`, with a `prefers-color-scheme: dark` variant, so the first frame on reload or on the fallback path isn't a white flash. Keyed off the OS rather than the stored preference because reading `localStorage` would need an inline script, which the CSP (`script-src 'self'`) correctly blocks.

## Testing

- `cargo check` clean, `cargo test` 185 passed
- `bun run test` 330 passed (42 files)
- `bun run build` green

Not yet verified visually on launch — worth a look via `bun run tauri:dev` and in a release build, since dev's unbundled module graph makes the load window much wider than production.