### PR TITLE
fix(lock): master password caret follows the real selection so mid-passphrase edits land where shown

### DIFF
--- a/src/components/elements/Masterpass/Dots.tsx
+++ b/src/components/elements/Masterpass/Dots.tsx
@@ -1,4 +1,10 @@
+import type { Ref } from 'react'
 import { cx } from '@/utils/cx'
+
+// Cell pitch in px: a hair under the 15px type size so the row reads gently
+// tracked-out without going sparse. Exported so the input can map a click's x
+// back to a character index against the same grid it is drawn on.
+export const CELL = 15
 
 // Stagger offsets for the busy ripple, precomputed so renders allocate no
 // style objects. 40 covers any plausible passphrase; longer ones wrap.
@@ -9,6 +15,11 @@ const WAVE_DELAYS = Array.from({ length: 40 }, (_, i) => ({
 interface Props {
   count: number
   caret: boolean
+  // The input's live [selectionStart, selectionEnd]; the caret is drawn at the
+  // start boundary and the cells in between are washed as selected.
+  selection: [number, number]
+  // Attached to the cell row so the input can read its on-screen geometry.
+  rowRef?: Ref<HTMLDivElement>
   // The value to show in place of the dots (reveal mode). Same cell grid, so
   // each character appears exactly where its dot was — a true in-place reveal.
   text?: string
@@ -19,33 +30,49 @@ interface Props {
 
 // One fixed-width cell per typed character. Cells hold either a mask dot or,
 // when `text` is given, the character itself — identical geometry either way,
-// centered over the (text-transparent) input, with an optional blinking caret
-// trailing them. The pitch (15px) is a hair under the 15px type size so the
-// row reads gently tracked-out without going sparse.
-export default function Dots({ count, caret, text, busy }: Props) {
+// centered over the (text-transparent) input. The caret is drawn on the cell
+// boundary matching the input's real selection, so editing mid-passphrase
+// shows the bar exactly where backspace will act.
+export default function Dots({
+  count,
+  caret,
+  selection: [start, end],
+  rowRef,
+  text,
+  busy
+}: Props) {
   return (
     <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-      {Array.from({ length: count }).map((_, i) => (
-        <span
-          key={i}
-          className="animate-fade flex w-[15px] flex-none items-center justify-center"
-        >
+      <div ref={rowRef} className="relative flex">
+        {Array.from({ length: count }).map((_, i) => (
           <span
+            key={i}
             className={cx(
-              busy && 'animate-[dotwave_1.05s_ease-in-out_infinite]',
-              text === undefined
-                ? 'h-[7px] w-[7px] rounded-full bg-text/75'
-                : 'text-[15px] text-text'
+              'animate-fade flex flex-none items-center justify-center rounded-[3px]',
+              i >= start && i < end && 'bg-accent-soft'
             )}
-            style={busy ? WAVE_DELAYS[i % WAVE_DELAYS.length] : undefined}
+            style={{ width: CELL }}
           >
-            {text?.[i]}
+            <span
+              className={cx(
+                busy && 'animate-[dotwave_1.05s_ease-in-out_infinite]',
+                text === undefined
+                  ? 'h-[7px] w-[7px] rounded-full bg-text/75'
+                  : 'text-[15px] text-text'
+              )}
+              style={busy ? WAVE_DELAYS[i % WAVE_DELAYS.length] : undefined}
+            >
+              {text?.[i]}
+            </span>
           </span>
-        </span>
-      ))}
-      {caret && (
-        <span className="ml-1 h-6 w-px bg-accent animate-[caret_1.1s_steps(1,end)_infinite]" />
-      )}
+        ))}
+        {caret && (
+          <span
+            className="absolute top-1/2 h-6 w-px -translate-x-1/2 -translate-y-1/2 bg-accent animate-[caret_1.1s_steps(1,end)_infinite]"
+            style={{ left: start * CELL }}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -3,7 +3,8 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type KeyboardEvent
+  type KeyboardEvent,
+  type MouseEvent
 } from 'react'
 import { cx } from '@/utils/cx'
 import { useTranslation } from 'react-i18next'
@@ -11,7 +12,7 @@ import type { TKey } from '@/i18n'
 import Error from '../Error'
 import IconButton from '../IconButton'
 import { EyeGlyph, EyeOffGlyph, FingerprintGlyph } from '@/components/Main/icons'
-import Dots from './Dots'
+import Dots, { CELL } from './Dots'
 import KeyCuts from './KeyCuts'
 
 interface Props {
@@ -37,10 +38,13 @@ interface Props {
   onTouchID?: () => void
 }
 
-// Shared master-passphrase field. The real value lives in the (uncontrolled)
-// input; a mirrored copy drives the dot overlay. Masking is done with a
+// Shared master-passphrase field. The real value and selection live in the
+// input; mirrored copies drive the dot overlay. Masking is done with a
 // text-transparent input + custom dots so the caret and letter spacing match
-// the design in both themes.
+// the design in both themes. Because the input's own glyph geometry never
+// matches the fixed cell grid, clicks are mapped to a character index against
+// the drawn cells rather than left to the browser, and the overlay caret tracks
+// the input's real selection so it always shows where the next edit lands.
 //
 // The lock variant is deliberately unlike every other field in the app: a
 // white card set gently into the window ground (see --lockfield-shadow) with
@@ -67,7 +71,9 @@ export default function Masterpass({
   const [value, setValue] = useState('')
   const [reveal, setReveal] = useState(false)
   const [focused, setFocused] = useState(false)
+  const [selection, setSelection] = useState<[number, number]>([0, 0])
   const inputRef = useRef<HTMLInputElement>(null)
+  const rowRef = useRef<HTMLDivElement>(null)
 
   const lock = variant === 'lock'
   const bad = !!error || !!invalid
@@ -87,13 +93,39 @@ export default function Masterpass({
     onEnter?.(val)
   }
 
+  // Mirror the input's selection into state so the overlay caret follows it.
+  // Called from every event that can move it (typing, arrows, select-all,
+  // focus, and our own click mapping).
+  const syncSelection = () => {
+    const el = inputRef.current
+    if (!el) return
+    const end = el.value.length
+    setSelection([el.selectionStart ?? end, el.selectionEnd ?? end])
+  }
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.currentTarget.value)
+    syncSelection()
     onChange?.(event)
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') doSubmit(event.currentTarget.value)
+  }
+
+  // Place the caret on the cell boundary nearest the click. The browser would
+  // otherwise position it by the input's own (transparent, differently spaced)
+  // glyphs, landing it on a different character than the one under the pointer.
+  const handleMouseDown = (event: MouseEvent<HTMLInputElement>) => {
+    const row = rowRef.current
+    if (event.button !== 0 || !row) return
+    event.preventDefault()
+    const input = event.currentTarget
+    const x = event.clientX - row.getBoundingClientRect().left
+    const at = Math.max(0, Math.min(input.value.length, Math.round(x / CELL)))
+    input.focus()
+    input.setSelectionRange(at, at)
+    syncSelection()
   }
 
   const input = (
@@ -103,8 +135,9 @@ export default function Masterpass({
       className={cx(
         // The input's own text never shows: masked dots and the revealed value
         // are both drawn by the cell overlay (see Dots) so they share one
-        // geometry. Only the placeholder renders from here (15px, muted ink).
-        'absolute inset-0 w-full border-0 bg-transparent text-center font-sans text-[15px] tracking-secret text-transparent caret-transparent outline-none placeholder:text-text3',
+        // geometry, including the selection wash. Only the placeholder renders
+        // from here (15px, muted ink).
+        'absolute inset-0 w-full border-0 bg-transparent text-center font-sans text-[15px] tracking-secret text-transparent caret-transparent outline-none selection:bg-transparent placeholder:text-text3',
         lock && 'rounded-xl px-10'
       )}
       placeholder={placeholder || t('Master Password')}
@@ -114,7 +147,13 @@ export default function Masterpass({
       value={value}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
-      onFocus={() => setFocused(true)}
+      onKeyUp={syncSelection}
+      onSelect={syncSelection}
+      onMouseDown={handleMouseDown}
+      onFocus={() => {
+        setFocused(true)
+        syncSelection()
+      }}
       onBlur={() => setFocused(false)}
     />
   )
@@ -123,6 +162,8 @@ export default function Masterpass({
     <Dots
       count={value.length}
       caret={focused && !inert}
+      selection={selection}
+      rowRef={rowRef}
       text={reveal ? value : undefined}
       busy={pending}
     />

--- a/src/test/auth.test.tsx
+++ b/src/test/auth.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Auth from '@/components/Auth'
 import { unlock, unlockBiometric } from '@/lib/commands'
@@ -34,6 +34,24 @@ describe('Auth', () => {
     await userEvent.type(screen.getByPlaceholderText('Master Password'), 'a')
 
     expect(screen.getByLabelText('Reveal passphrase')).toBeInTheDocument()
+  })
+
+  it('puts the caret where you click so backspace edits mid-passphrase', async () => {
+    renderWithStore(<Auth touchID={false} />)
+    const input = screen.getByPlaceholderText<HTMLInputElement>('Master Password')
+
+    await userEvent.type(input, 'abcd')
+    expect(input.selectionStart).toBe(4)
+
+    // jsdom lays the cell row out at x=0, so 30px (two 15px cells) is the
+    // boundary between 'b' and 'c'.
+    fireEvent.mouseDown(input, { clientX: 30, button: 0 })
+    expect(input.selectionStart).toBe(2)
+    expect(input.selectionEnd).toBe(2)
+
+    await userEvent.keyboard('{Backspace}')
+    expect(input.value).toBe('acd')
+    expect(input.selectionStart).toBe(1)
   })
 
   it('acknowledges Enter immediately with a verifying state', async () => {


### PR DESCRIPTION
## Summary

The master password field's visible caret was decorative: the Dots overlay always drew it after the last dot, while the real caret in the text-transparent input moved wherever a click landed. Backspace acted on the real one, so fixing a typo mid-passphrase deleted the wrong character, and a caret parked at position 0 made the last characters undeletable. Clicks were also positioned by the browser against the input's own glyph spacing, which never matched the 15px cell grid, so even a precise click landed on a different index.

## Changes

- **Dots draws the caret at the input's real selection** and washes selected cells with the accent tint, so shift+arrow and select-all are visible.
- **Masterpass maps mousedown x to a cell index** against the drawn cell row, focuses the input, and sets the selection there instead of letting the browser place it.
- **Selection is mirrored into state** on change, keyup, select, and focus, so arrows, Home, End, and Cmd+A move the visible caret.
- **Native selection highlight is hidden** on the input so the misaligned block no longer paints.
- **Regression test** in the auth suite: type four characters, click the boundary after the second, backspace removes the second character.

## Verification

- `vitest run`: 347 passed
- `tsc --noEmit`: clean
- `eslint` on changed files: clean

## Not covered

- Drag-to-select and shift+click range selection with the mouse (keyboard range selection works).
- Double-click word/all selection (Cmd+A works).
- Visual check on real WebKit; the alignment is verified by test geometry only.