### PR TITLE
feat(passkeys): passkey data model and Bitwarden import/export

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -15,8 +15,8 @@ use tauri_plugin_dialog::DialogExt;
 
 use crate::commands::store_err;
 use crate::error::{Error, Result};
-use crate::import::{self, EntryKind, Format, ImportedEntry, RowError};
-use crate::models::Entry;
+use crate::import::{self, EntryKind, Format, ImportedEntry, ImportedPasskey, RowError};
+use crate::models::{Entry, Passkey};
 use crate::state::AppState;
 use crate::store::{migrate, Record, VaultStore};
 
@@ -239,6 +239,9 @@ fn imported_to_entry(imp: &ImportedEntry) -> Entry {
         pin: None,
         name: None,
         tags: (!imp.tags.is_empty()).then(|| imp.tags.clone()),
+        // Set below for logins only; stays None so a passkey-less entry
+        // serializes exactly as it did before passkeys existed.
+        passkeys: None,
         // No third-party format carries a star.
         favorite: false,
         created_at: Some(now.clone()),
@@ -251,6 +254,8 @@ fn imported_to_entry(imp: &ImportedEntry) -> Entry {
             e.password = imp.password.clone();
             e.website = imp.url.clone();
             e.otp = imp.otp.clone();
+            e.passkeys =
+                (!imp.passkeys.is_empty()).then(|| imp.passkeys.iter().map(to_passkey).collect());
         }
         EntryKind::Card => {
             e.number = imp.card_number.clone();
@@ -285,5 +290,42 @@ fn entry_to_imported(e: &Entry) -> ImportedEntry {
         card_year: e.year.clone(),
         card_cvc: e.cvc.clone(),
         cardholder: e.name.clone(),
+        passkeys: e
+            .passkeys
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(to_imported_passkey)
+            .collect(),
+    }
+}
+
+// The two halves of the passkey mapping. Field-for-field: the import layer's
+// struct mirrors `models::Passkey`, and base64url values cross unchanged.
+fn to_passkey(p: &ImportedPasskey) -> Passkey {
+    Passkey {
+        credential_id: p.credential_id.clone(),
+        rp_id: p.rp_id.clone(),
+        rp_name: p.rp_name.clone(),
+        user_handle: p.user_handle.clone(),
+        user_name: p.user_name.clone(),
+        user_display_name: p.user_display_name.clone(),
+        private_key: p.private_key.clone(),
+        counter: p.counter,
+        created_at: p.created_at.clone(),
+    }
+}
+
+fn to_imported_passkey(p: &Passkey) -> ImportedPasskey {
+    ImportedPasskey {
+        credential_id: p.credential_id.clone(),
+        rp_id: p.rp_id.clone(),
+        rp_name: p.rp_name.clone(),
+        user_handle: p.user_handle.clone(),
+        user_name: p.user_name.clone(),
+        user_display_name: p.user_display_name.clone(),
+        private_key: p.private_key.clone(),
+        counter: p.counter,
+        created_at: p.created_at.clone(),
     }
 }

--- a/src-tauri/src/crypto/vault.rs
+++ b/src-tauri/src/crypto/vault.rs
@@ -189,4 +189,53 @@ mod tests {
         let back = cipher.unseal(&sealed).unwrap();
         assert_eq!(back.password.as_deref(), Some("s3cret"));
     }
+
+    fn entry_with_passkey() -> Entry {
+        Entry {
+            passkeys: Some(vec![crate::models::Passkey {
+                credential_id: "Y3JlZDE".into(),
+                rp_id: "ex.com".into(),
+                rp_name: Some("Example".into()),
+                user_handle: "dWgx".into(),
+                user_name: "alice".into(),
+                user_display_name: "Alice".into(),
+                private_key: "cHJpdmF0ZUtleQ".into(),
+                counter: 3,
+                created_at: Some("2024-01-01T00:00:00Z".into()),
+            }]),
+            ..entry()
+        }
+    }
+
+    // Both payload ciphers carry passkeys through untouched — the legacy one
+    // obscures only the named secret fields, so this is the check that its
+    // per-field pass does not drop the new list.
+    #[test]
+    fn aead_payload_round_trips_passkeys() {
+        let cipher = argon2_key().payload_cipher();
+        let sealed = cipher.seal(&entry_with_passkey()).unwrap();
+        // The private key never appears in the sealed bytes.
+        let secret = b"cHJpdmF0ZUtleQ";
+        assert!(!sealed.windows(secret.len()).any(|w| w == secret));
+        let back = cipher.unseal(&sealed).unwrap();
+        assert_eq!(back.passkeys, entry_with_passkey().passkeys);
+    }
+
+    #[test]
+    fn legacy_payload_round_trips_passkeys() {
+        let cipher = VaultKey::legacy_from_password("pw").payload_cipher();
+        let sealed = cipher.seal(&entry_with_passkey()).unwrap();
+        let back = cipher.unseal(&sealed).unwrap();
+        assert_eq!(back.passkeys, entry_with_passkey().passkeys);
+    }
+
+    // The `.swftx` path: `export_entry`'s obscure + the import path's expose,
+    // under a second Cryptor, must leave passkeys byte-identical.
+    #[test]
+    fn legacy_obscure_expose_preserves_passkeys() {
+        let out = Cryptor::new("backup-password");
+        let obscured = out.obscure(&entry_with_passkey()).unwrap();
+        let back = out.expose(&obscured).unwrap();
+        assert_eq!(back.passkeys, entry_with_passkey().passkeys);
+    }
 }

--- a/src-tauri/src/import/bitwarden.rs
+++ b/src-tauri/src/import/bitwarden.rs
@@ -3,9 +3,14 @@
 
 use serde::Deserialize;
 
-use super::{EntryKind, ImportResult, ImportedEntry, Importer};
+use super::{EntryKind, ImportResult, ImportedEntry, ImportedPasskey, Importer};
 
 pub struct Bitwarden;
+
+/// The only passkey shape we support, on the way in and on the way out.
+pub const KEY_TYPE: &str = "public-key";
+pub const KEY_ALGORITHM: &str = "ECDSA";
+pub const KEY_CURVE: &str = "P-256";
 
 #[derive(Deserialize)]
 struct Export {
@@ -37,6 +42,84 @@ struct Login {
     totp: Option<String>,
     #[serde(default)]
     uris: Vec<Uri>,
+    #[serde(default, rename = "fido2Credentials")]
+    fido2_credentials: Vec<Fido2Credential>,
+}
+
+// Every value in a Bitwarden fido2Credentials element is a JSON string,
+// `counter` included — but a number is accepted too, so one odd producer
+// cannot fail the whole file.
+#[derive(Deserialize)]
+struct Fido2Credential {
+    #[serde(default, rename = "credentialId")]
+    credential_id: Option<String>,
+    #[serde(default, rename = "keyAlgorithm")]
+    key_algorithm: Option<String>,
+    #[serde(default, rename = "keyCurve")]
+    key_curve: Option<String>,
+    #[serde(default, rename = "keyValue")]
+    key_value: Option<String>,
+    #[serde(default, rename = "rpId")]
+    rp_id: Option<String>,
+    #[serde(default, rename = "rpName")]
+    rp_name: Option<String>,
+    #[serde(default, rename = "userHandle")]
+    user_handle: Option<String>,
+    #[serde(default, rename = "userName")]
+    user_name: Option<String>,
+    #[serde(default, rename = "userDisplayName")]
+    user_display_name: Option<String>,
+    #[serde(default)]
+    counter: Option<serde_json::Value>,
+    #[serde(default, rename = "creationDate")]
+    creation_date: Option<String>,
+}
+
+impl Fido2Credential {
+    // Absent algorithm/curve means "the default", which is the only one we
+    // support; a stated one that differs is a credential we cannot use. Nor is
+    // one missing its id, relying party or key — there is nothing to sign with.
+    fn is_usable(&self) -> bool {
+        let ok = |v: &Option<String>, want: &str| match v.as_deref() {
+            Some(v) => v == want,
+            None => true,
+        };
+        let present = |v: &Option<String>| v.as_deref().is_some_and(|s| !s.is_empty());
+        ok(&self.key_algorithm, KEY_ALGORITHM)
+            && ok(&self.key_curve, KEY_CURVE)
+            && present(&self.credential_id)
+            && present(&self.rp_id)
+            && present(&self.key_value)
+    }
+
+    // A missing or non-numeric counter starts the credential at zero rather
+    // than failing the import.
+    fn counter(&self) -> u32 {
+        match &self.counter {
+            Some(serde_json::Value::String(s)) => s.parse().unwrap_or(0),
+            Some(serde_json::Value::Number(n)) => {
+                n.as_u64().and_then(|n| n.try_into().ok()).unwrap_or(0)
+            }
+            _ => 0,
+        }
+    }
+}
+
+impl From<Fido2Credential> for ImportedPasskey {
+    fn from(c: Fido2Credential) -> Self {
+        let counter = c.counter();
+        ImportedPasskey {
+            credential_id: c.credential_id.unwrap_or_default(),
+            rp_id: c.rp_id.unwrap_or_default(),
+            rp_name: opt(c.rp_name),
+            user_handle: c.user_handle.unwrap_or_default(),
+            user_name: c.user_name.unwrap_or_default(),
+            user_display_name: c.user_display_name.unwrap_or_default(),
+            private_key: c.key_value.unwrap_or_default(),
+            counter,
+            created_at: opt(c.creation_date),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -80,7 +163,18 @@ impl Importer for Bitwarden {
                         password: None,
                         totp: None,
                         uris: vec![],
+                        fido2_credentials: vec![],
                     });
+                    // An unusable credential is dropped on its own — the login
+                    // and its other passkeys still import.
+                    let mut passkeys = Vec::new();
+                    for cred in login.fido2_credentials {
+                        if cred.is_usable() {
+                            passkeys.push(cred.into());
+                        } else {
+                            result.push_err(row, "unsupported or incomplete passkey");
+                        }
+                    }
                     result.entries.push(ImportedEntry {
                         kind: EntryKind::Login,
                         title,
@@ -89,6 +183,7 @@ impl Importer for Bitwarden {
                         url: login.uris.into_iter().find_map(|u| opt(u.uri)),
                         notes: opt(item.notes),
                         otp: opt(login.totp),
+                        passkeys,
                         ..Default::default()
                     });
                 }

--- a/src-tauri/src/import/export.rs
+++ b/src-tauri/src/import/export.rs
@@ -5,7 +5,8 @@
 use serde::Serialize;
 use serde_json::json;
 
-use super::{EntryKind, ImportedEntry};
+use super::bitwarden::{KEY_ALGORITHM, KEY_CURVE, KEY_TYPE};
+use super::{EntryKind, ImportedEntry, ImportedPasskey};
 
 /// Bitwarden `type` codes.
 fn bw_type(kind: EntryKind) -> u8 {
@@ -34,6 +35,12 @@ pub fn to_bitwarden_json(entries: &[ImportedEntry]) -> serde_json::Result<Vec<u8
                         "totp": e.otp,
                         "uris": e.url.as_ref().map(|u| vec![json!({ "uri": u })]).unwrap_or_default(),
                     });
+                    // Only written when there is something to write, so an
+                    // export of a passkey-less vault is unchanged.
+                    if !e.passkeys.is_empty() {
+                        item["login"]["fido2Credentials"] =
+                            json!(e.passkeys.iter().map(fido2_credential).collect::<Vec<_>>());
+                    }
                 }
                 EntryKind::Card => {
                     item["card"] = json!({
@@ -60,6 +67,26 @@ pub fn to_bitwarden_json(entries: &[ImportedEntry]) -> serde_json::Result<Vec<u8
         encrypted: false,
         folders: vec![],
         items,
+    })
+}
+
+/// One Bitwarden `fido2Credentials` element. Every value is a string there,
+/// `counter` included; the key material is passed through verbatim.
+fn fido2_credential(p: &ImportedPasskey) -> serde_json::Value {
+    json!({
+        "credentialId": p.credential_id,
+        "keyType": KEY_TYPE,
+        "keyAlgorithm": KEY_ALGORITHM,
+        "keyCurve": KEY_CURVE,
+        "keyValue": p.private_key,
+        "rpId": p.rp_id,
+        "rpName": p.rp_name,
+        "userHandle": p.user_handle,
+        "userName": p.user_name,
+        "userDisplayName": p.user_display_name,
+        "counter": p.counter.to_string(),
+        "discoverable": "true",
+        "creationDate": p.created_at,
     })
 }
 

--- a/src-tauri/src/import/mod.rs
+++ b/src-tauri/src/import/mod.rs
@@ -53,6 +53,24 @@ pub struct ImportedEntry {
     pub card_year: Option<String>,
     pub card_cvc: Option<String>,
     pub cardholder: Option<String>,
+    // WebAuthn passkeys (only meaningful when kind == Login). Empty when the
+    // source format carries none, which is the case for every CSV dialect.
+    pub passkeys: Vec<ImportedPasskey>,
+}
+
+/// A normalized, plaintext passkey — mirrors `models::Passkey` field for field.
+/// Base64url values are carried through verbatim; this module never re-encodes.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ImportedPasskey {
+    pub credential_id: String,
+    pub rp_id: String,
+    pub rp_name: Option<String>,
+    pub user_handle: String,
+    pub user_name: String,
+    pub user_display_name: String,
+    pub private_key: String,
+    pub counter: u32,
+    pub created_at: Option<String>,
 }
 
 /// A per-row parse failure. `row` is 1-based in the source file so it points a

--- a/src-tauri/src/import/tests.rs
+++ b/src-tauri/src/import/tests.rs
@@ -1,5 +1,5 @@
 use super::export::{sanitize_cell, to_bitwarden_json, to_generic_csv};
-use super::{detect, EntryKind, Format, ImportedEntry, Importer};
+use super::{detect, EntryKind, Format, ImportedEntry, ImportedPasskey, Importer};
 
 fn parse(fmt: Format, bytes: &[u8]) -> super::ImportResult {
     fmt.importer().parse(bytes)
@@ -30,6 +30,91 @@ fn bitwarden_maps_login_note_card_and_flags_unsupported() {
     assert_eq!(card.kind, EntryKind::Card);
     assert_eq!(card.card_number.as_deref(), Some("4111"));
     assert_eq!(card.cardholder.as_deref(), Some("A B"));
+}
+
+#[test]
+fn bitwarden_maps_fido2_credentials_onto_passkeys() {
+    let json = br#"{"items":[
+      {"type":1,"name":"Acme","login":{"username":"alice","fido2Credentials":[
+        {"credentialId":"Y3JlZDE","keyType":"public-key","keyAlgorithm":"ECDSA","keyCurve":"P-256",
+         "keyValue":"cGsx","rpId":"acme.test","rpName":"Acme","userHandle":"dWgx","userName":"alice",
+         "userDisplayName":"Alice","counter":"7","discoverable":"true",
+         "creationDate":"2024-01-01T00:00:00.000Z"},
+        {"credentialId":"Y3JlZDI","keyValue":"cGsy","rpId":"other.test","userHandle":"dWgy",
+         "userName":"bob","userDisplayName":"Bob"}
+      ]}}
+    ]}"#;
+    let r = parse(Format::Bitwarden, json);
+    assert!(r.errors.is_empty());
+    let passkeys = &r.entries[0].passkeys;
+    assert_eq!(passkeys.len(), 2);
+    assert_eq!(
+        passkeys[0],
+        ImportedPasskey {
+            credential_id: "Y3JlZDE".into(),
+            rp_id: "acme.test".into(),
+            rp_name: Some("Acme".into()),
+            user_handle: "dWgx".into(),
+            user_name: "alice".into(),
+            user_display_name: "Alice".into(),
+            private_key: "cGsx".into(),
+            counter: 7,
+            created_at: Some("2024-01-01T00:00:00.000Z".into()),
+        }
+    );
+    // Optional fields absent: no rpName/creationDate, counter defaults to 0.
+    assert_eq!(passkeys[1].credential_id, "Y3JlZDI");
+    assert_eq!(passkeys[1].private_key, "cGsy");
+    assert_eq!(passkeys[1].rp_name, None);
+    assert_eq!(passkeys[1].created_at, None);
+    assert_eq!(passkeys[1].counter, 0);
+}
+
+// An unusable credential — wrong algorithm, or missing its id / rp / key — is
+// dropped on its own, one error each; the login and its good passkey import.
+#[test]
+fn bitwarden_drops_unsupported_or_incomplete_passkeys() {
+    let json = br#"{"items":[
+      {"type":1,"name":"Acme","login":{"username":"alice","fido2Credentials":[
+        {"credentialId":"a","keyAlgorithm":"RSA","keyValue":"k","rpId":"acme.test"},
+        {"credentialId":"b","keyAlgorithm":"ECDSA","keyCurve":"P-256","keyValue":"k","rpId":"acme.test"},
+        {"credentialId":"c","rpId":"acme.test"},
+        {"credentialId":"","keyValue":"k","rpId":"acme.test"},
+        {"credentialId":"d","keyValue":"k"}
+      ]}}
+    ]}"#;
+    let r = parse(Format::Bitwarden, json);
+    assert_eq!(r.entries.len(), 1);
+    assert_eq!(r.entries[0].username.as_deref(), Some("alice"));
+    assert_eq!(r.entries[0].passkeys.len(), 1);
+    assert_eq!(r.entries[0].passkeys[0].credential_id, "b");
+    assert_eq!(r.errors.len(), 4);
+    assert!(r
+        .errors
+        .iter()
+        .all(|e| e.row == 1 && e.message.contains("passkey")));
+}
+
+// Bitwarden writes `counter` as a string; a numeric one is taken as-is rather
+// than failing the whole file.
+#[test]
+fn bitwarden_accepts_a_numeric_passkey_counter() {
+    let json = br#"{"items":[
+      {"type":1,"name":"Acme","login":{"fido2Credentials":[
+        {"credentialId":"a","keyValue":"k","rpId":"acme.test","counter":3}
+      ]}}
+    ]}"#;
+    let r = parse(Format::Bitwarden, json);
+    assert!(r.errors.is_empty());
+    assert_eq!(r.entries[0].passkeys[0].counter, 3);
+}
+
+#[test]
+fn bitwarden_login_without_fido2_credentials_has_no_passkeys() {
+    let json = br#"{"items":[{"type":1,"name":"Acme","login":{"username":"alice"}}]}"#;
+    let r = parse(Format::Bitwarden, json);
+    assert!(r.errors.is_empty());
+    assert!(r.entries[0].passkeys.is_empty());
 }
 
 #[test]
@@ -186,6 +271,67 @@ fn round_trip_bitwarden_json() {
     assert_eq!(back.entries.len(), 2);
     assert_eq!(back.entries[0].username.as_deref(), Some("neo"));
     assert_eq!(back.entries[1].card_number.as_deref(), Some("4111"));
+}
+
+fn passkey() -> ImportedPasskey {
+    ImportedPasskey {
+        credential_id: "Y3JlZDE".into(),
+        rp_id: "acme.test".into(),
+        rp_name: Some("Acme".into()),
+        user_handle: "dWgx".into(),
+        user_name: "alice".into(),
+        user_display_name: "Alice".into(),
+        private_key: "cGsx".into(),
+        counter: 42,
+        created_at: Some("2024-01-01T00:00:00.000Z".into()),
+    }
+}
+
+fn login_with_passkeys() -> Vec<ImportedEntry> {
+    vec![ImportedEntry {
+        kind: EntryKind::Login,
+        title: "Acme".into(),
+        username: Some("alice".into()),
+        passkeys: vec![passkey()],
+        ..Default::default()
+    }]
+}
+
+#[test]
+fn bitwarden_export_writes_fido2_credentials_with_the_supported_constants() {
+    let bytes = to_bitwarden_json(&login_with_passkeys()).unwrap();
+    let out: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let cred = &out["items"][0]["login"]["fido2Credentials"][0];
+    assert_eq!(cred["keyType"], "public-key");
+    assert_eq!(cred["keyAlgorithm"], "ECDSA");
+    assert_eq!(cred["keyCurve"], "P-256");
+    assert_eq!(cred["keyValue"], "cGsx");
+    assert_eq!(cred["counter"], "42"); // a string, as Bitwarden writes it
+    assert_eq!(cred["discoverable"], "true");
+    assert_eq!(cred["creationDate"], "2024-01-01T00:00:00.000Z");
+}
+
+// No passkeys means no key at all, so a pre-passkey export is byte-identical.
+#[test]
+fn bitwarden_export_omits_fido2_credentials_without_passkeys() {
+    let entries = vec![ImportedEntry {
+        kind: EntryKind::Login,
+        title: "Acme".into(),
+        ..Default::default()
+    }];
+    let bytes = to_bitwarden_json(&entries).unwrap();
+    let out: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(out["items"][0]["login"].get("fido2Credentials").is_none());
+    assert!(!String::from_utf8(bytes).unwrap().contains("fido2"));
+}
+
+#[test]
+fn round_trip_bitwarden_passkeys() {
+    let entries = login_with_passkeys();
+    let bytes = to_bitwarden_json(&entries).unwrap();
+    let back = super::bitwarden::Bitwarden.parse(&bytes);
+    assert!(back.errors.is_empty());
+    assert_eq!(back.entries[0].passkeys, entries[0].passkeys);
 }
 
 #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -35,6 +35,11 @@ pub struct Entry {
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+    /// WebAuthn passkeys stored on a login entry. `None` when the entry has
+    /// none, so every pre-passkey vault JSON, `.swftx` backup and fixture
+    /// serializes byte-identically to before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passkeys: Option<Vec<Passkey>>,
     /// The user's star. Stored as a column rather than in the payload, so it
     /// rides along here only to survive a `.swftx` export/import round-trip —
     /// the editor never sends it, which is what keeps an ordinary save from
@@ -56,6 +61,30 @@ pub struct Entry {
 
 fn is_unset(flag: &bool) -> bool {
     !*flag
+}
+
+/// A single WebAuthn credential held by a login entry. Only P-256 ECDSA is
+/// supported, so there is no algorithm field. `credential_id`, `user_handle` and
+/// `private_key` are base64url and are stored exactly as the source gave them —
+/// never re-encoded, so a round-trip through import/export is byte-exact.
+/// `private_key` is a secret and only ever lives inside the sealed payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Passkey {
+    pub credential_id: String,
+    pub rp_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rp_name: Option<String>,
+    pub user_handle: String,
+    pub user_name: String,
+    pub user_display_name: String,
+    /// PKCS#8 DER, base64url.
+    pub private_key: String,
+    #[serde(default)]
+    pub counter: u32,
+    /// RFC3339.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,4 +187,42 @@ pub type Audit = HashMap<String, AuditItem>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncStatus {
     pub configured: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pre-passkey JSON stays readable, and an entry without passkeys serializes
+    // exactly as it did before the field existed.
+    #[test]
+    fn entry_without_passkeys_round_trips_without_the_key() {
+        let json = r#"{"id":"1","type":"login","title":"Site","password":"pw"}"#;
+        let entry: Entry = serde_json::from_str(json).unwrap();
+        assert!(entry.passkeys.is_none());
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(!out.contains("passkeys"), "{out}");
+    }
+
+    #[test]
+    fn passkey_serializes_camel_case_and_skips_absent_optionals() {
+        let entry: Entry = serde_json::from_str(
+            r#"{"id":"1","type":"login","title":"Site","passkeys":[
+                 {"credentialId":"Y3JlZDE","rpId":"acme.test","userHandle":"dWgx",
+                  "userName":"alice","userDisplayName":"Alice","privateKey":"cGsx"}]}"#,
+        )
+        .unwrap();
+        let passkeys = entry.passkeys.clone().unwrap();
+        assert_eq!(passkeys[0].credential_id, "Y3JlZDE");
+        assert_eq!(passkeys[0].private_key, "cGsx");
+        assert_eq!(passkeys[0].counter, 0);
+        assert_eq!(passkeys[0].rp_name, None);
+
+        let out = serde_json::to_value(&entry).unwrap();
+        let p = &out["passkeys"][0];
+        assert_eq!(p["userDisplayName"], "Alice");
+        assert_eq!(p["counter"], 0);
+        assert!(p.get("rpName").is_none());
+        assert!(p.get("createdAt").is_none());
+    }
 }

--- a/src/components/elements/fields/TagsField.tsx
+++ b/src/components/elements/fields/TagsField.tsx
@@ -11,7 +11,9 @@ export default function TagsField({ name = 'tags' }) {
   const { t } = useTranslation()
   const { entry, set } = useFields()
   const raw = entry[name]
-  const tags = Array.isArray(raw) ? raw : []
+  // A draft array is not necessarily strings (a login also carries passkeys),
+  // so narrow rather than assume the key holds tags.
+  const tags = Array.isArray(raw) ? raw.filter(v => typeof v === 'string') : []
 
   if (!set && tags.length === 0) return null
 

--- a/src/components/elements/fields/formats.ts
+++ b/src/components/elements/fields/formats.ts
@@ -23,7 +23,7 @@ export const emailError = (value: string): string =>
  * What every kind's `isValid` counts as a value: present, and not just spaces.
  * A type guard, so the same test narrows a draft key for the format checks.
  */
-export const filled = (value?: string | string[]): value is string =>
+export const filled = (value?: unknown): value is string =>
   typeof value === 'string' && value.trim() !== ''
 
 /**

--- a/src/defaults/entries.ts
+++ b/src/defaults/entries.ts
@@ -1,4 +1,4 @@
-import type { EntryType } from '@/lib/commands'
+import type { EntryType, Passkey } from '@/lib/commands'
 
 // Editable draft used by the entry form; ids/timestamps are added on save.
 // The empty draft each kind starts from lives with that kind (src/kinds).
@@ -10,5 +10,7 @@ export interface EntryDraft {
   createdAt?: string
   updatedAt?: string
   password_updated_at?: string
-  [field: string]: string | string[] | undefined
+  // Passkeys are in the union so a draft spread from a revealed login carries
+  // them through the editor untouched; no form field edits them.
+  [field: string]: string | string[] | Passkey[] | undefined
 }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -26,6 +26,22 @@ interface BaseEntry {
   updated_at?: string
 }
 
+// A WebAuthn credential held by a login entry. Only P-256 ECDSA is supported,
+// so there is no algorithm field. credentialId/userHandle/privateKey are
+// base64url and are carried verbatim — never re-encoded. privateKey is a secret
+// and only ever arrives inside a revealed entry.
+export interface Passkey {
+  credentialId: string
+  rpId: string
+  rpName?: string
+  userHandle: string
+  userName: string
+  userDisplayName: string
+  privateKey: string // PKCS#8 DER, base64url
+  counter: number
+  createdAt?: string // RFC3339
+}
+
 export interface LoginEntry extends BaseEntry {
   type: 'login'
   website: string
@@ -35,6 +51,8 @@ export interface LoginEntry extends BaseEntry {
   note: string
   otp: string // base32 TOTP secret
   password_updated_at?: string
+  // Absent on entries with no passkeys, so a pre-passkey vault is unchanged.
+  passkeys?: Passkey[]
 }
 
 export interface NoteEntry extends BaseEntry {

--- a/src/store/thunks.test.ts
+++ b/src/store/thunks.test.ts
@@ -10,7 +10,7 @@ import {
   lockVault
 } from './index'
 import { saveEntry as saveEntryCmd, toEntryMeta, syncNow } from '@/lib/commands'
-import type { EntryMeta } from '@/lib/commands'
+import type { EntryMeta, Passkey } from '@/lib/commands'
 
 const meta = (id: string, title = id): EntryMeta =>
   ({ id, type: 'login', title, tags: [], urlHost: '', favorite: false })
@@ -76,6 +76,29 @@ describe('saveEntry', () => {
 
     expect(store.getState().filters.type).toBe('login')
     expect(store.getState().entries.current?.title).toBe('New')
+  })
+
+  // A draft spread from a revealed login carries its passkeys, and they reach
+  // the backend untouched — while staying out of the list metadata.
+  it('carries a login draft passkeys through to the backend', async () => {
+    const store = makeStore()
+    const passkeys: Passkey[] = [
+      {
+        credentialId: 'Y3JlZDE',
+        rpId: 'acme.test',
+        userHandle: 'dWgx',
+        userName: 'alice',
+        userDisplayName: 'Alice',
+        privateKey: 'cGsx',
+        counter: 0
+      }
+    ]
+
+    await saveEntry({ type: 'login', title: 'Acme', username: 'u', password: 'p', passkeys })
+
+    const saved = vi.mocked(saveEntryCmd).mock.calls[0][0]
+    expect(saved.type === 'login' && saved.passkeys).toEqual(passkeys)
+    expect(store.getState().entries.items[0]).not.toHaveProperty('passkeys')
   })
 })
 


### PR DESCRIPTION
## Summary

First PR of the passkey series: a login entry can now hold WebAuthn passkeys, and the Bitwarden JSON importer/exporter carries them. No UI, metadata column or authenticator logic yet.

## Changes

- **Model.** `Passkey` struct (credential id, rpId, rpName, user handle / name / display name, PKCS#8 private key, counter, created at) and an optional `passkeys` list on `Entry`. Omitted when absent, so existing vault payloads, `.swftx` backups and fixtures serialize byte-identically. Passkeys live inside the sealed payload, so sync needs no changes.
- **Import layer.** `ImportedEntry.passkeys` mirrors the model. The Bitwarden importer reads `fido2Credentials` on login items; the exporter writes it only when a login has passkeys, with the `public-key` / `ECDSA` / `P-256` constants Bitwarden expects. A credential with an unsupported algorithm or missing its id, rpId or key is dropped with a row error rather than failing the file. `counter` accepts Bitwarden's string form or a number. CSV formats untouched.
- **Command layer.** `imported_to_entry` / `entry_to_imported` map passkeys both ways. No store, session or transaction code changed.
- **Frontend types.** `Passkey` interface and `passkeys?` on `LoginEntry`. The editor draft's index signature is widened so a draft spread from a revealed login carries passkeys through an edit-and-save untouched. Two type-only follow-ons: `filled()` accepts `unknown`, and the tags field filters its array to strings. Behavior unchanged.

## Tests

- Bitwarden import mapping (all fields, optional fields absent), dropped unsupported/incomplete passkeys, numeric counter, export constants, export → import round trip, no `fido2Credentials` key when a login has none.
- Serde back-compat: entries without passkeys round-trip without the key.
- AEAD and legacy cipher round trips preserve passkeys, including the `.swftx` obscure/expose path.
- Frontend: a saved draft keeps its passkeys; list metadata never receives them.

`cargo test` 203 passed, clippy/fmt clean, `bun run typecheck|build|lint` clean, vitest 332 passed.

## Known limits (by design)

- A passkey-only login imported from Bitwarden has no password, so the editor will not save it until PR 2 relaxes login validation. Import itself works.
- Nothing shows passkeys in the UI yet (PR 2).