### PR TITLE
feat(scan): drop or pick a card or ID photo to prefill an entry

### DIFF
--- a/src/components/Main/AddSecret/ScanAction.tsx
+++ b/src/components/Main/AddSecret/ScanAction.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next'
+import { useStore, closeAddPicker } from '@/store'
+import { IMAGE_EXTENSIONS } from '../Scan/fields'
+import { runScan } from '../Scan/run'
+import { ScanGlyph } from '../icons'
+
+/**
+ * "Scan a card or document…": the picked-file twin of dropping a photo on the
+ * window, for the file that is already on disk rather than in hand.
+ *
+ * Deliberately outside the tile grid — the digits and arrows are bound to the
+ * tiles, and this is not an nth kind. It owns its own divider so that nothing
+ * is left framing an empty space where the OS cannot scan at all.
+ */
+export default function ScanAction() {
+  const { t } = useTranslation()
+  const supported = useStore(state => state.ui.scan.supported)
+
+  if (!supported) return null
+
+  const pick = async () => {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const path = await open({
+      multiple: false,
+      directory: false,
+      // The native dialog's own chrome, so the filter is named in the user's
+      // language like everything else in it.
+      filters: [{ name: t('Images'), extensions: IMAGE_EXTENSIONS }]
+    })
+    // A cancelled dialog leaves the picker as it was; a chosen file hands the
+    // window over to the editor the scan is about to fill.
+    if (typeof path !== 'string') return
+    closeAddPicker()
+    void runScan(path)
+  }
+
+  return (
+    <div className="mt-5 border-t border-line pt-4">
+      <button
+        type="button"
+        data-testid="add-scan-image"
+        onClick={() => void pick()}
+        className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 text-base text-text2 transition-colors hover:bg-hover hover:text-text"
+      >
+        <ScanGlyph size={16} className="flex-none text-text3" />
+        <span>{t('Scan a card or document…')}</span>
+      </button>
+      <p className="mt-1 pl-[30px] text-base text-text3">
+        {t('A photo or screenshot, read on this device.')}
+      </p>
+    </div>
+  )
+}

--- a/src/components/Main/AddSecret/index.tsx
+++ b/src/components/Main/AddSecret/index.tsx
@@ -5,6 +5,7 @@ import { useStore, closeAddPicker, startEntry } from '@/store'
 import { KINDS } from '@/kinds'
 import Modal from '@/components/elements/Modal'
 import KindTile from './KindTile'
+import ScanAction from './ScanAction'
 
 const TITLE_ID = 'add-secret-title'
 
@@ -82,6 +83,8 @@ export default function AddSecret() {
             <KindTile key={kind.type} kind={kind} onSelect={() => pick(kind.type)} />
           ))}
         </div>
+
+        <ScanAction />
       </div>
     </Modal>
   )

--- a/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
+++ b/src/components/Main/Body/Aside/Show/Edit/useDraft.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
-import { setCurrentEntry, setNoEntry, saveEntry } from '@/store'
+import { useStore, setCurrentEntry, setNoEntry, saveEntry, clearPrefill } from '@/store'
 import { kindOf } from '@/kinds'
 import { pruneExtra } from '@/components/elements/fields'
+import { mergeFields } from '@/components/Main/Scan/fields'
 import { dialogOpen } from '@/utils/dialogOpen'
 import type { DraftValue, EntryDraft } from '@/defaults/entries'
 import type { Entry, EntryType } from '@/lib/commands'
@@ -35,7 +36,12 @@ export function useDraft(type: EntryType, revealed: Entry | null): Draft {
   // means a later reveal (a sync merge moving `updatedAt`) cannot replace the
   // draft. The baseline is the state at open; a concurrent change resolves
   // through last-writer-wins on save.
-  const initial = (): EntryDraft => ({ ...(revealed ?? kind.defaults) })
+  // Fields a scan read out of an image, waiting for a form to land in. A new
+  // entry's are in the store before this mounts, so they are part of the
+  // initial draft — the editor opens already filled in, and nothing about it
+  // reads as unsaved typing.
+  const [seed] = useState(() => useStore.getState().entries.prefill)
+  const initial = (): EntryDraft => mergeFields({ ...(revealed ?? kind.defaults) }, seed ?? {})
 
   const [attempted, setAttempted] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -50,6 +56,16 @@ export function useDraft(type: EntryType, revealed: Entry | null): Draft {
     setConfirmDiscard(false)
     setModel(current => ({ ...current, [name]: value }))
   }
+
+  // A scan of what is already being edited arrives after the mount: it fills
+  // this draft's blanks in place rather than opening a second one. Consumed
+  // either way, so the prefill can never seed a later entry.
+  const prefill = useStore(state => state.entries.prefill)
+  useEffect(() => {
+    if (!prefill) return
+    if (prefill !== seed) setModel(current => mergeFields(current, prefill))
+    clearPrefill()
+  }, [prefill, seed])
 
   const close = () => {
     if (model.id) setCurrentEntry(model.id)

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -39,8 +39,13 @@ export default function Show({ entry, type, editing }: Props) {
     // too.)
     if (entry && !current && served.current !== entry.id)
       return <div className="mx-auto min-h-[320px] w-full max-w-[860px]" />
-    // Keyed per entry: each editing session starts from a fresh draft.
-    return <Edit key={entry?.id ?? 'new'} type={kindType} revealed={current} />
+    // Keyed per entry: each editing session starts from a fresh draft. A new
+    // entry has no id to key on, so it is keyed by its kind — choosing another
+    // kind (the picker again, or a scan that recognized a different one) is a
+    // different draft, not the same one with other rows on it.
+    return (
+      <Edit key={entry?.id ?? `new-${kindType}`} type={kindType} revealed={current} />
+    )
   }
   if (!entry) return null
   return <Read entry={entry} revealed={current} />

--- a/src/components/Main/Scan/Overlay.tsx
+++ b/src/components/Main/Scan/Overlay.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next'
+import { ScanGlyph } from '../icons'
+
+// Shown while an image is dragged over the window: the whole surface becomes
+// the target, so the answer to "where do I drop this?" is "anywhere". Above the
+// toasts and inert — the drag is the OS's, not the DOM's, so nothing here has
+// to be hit-testable.
+export default function Overlay() {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      data-testid="scan-overlay"
+      aria-hidden
+      className="animate-fade pointer-events-none fixed inset-0 z-[1100] grid place-items-center bg-[var(--scrim)] backdrop-blur-sm"
+    >
+      <div className="m-6 flex flex-col items-center gap-3 rounded-xl border border-dashed border-accent-line px-10 py-9 text-center">
+        <span className="grid h-12 w-12 place-items-center rounded-lg bg-accent-soft text-accent">
+          <ScanGlyph size={22} />
+        </span>
+        <strong className="text-lg font-semibold tracking-display">
+          {t('Drop to scan the card or document')}
+        </strong>
+        <span className="max-w-[320px] text-base text-text2">
+          {t('Read on this device. The image is never copied or uploaded.')}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Main/Scan/Status.tsx
+++ b/src/components/Main/Scan/Status.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TKey } from '@/i18n'
+import { useStore, dismissScan } from '@/store'
+import type { ScanError } from '@/store/uiSlice'
+import { TOAST } from '@/components/elements/tokens'
+import { ScanGlyph } from '../icons'
+
+const COPY: Record<ScanError, TKey> = {
+  unreadable: 'Nothing recognized in that image.',
+  unsupported: 'Scanning is not available on this device.',
+  failed: 'That image could not be read.'
+}
+
+// Only "nothing recognized" is worth advising about: it is the one failure the
+// user can answer by taking a better photo.
+const HINT: TKey =
+  'Good, even light helps — with the whole card, or the two or three machine-readable lines, inside the frame.'
+
+// How long a complaint stays up. Long enough to read twice, short enough that
+// it is gone by the time the next photo is dropped.
+const DISMISS_MS = 8000
+
+// Bottom-left, opposite the update toast: recognition runs while the user keeps
+// working, so neither state may block anything or move the pane underneath.
+export default function Status() {
+  const { t } = useTranslation()
+  const { busy, error } = useStore(state => state.ui.scan)
+
+  useEffect(() => {
+    if (!error) return
+    const timer = setTimeout(dismissScan, DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [error])
+
+  if (busy)
+    return (
+      <div
+        data-testid="scan-status"
+        role="status"
+        className={`${TOAST} bottom-5 left-5 flex items-center gap-3 px-4 py-3`}
+      >
+        {/* The comet ring the sync chip spins, at toast scale. */}
+        <span
+          aria-hidden
+          className="h-3.5 w-3.5 flex-none animate-spin rounded-full border-2 border-accent/25 border-l-accent"
+        />
+        <span className="text-base text-text2">{t('Reading the image…')}</span>
+      </div>
+    )
+
+  if (!error) return null
+
+  return (
+    <div
+      data-testid="scan-error"
+      role="alert"
+      className={`${TOAST} bottom-5 left-5 flex gap-3 px-4 py-3`}
+    >
+      <ScanGlyph size={16} className="mt-0.5 flex-none text-text3" />
+      <div className="flex flex-col gap-1">
+        <span className="text-base text-text2">{t(COPY[error])}</span>
+        {error === 'unreadable' && <span className="text-base text-text3">{t(HINT)}</span>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Main/Scan/fields.ts
+++ b/src/components/Main/Scan/fields.ts
@@ -1,0 +1,67 @@
+import type { EntryDraft } from '@/defaults/entries'
+
+/**
+ * Turning what a scan read into what a draft holds.
+ *
+ * The backend already speaks the draft's language — its field keys are the
+ * kind's keys, its dates are ISO, its expiry month and year are two digits, and
+ * the names it reads off a card or an MRZ are uppercase because that is how
+ * they are printed. So there is no reformatting here: only which values are
+ * worth carrying, and which of the draft's own values may be overwritten.
+ */
+
+// What the OS recognizers can open, and what the file dialog filters to.
+// Anything else dropped on the window is somebody else's business — the Import
+// drop zone still wants its .csv.
+export const IMAGE_EXTENSIONS = [
+  'png',
+  'jpg',
+  'jpeg',
+  'heic',
+  'heif',
+  'webp',
+  'tiff',
+  'tif',
+  'bmp',
+  'gif'
+]
+
+export const isImagePath = (path: string): boolean => {
+  const extension = /\.([^.\\/]+)$/.exec(path)?.[1]
+  return !!extension && IMAGE_EXTENSIONS.includes(extension.toLowerCase())
+}
+
+/** The first image among dropped paths — a drop can carry more than one file. */
+export const firstImage = (paths: string[]): string | undefined =>
+  paths.find(isImagePath)
+
+// A field the user has not answered yet. A missing key counts (a card draft has
+// no `doc_type`), and so does whitespace — it is nothing typed, not an answer.
+const blank = (value: unknown): boolean =>
+  value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
+
+/**
+ * Drop the fields the recognizer could not fill. An MRZ hands back its whole
+ * field set, empty entries and all (an optional personal number is often
+ * filler), and an empty string is not something to overwrite a draft with.
+ */
+export const cleanFields = (fields: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(Object.entries(fields).filter(([, value]) => !blank(value)))
+
+/**
+ * Fold scanned fields into a draft.
+ *
+ * What the user has already typed wins: a scan fills the blanks, it does not
+ * correct anybody. `doc_type` is the exception — it is not typed but chosen
+ * from a default (`passport`), and it decides which rows the form even shows,
+ * so a document that says what it is always gets to say so.
+ */
+export const mergeFields = (
+  draft: EntryDraft,
+  fields: Record<string, string>
+): EntryDraft => {
+  const next = { ...draft }
+  for (const [key, value] of Object.entries(fields))
+    if (key === 'doc_type' || blank(next[key])) next[key] = value
+  return next
+}

--- a/src/components/Main/Scan/index.tsx
+++ b/src/components/Main/Scan/index.tsx
@@ -1,0 +1,28 @@
+import { useStore } from '@/store'
+import Overlay from './Overlay'
+import Status from './Status'
+import { useDropScan } from './useDropScan'
+
+/**
+ * A photo of a card or an ID document, turned into a filled-in editor.
+ *
+ * Mounted once by `Main`, so the drop target is the unlocked app as a whole
+ * rather than one pane. The same routing off a picked file lives in the "Add a
+ * secret" picker (`AddSecret/ScanAction`), and both meet in `run.ts`.
+ *
+ * Where the OS has no text recognizer there is nothing to offer, so this
+ * renders — and listens — for nothing at all.
+ */
+export default function Scan() {
+  const supported = useStore(state => state.ui.scan.supported)
+  const over = useDropScan(supported)
+
+  if (!supported) return null
+
+  return (
+    <>
+      {over && <Overlay />}
+      <Status />
+    </>
+  )
+}

--- a/src/components/Main/Scan/run.ts
+++ b/src/components/Main/Scan/run.ts
@@ -1,0 +1,52 @@
+import { scanImage, type EntryType } from '@/lib/commands'
+import type { ScanError } from '@/store/uiSlice'
+import {
+  useStore,
+  startEntry,
+  setPrefill,
+  scanStarted,
+  scanFinished
+} from '@/store'
+import { cleanFields } from './fields'
+
+// Which kind the detail pane is editing right now, if any — a new entry's
+// chosen kind, or the kind of the entry being edited.
+const editingKind = (): EntryType | null => {
+  const { new: creating, edit, current } = useStore.getState().entries
+  if (creating) return creating
+  return edit ? (current?.type ?? null) : null
+}
+
+// The backend's failures, classified for the copy. An invoke rejects with the
+// serialized error — a string here — but a thrown Error is handled too so a
+// broken IPC still lands as a message rather than as an unhandled rejection.
+const reason = (error: unknown): ScanError => {
+  const message = typeof error === 'string' ? error : String((error as Error)?.message ?? error)
+  if (message.includes('nothing recognized')) return 'unreadable'
+  if (message.includes('not available on this platform')) return 'unsupported'
+  return 'failed'
+}
+
+/**
+ * Read one image and land its fields in an editor.
+ *
+ * The same path for a drop and for a file picked from the dialog. A scan of the
+ * kind already open fills that form in place — a second photo of the same
+ * passport should not open a second draft — and anything else starts a new
+ * entry of the kind that was recognized. Both go through `entries.prefill`,
+ * which `useDraft` is the only reader of.
+ *
+ * Never throws: the outcome is the status in the store.
+ */
+export const runScan = async (path: string): Promise<void> => {
+  scanStarted()
+  try {
+    const result = await scanImage(path)
+    const fields = cleanFields(result.fields)
+    if (editingKind() === result.kind) setPrefill(fields)
+    else startEntry(result.kind, fields)
+    scanFinished()
+  } catch (error) {
+    scanFinished(reason(error))
+  }
+}

--- a/src/components/Main/Scan/useDropScan.ts
+++ b/src/components/Main/Scan/useDropScan.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+import { dialogOpen } from '@/utils/dialogOpen'
+import { firstImage } from './fields'
+import { runScan } from './run'
+
+/**
+ * The whole unlocked window as a drop target for card and document photos.
+ *
+ * Files arrive as OS paths through the webview rather than as a browser
+ * DataTransfer, so this is the same listener the Import drop zone uses (see
+ * `Settings/Sections/Import/DropZone`) — one per surface, each minding its own
+ * file types. Only images are ours; an export file dropped anywhere still
+ * belongs to Import.
+ *
+ * Returns whether an image is currently being dragged over the window, which is
+ * what the overlay renders on.
+ */
+export function useDropScan(enabled: boolean): boolean {
+  const [over, setOver] = useState(false)
+
+  useEffect(() => {
+    if (!enabled) return
+    let alive = true
+    let unlisten: (() => void) | undefined
+
+    // Imported lazily so a non-Tauri host (the vitest jsdom run) simply never
+    // wires the listener up.
+    import('@tauri-apps/api/webview')
+      .then(({ getCurrentWebview }) =>
+        getCurrentWebview().onDragDropEvent(({ payload }) => {
+          // A modal owns the window while it is up, and the one with a drop
+          // zone in it (Settings › Import) means something else by a drop.
+          if (dialogOpen()) return
+
+          if (payload.type === 'enter') {
+            setOver(!!firstImage(payload.paths))
+            return
+          }
+          if (payload.type === 'leave') {
+            setOver(false)
+            return
+          }
+          if (payload.type === 'drop') {
+            setOver(false)
+            const image = firstImage(payload.paths)
+            if (image) void runScan(image)
+          }
+          // `over` fires without paths, so what `enter` decided still stands.
+        })
+      )
+      .then(stop => {
+        if (alive) unlisten = stop
+        else stop()
+      })
+      .catch(() => {})
+
+    return () => {
+      alive = false
+      unlisten?.()
+    }
+  }, [enabled])
+
+  return over
+}

--- a/src/components/Main/icons.tsx
+++ b/src/components/Main/icons.tsx
@@ -35,6 +35,7 @@ import {
   Pencil,
   Plus,
   RefreshCw,
+  ScanLine,
   Search,
   Settings,
   ShieldCheck,
@@ -104,6 +105,7 @@ export const LoginGlyph = glyph(Globe, 16)
 export const NoteGlyph = glyph(FileText, 16)
 export const CardGlyph = glyph(CreditCard, 16)
 export const IdentityGlyph = glyph(IdCard, 16)
+export const ScanGlyph = glyph(ScanLine, 16)
 export const ShieldGlyph = glyph(ShieldCheck, 16)
 export const GlobeGlyph = glyph(Globe, 16)
 export const ActivityGlyph = glyph(Activity, 16)

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -5,6 +5,7 @@ import Body from './Body'
 import Generator from './Generator'
 import Palette from './Palette'
 import AddSecret from './AddSecret'
+import Scan from './Scan'
 import { useShortcuts } from './useShortcuts'
 
 // Three-pane shell: a full-width top chrome bar over a row of
@@ -26,6 +27,7 @@ export function Main() {
       <Generator />
       <Palette />
       <AddSecret />
+      <Scan />
       {/* `copied-notification` + `hidden` are toggled by services/copy.ts; the
           display flip is what replays `animate-pop`. App-level so copies from
           the palette and standalone generator get feedback too. Centering uses

--- a/src/components/elements/UpdateToast.tsx
+++ b/src/components/elements/UpdateToast.tsx
@@ -4,6 +4,7 @@ import type { TKey } from '@/i18n'
 import { useStore } from '@/store'
 import { restartForUpdate } from '@/services/autoUpdate'
 import Button from './Button'
+import { TOAST } from './tokens'
 import { DownloadGlyph } from '../Main/icons'
 
 // Bottom-right toast. Prefers the sticky "update ready → restart" prompt when one
@@ -17,8 +18,7 @@ export default function UpdateToast() {
   return null
 }
 
-const shell =
-  'animate-pop fixed bottom-5 right-5 z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-[var(--shadow)]'
+const shell = `${TOAST} bottom-5 right-5`
 
 function ReadyToast({ version, notes }: { version: string; notes: string | null }) {
   const { t } = useTranslation()

--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -2,6 +2,12 @@ export const CARD = 'overflow-hidden rounded-lg border border-line bg-[image:var
 
 export const ROW_HAIRLINE = 'shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none'
 
+// App-level transient feedback (the update prompt, the scan status): a floating
+// panel on the detail surface. Each toast places itself — two of them in the
+// same corner would sit on top of each other.
+export const TOAST =
+  'animate-pop fixed z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-[var(--shadow)]'
+
 // The mono micro-label face, without an ink. Take this when the label needs a
 // different colour (the accent "EDITING ·" eyebrow) and MONO_LABEL otherwise.
 export const MONO_TYPE = 'font-mono text-xs uppercase tracking-label'

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -345,5 +345,15 @@
   "Untitled {kind}": "Untitled {kind}",
   "changed on {d}": "changed on {d}",
   "changed {t} ago": "changed {t} ago",
-  "refreshes in {n}s": "refreshes in {n}s"
+  "refreshes in {n}s": "refreshes in {n}s",
+  "Drop to scan the card or document": "Drop to scan the card or document",
+  "Read on this device. The image is never copied or uploaded.": "Read on this device. The image is never copied or uploaded.",
+  "Reading the image…": "Reading the image…",
+  "Nothing recognized in that image.": "Nothing recognized in that image.",
+  "Scanning is not available on this device.": "Scanning is not available on this device.",
+  "That image could not be read.": "That image could not be read.",
+  "Good, even light helps — with the whole card, or the two or three machine-readable lines, inside the frame.": "Good, even light helps — with the whole card, or the two or three machine-readable lines, inside the frame.",
+  "Scan a card or document…": "Scan a card or document…",
+  "A photo or screenshot, read on this device.": "A photo or screenshot, read on this device.",
+  "Images": "Images"
 }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -342,6 +342,31 @@ export const exportEntries = (
   invoke('export_entries', { path: path ?? null, format })
 
 // ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+// What the OS text recognizer read out of one image: the kind of secret it is,
+// and its fields keyed exactly like that kind's draft.
+export interface ScanResult {
+  kind: 'card' | 'identity'
+  fields: Record<string, string>
+}
+
+/**
+ * Recognize a card or an identity document in the image at `path`.
+ *
+ * The path is the one the user already has (a drop, or the file dialog) — the
+ * image is read where it lies and never copied. Rejects with "nothing
+ * recognized" when the text is there but says neither.
+ */
+export const scanImage = (path: string): Promise<ScanResult> =>
+  invoke('scan_image', { path })
+
+// Whether this platform has a text recognizer at all. False on Linux and on a
+// Windows without an OCR language pack, where the UI offers no scanning.
+export const scanSupported = (): Promise<boolean> => invoke('scan_supported')
+
+// ---------------------------------------------------------------------------
 // Generator & OTP
 // ---------------------------------------------------------------------------
 

--- a/src/store/entriesSlice.ts
+++ b/src/store/entriesSlice.ts
@@ -12,11 +12,17 @@ interface Entries {
   // Tombstones, as the Trash view lists them. Not part of the unlock payload,
   // so this stays empty until the Trash is opened.
   trash: EntryMeta[]
+  // Field values waiting for an editor to take them (what a scan read out of an
+  // image). Consumed once — `useDraft` folds them into the draft and clears
+  // them, so nothing is left to seed the next entry with.
+  prefill: Record<string, string> | null
 }
 
 export interface EntriesSlice {
   entries: Entries
-  newEntry: (type: EntryType) => void
+  newEntry: (type: EntryType, prefill?: Record<string, string>) => void
+  setPrefill: (prefill: Record<string, string>) => void
+  clearPrefill: () => void
   setNoEntry: () => void
   editEntry: () => void
   setEntries: (items: EntryMeta[]) => void
@@ -30,10 +36,17 @@ const find = (entries: Entries, id?: string) =>
   [...entries.items, ...entries.trash].find(item => item.id === id) ?? null
 
 export const createEntriesSlice: StateCreator<StoreState, [], [], EntriesSlice> = (set, get) => ({
-  entries: { new: null, edit: false, current: null, items: [], trash: [] },
-  newEntry: type =>
-    set(s => ({ entries: { ...s.entries, new: type, edit: false, current: null } })),
-  setNoEntry: () => set(s => ({ entries: { ...s.entries, new: null, edit: false, current: null } })),
+  entries: { new: null, edit: false, current: null, items: [], trash: [], prefill: null },
+  newEntry: (type, prefill) =>
+    set(s => ({
+      entries: { ...s.entries, new: type, edit: false, current: null, prefill: prefill ?? null }
+    })),
+  setPrefill: prefill => set(s => ({ entries: { ...s.entries, prefill } })),
+  clearPrefill: () => set(s => ({ entries: { ...s.entries, prefill: null } })),
+  setNoEntry: () =>
+    set(s => ({
+      entries: { ...s.entries, new: null, edit: false, current: null, prefill: null }
+    })),
   // A tombstone has no editable form: `reveal_entry` refuses deleted rows, so an
   // edit would open a pane that can never load its own values and whose save
   // would resurrect the entry behind the user's back. Refusing here rather than

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -84,6 +84,8 @@ export const {
   setFilterQuery,
   setFilterType,
   newEntry,
+  setPrefill,
+  clearPrefill,
   setNoEntry,
   editEntry,
   setEntries,
@@ -109,6 +111,10 @@ export const {
   openAddPicker,
   closeAddPicker,
   setView,
+  setScanSupported,
+  scanStarted,
+  scanFinished,
+  dismissScan,
   runUpdateCheck,
   saveEntry,
   deleteEntry,
@@ -121,14 +127,15 @@ export const {
   restoreBackup
 } = useStore.getState()
 
-// Starts a new entry of `type` from anywhere (kind picker, palette command),
-// leaving the audit view first — it has no editor to land the form in.
+// Starts a new entry of `type` from anywhere (kind picker, palette command,
+// a scan), leaving the audit view first — it has no editor to land the form in.
 // `setView` clears any half-written draft, so it has to run before `newEntry`.
-export const startEntry = (type: EntryType) => {
+// `prefill` seeds the fields a scan already read (see `Scan/run`).
+export const startEntry = (type: EntryType, prefill?: Record<string, string>) => {
   // Only All Items can hold a draft: every other view is a filtered or
   // read-only surface the new entry would immediately fall out of.
   if (useStore.getState().ui.view !== 'items') setView('items')
-  newEntry(type)
+  newEntry(type, prefill)
 }
 
 // Manual lock, from anywhere (top chrome, Settings, palette): clear the session,

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -12,7 +12,8 @@ import {
   setup,
   readVault,
   importBackup,
-  setAutolockTimeout
+  setAutolockTimeout,
+  scanSupported
 } from '@/lib/commands'
 import type { EntryDraft } from '@/defaults/entries'
 import { getSecs } from '@/defaults/autolock'
@@ -155,6 +156,11 @@ export const createAsyncSlice: StateCreator<StoreState, [], [], AsyncSlice> = (_
       // the stored preference as soon as there is a session to protect.
       setAutolockTimeout(getSecs()).catch(() => {})
       get().syncInit(result.syncConfigured)
+      // Asked once per session: whether the OS can read a card off a photo
+      // decides whether any scan affordance is offered at all.
+      scanSupported()
+        .then(get().setScanSupported)
+        .catch(() => {})
       // One run on unlock: this device may have been off while another pushed,
       // and it may itself be holding writes a previous session never published.
       if (result.syncConfigured) syncNow().catch(() => {})

--- a/src/store/uiSlice.ts
+++ b/src/store/uiSlice.ts
@@ -6,6 +6,9 @@ export type View = 'items' | 'favorites' | 'health' | 'trash'
 // The Settings sections, in nav order.
 export type Section = 'sync' | 'security' | 'audit' | 'import' | 'language'
 
+/** Why a scan produced no fields. The copy for each lives in `Scan/Status`. */
+export type ScanError = 'unreadable' | 'unsupported' | 'failed'
+
 export interface UiSlice {
   ui: {
     palette: boolean
@@ -13,7 +16,18 @@ export interface UiSlice {
     settingsSection: Section
     addPicker: boolean
     view: View
+    // Image scanning: whether the platform can do it at all (asked once per
+    // unlock — no affordance is shown when it cannot), and the current run.
+    scan: {
+      supported: boolean
+      busy: boolean
+      error: ScanError | null
+    }
   }
+  setScanSupported: (supported: boolean) => void
+  scanStarted: () => void
+  scanFinished: (error?: ScanError | null) => void
+  dismissScan: () => void
   openPalette: () => void
   closePalette: () => void
   openSettings: (section?: Section) => void
@@ -30,8 +44,16 @@ export const createUiSlice: StateCreator<StoreState, [], [], UiSlice> = (set, ge
     settings: false,
     settingsSection: 'sync',
     addPicker: false,
-    view: 'items'
+    view: 'items',
+    scan: { supported: false, busy: false, error: null }
   },
+  setScanSupported: supported =>
+    set(s => ({ ui: { ...s.ui, scan: { ...s.ui.scan, supported } } })),
+  // A new run replaces the previous run's complaint: the user is answering it.
+  scanStarted: () => set(s => ({ ui: { ...s.ui, scan: { ...s.ui.scan, busy: true, error: null } } })),
+  scanFinished: error =>
+    set(s => ({ ui: { ...s.ui, scan: { ...s.ui.scan, busy: false, error: error ?? null } } })),
+  dismissScan: () => set(s => ({ ui: { ...s.ui, scan: { ...s.ui.scan, error: null } } })),
   openPalette: () => set(s => ({ ui: { ...s.ui, palette: true } })),
   closePalette: () => set(s => ({ ui: { ...s.ui, palette: false } })),
   // Without a section the modal reopens where it was left, so a deep link from
@@ -52,7 +74,7 @@ export const createUiSlice: StateCreator<StoreState, [], [], UiSlice> = (set, ge
   setView: view => {
     set(s => ({
       ui: { ...s.ui, view },
-      entries: { ...s.entries, new: null, edit: false, current: null }
+      entries: { ...s.entries, new: null, edit: false, current: null, prefill: null }
     }))
     // Tombstones are not part of the unlock payload, so the Trash reads them
     // when it is opened. Refetching on every visit is also what keeps it honest

--- a/src/test/scan.test.tsx
+++ b/src/test/scan.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { open } from '@tauri-apps/plugin-dialog'
+import Main from '@/components/Main'
+import { scanImage } from '@/lib/commands'
+import { makeStore, useStore, setScanSupported, startEntry } from '@/store'
+import {
+  cleanFields,
+  firstImage,
+  isImagePath,
+  mergeFields
+} from '@/components/Main/Scan/fields'
+import { runScan } from '@/components/Main/Scan/run'
+import { renderWithStore, withEntries, loginMeta } from './utils'
+
+const CARD = { number: '4242424242424242', month: '04', year: '27', name: 'ADA LOVELACE' }
+
+const PASSPORT = {
+  doc_type: 'passport',
+  name: 'ANNA MARIA ERIKSSON',
+  number: 'L898902C3',
+  country: 'UTO',
+  nationality: 'UTO',
+  birth_date: '1974-08-12',
+  sex: 'F',
+  expiry_date: '2012-04-15',
+  personal_number: 'ZE184226B'
+}
+
+const seed = () => {
+  const store = makeStore()
+  withEntries([loginMeta({ id: 'l1', title: 'Google' })])
+  return store
+}
+
+const scan = (path: string) => act(async () => void (await runScan(path)))
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('scan fields', () => {
+  it('takes only images, whatever the case of the extension', () => {
+    expect(isImagePath('/Users/me/Desktop/card.png')).toBe(true)
+    expect(isImagePath('/Users/me/IMG_0042.HEIC')).toBe(true)
+    expect(isImagePath('shot.jpeg')).toBe(true)
+    // What the Import drop zone is there for, and must keep getting.
+    expect(isImagePath('/Users/me/export.csv')).toBe(false)
+    expect(isImagePath('/Users/me/vault.swftx')).toBe(false)
+    expect(isImagePath('/Users/me/scan.pdf')).toBe(false)
+    // No extension at all — including a directory that only looks like one.
+    expect(isImagePath('/Users/me/screenshot')).toBe(false)
+    expect(isImagePath('/Users/me/photos.png/notes')).toBe(false)
+  })
+
+  it('picks the image out of a mixed drop', () => {
+    expect(firstImage(['/a/readme.txt', '/a/card.jpg'])).toBe('/a/card.jpg')
+    expect(firstImage(['/a/readme.txt', '/a/export.csv'])).toBeUndefined()
+    expect(firstImage([])).toBeUndefined()
+  })
+
+  it('drops the fields the recognizer could not fill', () => {
+    expect(cleanFields({ number: 'L898902C3', personal_number: '', sex: '   ' })).toEqual({
+      number: 'L898902C3'
+    })
+  })
+
+  it('fills only what is empty', () => {
+    const draft = { type: 'card' as const, title: 'My card', number: '', name: 'MY OWN NAME' }
+
+    expect(mergeFields(draft, CARD)).toEqual({
+      type: 'card',
+      title: 'My card',
+      number: '4242424242424242',
+      month: '04',
+      year: '27',
+      // Typed by hand, so the scan does not get to correct it.
+      name: 'MY OWN NAME'
+    })
+  })
+
+  it('always sets the document type', () => {
+    const draft = { type: 'identity' as const, title: '', doc_type: 'passport', number: '' }
+
+    // The default is not an answer: the document says what it is.
+    expect(mergeFields(draft, { doc_type: 'id_card', number: 'X1' })).toMatchObject({
+      doc_type: 'id_card',
+      number: 'X1'
+    })
+  })
+
+  it('leaves values that are not text alone', () => {
+    const draft = { type: 'card' as const, title: '', tags: ['travel'] }
+
+    expect(mergeFields(draft, { tags: 'ignored' }).tags).toEqual(['travel'])
+  })
+})
+
+describe('scan routing', () => {
+  it('starts a new entry of the kind that was recognized, seeded', async () => {
+    seed()
+    vi.mocked(scanImage).mockResolvedValue({ kind: 'card', fields: CARD })
+
+    await scan('/Users/me/card.png')
+
+    expect(useStore.getState().entries.new).toBe('card')
+    expect(useStore.getState().entries.prefill).toEqual(CARD)
+    expect(useStore.getState().ui.scan.busy).toBe(false)
+  })
+
+  it('fills the editor already open for that kind instead of opening another', async () => {
+    seed()
+    startEntry('identity')
+    vi.mocked(scanImage).mockResolvedValue({ kind: 'identity', fields: PASSPORT })
+
+    await scan('/Users/me/passport.jpg')
+
+    expect(useStore.getState().entries.new).toBe('identity')
+    expect(useStore.getState().entries.prefill).toEqual(PASSPORT)
+  })
+
+  it('reports why nothing came back', async () => {
+    seed()
+    vi.mocked(scanImage).mockRejectedValue('nothing recognized')
+
+    await scan('/Users/me/wall.png')
+
+    expect(useStore.getState().entries.new).toBeNull()
+    expect(useStore.getState().ui.scan).toMatchObject({ busy: false, error: 'unreadable' })
+  })
+})
+
+describe('a scanned draft', () => {
+  it('opens the editor with the fields already in it', async () => {
+    const store = seed()
+    setScanSupported(true)
+    vi.mocked(scanImage).mockResolvedValue({ kind: 'identity', fields: PASSPORT })
+    renderWithStore(<Main />, { store })
+
+    await scan('/Users/me/passport.jpg')
+
+    await waitFor(() =>
+      expect(document.querySelector('input[name="number"]')).toHaveValue('L898902C3')
+    )
+    expect(document.querySelector('input[name="name"]')).toHaveValue('ANNA MARIA ERIKSSON')
+    // Consumed: nothing is left to seed the next entry with.
+    expect(useStore.getState().entries.prefill).toBeNull()
+  })
+
+  it('fills the blanks of an editor that is already open', async () => {
+    const store = seed()
+    setScanSupported(true)
+    startEntry('identity')
+    renderWithStore(<Main />, { store })
+
+    const name = document.querySelector('input[name="name"]') as HTMLInputElement
+    await userEvent.type(name, 'MY OWN NAME')
+
+    vi.mocked(scanImage).mockResolvedValue({ kind: 'identity', fields: PASSPORT })
+    await scan('/Users/me/passport.jpg')
+
+    await waitFor(() =>
+      expect(document.querySelector('input[name="number"]')).toHaveValue('L898902C3')
+    )
+    expect(name).toHaveValue('MY OWN NAME')
+  })
+})
+
+describe('scanning from the picker', () => {
+  const openFromRail = () => userEvent.click(screen.getByTestId('add-entry-button'))
+
+  it('offers nothing where the platform cannot scan', async () => {
+    renderWithStore(<Main />, { store: seed() })
+    await openFromRail()
+
+    expect(screen.queryByTestId('add-scan-image')).not.toBeInTheDocument()
+  })
+
+  it('offers the action where it can', async () => {
+    const store = seed()
+    setScanSupported(true)
+    renderWithStore(<Main />, { store })
+    await openFromRail()
+
+    const action = within(screen.getByTestId('add-secret-modal')).getByTestId('add-scan-image')
+    expect(action).toHaveTextContent('Scan a card or document…')
+  })
+
+  it('routes a picked file like a drop', async () => {
+    const store = seed()
+    setScanSupported(true)
+    vi.mocked(open).mockResolvedValue('/Users/me/card.png')
+    vi.mocked(scanImage).mockResolvedValue({ kind: 'card', fields: CARD })
+    renderWithStore(<Main />, { store })
+    await openFromRail()
+
+    await userEvent.click(screen.getByTestId('add-scan-image'))
+
+    await waitFor(() => expect(useStore.getState().entries.new).toBe('card'))
+    expect(useStore.getState().ui.addPicker).toBe(false)
+    expect(vi.mocked(scanImage)).toHaveBeenCalledWith('/Users/me/card.png')
+  })
+
+  it('leaves the picker alone when the dialog is cancelled', async () => {
+    const store = seed()
+    setScanSupported(true)
+    vi.mocked(open).mockResolvedValue(null)
+    renderWithStore(<Main />, { store })
+    await openFromRail()
+
+    await userEvent.click(screen.getByTestId('add-scan-image'))
+
+    expect(screen.getByTestId('add-secret-modal')).toBeInTheDocument()
+    expect(vi.mocked(scanImage)).not.toHaveBeenCalled()
+  })
+
+  it('keeps the tiles answering to the digits', async () => {
+    const store = seed()
+    setScanSupported(true)
+    renderWithStore(<Main />, { store })
+    await openFromRail()
+
+    await userEvent.keyboard('2')
+
+    expect(useStore.getState().entries.new).toBe('card')
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -62,6 +62,9 @@ vi.mock('@/lib/commands', () => ({
   syncNow: vi.fn().mockResolvedValue(undefined),
   syncImport: vi.fn().mockResolvedValue(undefined),
   syncStatus: vi.fn().mockResolvedValue({ configured: false }),
+  // Off by default, so no suite sees a scan affordance it did not ask for.
+  scanSupported: vi.fn().mockResolvedValue(false),
+  scanImage: vi.fn().mockRejectedValue('nothing recognized'),
   // Pure helper (not a command); mirror the real projection so tests and the
   // dead sync path can use it against the mocked module.
   toEntryMeta: (entry: { id: string; type: string; title: string; tags?: string[] }) => ({
@@ -98,6 +101,11 @@ vi.mock('@tauri-apps/api/dpi', () => ({
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
   openUrl: vi.fn().mockResolvedValue(undefined)
+}))
+
+// The file dialog: nothing picked unless a test says otherwise.
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn().mockResolvedValue(null)
 }))
 
 // Components under test call useTranslation(); the singleton must be

--- a/tests/e2e/specs/scan.spec.ts
+++ b/tests/e2e/specs/scan.spec.ts
@@ -1,0 +1,48 @@
+import { resetEmpty, unlock, waitFor } from "../helpers";
+
+// Reading a card or a document off a photo.
+//
+// What is checked here is the affordance and the platform answer behind it: the
+// picker offers to scan exactly when the OS has a text recognizer, which the
+// app asks about once per unlock. macOS always has one (Vision), so it is the
+// one platform with a certain answer — Linux has none and Windows only has one
+// when a language pack is installed, so the spec skips there rather than
+// asserting something the machine gets to decide.
+//
+// Recognition itself is not driven from here. Both ways in are outside the
+// webview — an OS drag-and-drop and a native file dialog, neither scriptable
+// through WebDriver — and the parsers are already covered over fixed text in
+// `src-tauri/src/scan/tests.rs`.
+
+const MASTER_PASSWORD = "Rk4#vQz7mNp2!tLw";
+
+const scanAction = () => $('[data-testid="add-scan-image"]');
+
+async function openPicker(): Promise<void> {
+  await waitFor("add-entry-button");
+  await $('[data-testid="add-entry-button"]').click();
+  await waitFor("add-secret-modal");
+}
+
+describe("scanning", () => {
+  before(async function () {
+    if (process.platform !== "darwin") this.skip();
+    await resetEmpty(MASTER_PASSWORD);
+    await unlock(MASTER_PASSWORD);
+  });
+
+  it("offers to scan a card or document from the picker", async () => {
+    await openPicker();
+
+    await scanAction().waitForDisplayed({ timeout: 10_000 });
+    await expect(scanAction()).toHaveText(
+      expect.stringContaining("Scan a card or document"),
+    );
+
+    // The tiles keep the keyboard: the action is not an nth kind.
+    await browser.keys("2");
+    await waitFor("entry-sheet");
+    await expect($('[data-testid="entry-sheet"]')).toBeDisplayed();
+    await browser.keys("Escape");
+  });
+});


### PR DESCRIPTION
## Summary

The user-facing half of local scanning: drop a photo or screenshot of a credit card or an ID document anywhere on the unlocked window, or pick one from the "Add a secret" picker, and land in an editor prefilled with what the OS read. Nothing is saved until the user reviews and names the entry.

- **Global drop** (`src/components/Main/Scan/`): listens to the webview drag-drop event, reacts only to image extensions so the Import drop zone keeps its CSV/JSON, shows a full-window "drop to scan" overlay while an image is dragged over, and ignores drops while a modal is open.
- **Picker action**: "Scan a card or document…" below the kind tiles, opening the native file dialog with an image filter. Kept outside the tile grid so digit and arrow shortcuts are unchanged. Hidden entirely when `scan_supported()` is false (asked once per unlock, kept in the store).
- **Routing**: one `entries.prefill` channel. If an editor of the recognized kind is already open, the scan fills its blank fields in place (`doc_type` always wins, since it decides which rows render). Otherwise a new entry of that kind starts seeded. `useDraft` reads and clears the prefill; the change there is about ten lines.
- **Feedback**: a small bottom-left status while scanning and on "nothing recognized" or failure, with copy that follows the language setting. Moved the toast shell to a shared token so it cannot overlap the update toast.
- **Also**: a new draft is now keyed by kind in the detail pane, so switching kinds (or a scan recognizing a different kind) starts a fresh draft instead of reusing the old kind's model.
- **Tests**: 16 vitest tests for field mapping and merge, routing, and picker visibility. The e2e spec asserts the affordance and the real `scan_supported` answer on macOS and skips elsewhere; OS drag-drop and native dialogs are not scriptable through WebDriver.

## Out of scope

- Paste from clipboard (a screenshot in the clipboard has no path; needs a bytes entry point in the backend).
- The Import drop zone still accepts any path; an image dropped inside Settings › Import fails in the import parser as before.

No Rust changes. CSP unchanged: only the path crosses to Rust, the image is never loaded into the webview.

Stacked on #341 (`feat/identity-extra-fields`); #339 and #340 are already merged into `main`.