### PR TITLE
ci: shard E2E, path-gate PR jobs, stub dist for Rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,76 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # On PRs, each job below runs only when its inputs changed (a docs-only PR
+  # runs nothing; a frontend-only PR skips the Rust matrix). Pushes to the
+  # protected branches always run everything. A skipped job satisfies branch
+  # protection, and if this detection job itself fails every job runs anyway
+  # (see the `needs.changes.result != 'success'` clause on each job).
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      rust: ${{ steps.filter.outputs.rust }}
+      crypto: ${{ steps.filter.outputs.crypto }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      supply-chain: ${{ steps.filter.outputs.supply-chain }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ci: &ci
+              - '.github/workflows/ci.yml'
+            frontend-src: &frontend-src
+              - 'src/**'
+              - 'index.html'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - 'tsconfig.node.json'
+              - 'vite.config.ts'
+              - 'eslint.config.js'
+            rust-src: &rust-src
+              - 'src-tauri/**'
+              - 'rust-toolchain.toml'
+            frontend:
+              - *ci
+              - *frontend-src
+            rust:
+              - *ci
+              - *rust-src
+            crypto:
+              - *ci
+              - *rust-src
+              - 'scripts/**'
+            e2e:
+              - *ci
+              - *frontend-src
+              - *rust-src
+              - 'tests/e2e/**'
+            supply-chain:
+              - *ci
+              - 'package.json'
+              - 'bun.lock'
+              - 'src-tauri/Cargo.toml'
+              - 'src-tauri/Cargo.lock'
+              - 'src-tauri/deny.toml'
+
   frontend:
     name: Frontend (build + lint)
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.frontend == 'true'
+      )
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -27,6 +94,13 @@ jobs:
 
   rust:
     name: Rust (${{ matrix.os }})
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.rust == 'true'
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -56,13 +130,12 @@ jobs:
           # every PR, from any branch, restores.
           save-if: ${{ github.event_name == 'push' }}
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.3
-
-      # generate_context! needs the built frontend (../dist) to exist.
-      - run: bun install --frozen-lockfile
-      - run: bun run build
+      # generate_context! only needs `../dist` to exist. Debug builds load the
+      # frontend from `devUrl` and never embed it, so a stub replaces the full
+      # `bun install` + `bun run build` here (that was ~2 min on Windows).
+      - name: Stub frontend dist
+        shell: bash
+        run: mkdir -p dist && echo '<!doctype html>' > dist/index.html
 
       - name: Format check
         working-directory: src-tauri
@@ -79,6 +152,13 @@ jobs:
   supply-chain:
     name: Supply chain (audit + cargo-deny)
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.supply-chain == 'true'
+      )
     steps:
       - uses: actions/checkout@v4
 
@@ -114,6 +194,13 @@ jobs:
   crypto-compat:
     name: Crypto compatibility
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.crypto == 'true'
+      )
     steps:
       - uses: actions/checkout@v4
 
@@ -141,9 +228,11 @@ jobs:
         with:
           bun-version: 1.3.3
 
-      # generate_context! needs the built frontend (../dist) to exist.
+      # The crosscheck script runs under bun; the Rust side only needs `../dist`
+      # to exist (debug builds never embed it), so no frontend build.
       - run: bun install --frozen-lockfile
-      - run: bun run build
+      - name: Stub frontend dist
+        run: mkdir -p dist && echo '<!doctype html>' > dist/index.html
 
       # Rust decrypts the Node-generated golden fixtures and asserts plaintext.
       - name: Fixture + round-trip tests
@@ -155,8 +244,23 @@ jobs:
         run: bun scripts/crypto-crosscheck.mjs
 
   e2e:
-    name: E2E smoke suite
+    # Specs run one at a time against a single app instance (the in-app
+    # WebDriver server takes one session), so the suite is split across
+    # parallel shards instead. tests/e2e/wdio.conf.ts reads E2E_SHARD and
+    # picks every Nth spec file; add a shard here to split further.
+    name: E2E smoke suite (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.e2e == 'true'
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
 
@@ -198,8 +302,10 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # generate_context! needs the built frontend (../dist) to exist.
-      - run: bun run build
+      # The debug binary serves the frontend from the Vite dev server that
+      # wdio starts, so `../dist` only has to exist for generate_context!.
+      - name: Stub frontend dist
+        run: mkdir -p dist && echo '<!doctype html>' > dist/index.html
 
       - name: Build debug binary
         run: cargo build --manifest-path src-tauri/Cargo.toml
@@ -207,5 +313,6 @@ jobs:
       - name: Run E2E tests
         run: xvfb-run --server-args="-screen 0 1280x800x24" bun run test:e2e
         env:
+          E2E_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
           WEBKIT_DISABLE_COMPOSITING_MODE: 1
           NO_AT_BRIDGE: 1

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -25,6 +25,39 @@ const APP_BINARY =
 
 const TEST_DB_DIR = path.join(os.tmpdir(), `swifty-e2e-${Date.now()}`);
 
+const SPECS_DIR = path.join(__dirname, "specs");
+
+/**
+ * The spec files this run executes.
+ *
+ * Specs run one at a time (maxInstances: 1) because the in-app WebDriver
+ * server takes a single session, so CI splits the suite across parallel jobs
+ * instead: with `E2E_SHARD=k/n` this run takes every n-th spec starting at
+ * the k-th (1-based), over the alphabetically sorted list. Every shard sees
+ * the same order, so the shards are disjoint and together cover every spec.
+ * Unset (local runs) means all of them.
+ */
+function shardedSpecs(): string[] {
+  const all = fs
+    .readdirSync(SPECS_DIR)
+    .filter((f) => f.endsWith(".spec.ts"))
+    .sort()
+    .map((f) => path.join(SPECS_DIR, f));
+
+  const shard = process.env.E2E_SHARD;
+  if (!shard) return all;
+
+  const match = /^(\d+)\/(\d+)$/.exec(shard);
+  const index = match ? Number(match[1]) : NaN;
+  const total = match ? Number(match[2]) : NaN;
+  if (!match || total < 1 || index < 1 || index > total) {
+    throw new Error(`[e2e] E2E_SHARD must look like "1/3" (1-based), got "${shard}"`);
+  }
+  const mine = all.filter((_, i) => i % total === index - 1);
+  console.log(`[e2e] shard ${index}/${total}: ${mine.length} of ${all.length} specs`);
+  return mine;
+}
+
 let viteProcess: ChildProcess;
 let appProcess: ChildProcess;
 
@@ -73,7 +106,7 @@ export const config: WebdriverIO.Config = {
   port: 4445,
   path: "/",
 
-  specs: ["./specs/**/*.spec.ts"],
+  specs: shardedSpecs(),
   maxInstances: 1,
 
   capabilities: [


### PR DESCRIPTION
## Why

A PR run took about 6 minutes wall clock. Step timings from a recent run on `main`:

| Job | Duration | Where the time went |
|---|---|---|
| E2E smoke suite | 342s | 17 specs run serially against one app instance |
| Rust (windows) | 302s | 113s `bun install` + 19s `bun run build` for a frontend the Rust build never embeds |
| Rust (ubuntu / macos) | ~115s | includes bun install + frontend build |

A docs-only PR (#337) ran the whole matrix.

## What changed

**1. E2E is sharded 3 ways.** `tests/e2e/wdio.conf.ts` reads `E2E_SHARD=k/n` and takes every n-th spec file of the alphabetically sorted list, so shards are disjoint and together cover every spec. Unset (local runs) means all specs, unchanged behaviour. The workflow passes `matrix.shard/strategy.job-total`, so adding a shard is a one-token change. Each shard still pays the ~90s job setup, but spec time drops from ~250s to ~85s.

**2. Rust jobs stub `dist/` instead of building the frontend.** In debug builds with `devUrl` set, `tauri-codegen` never reads `frontendDist` (verified in `tauri-codegen` 2.6.3 `context.rs`); `tauri-build` only needs the directory to exist. The Rust matrix drops `setup-bun`, `bun install`, and `bun run build` entirely. Crypto compat and E2E keep `bun install` (crosscheck script, wdio, vite) but drop the build. The E2E debug binary loads the frontend from the Vite dev server wdio starts, same as before.

**3. PR jobs are path-gated.** A `changes` job uses `dorny/paths-filter@v3` (already used in `codeql.yml`) and each job runs only when its inputs changed. Pushes to protected branches still run everything. If the detection job fails, every job runs (fail open, via `needs.changes.result != 'success'`).

| Job | Runs on PRs when these change |
|---|---|
| Frontend | `src/**`, `index.html`, `package.json`, `bun.lock`, tsconfigs, `vite.config.ts`, `eslint.config.js` |
| Rust matrix | `src-tauri/**`, `rust-toolchain.toml` |
| Crypto compat | Rust inputs + `scripts/**` |
| E2E | Frontend inputs + Rust inputs + `tests/e2e/**` |
| Supply chain | `package.json`, `bun.lock`, `Cargo.toml`, `Cargo.lock`, `deny.toml` |

`ci.yml` itself is in every filter.

## Measured (run 33740760659, warm caches, every job ran because `ci.yml` changed)

| Job | Before | After |
|---|---|---|
| Whole run (wall clock) | ~6 min | 4 min 11 s |
| E2E | 342s (test step 252s) | 3 shards of 186–237s (test step 92–124s each) |
| Rust (windows) | 302s | 138s |
| Rust (ubuntu / macos) | 116s / 110s | 85s / 93s |
| Crypto compatibility | 156s | 139s |

The remaining E2E floor is ~90s of per-shard setup (apt, cache restore, debug build) plus the slowest shard's specs. Frontend-only and docs-only PRs skip the Rust and E2E jobs entirely, so they will be much faster than this all-jobs run.

Note on the first run of this PR (33739103708): it was cold and slow (Windows 15 min). The PR was opened against `master` and re-based to `main` three seconds after that run started, so the run's cache scope was `master` (no Rust caches) and `paths-filter` compared against the old Electron tree. Not related to the changes here; the re-run above is representative.

## Action needed after merge

- **Required status checks:** the E2E check is now named `E2E smoke suite (1/3)`, `(2/3)`, `(3/3)` instead of `E2E smoke suite`. If branch protection lists the old name, update it or PRs will wait forever on a check that never reports. Skipped jobs satisfy required checks, so the path gating needs no protection changes.
- The first push to `main` after merge re-saves the Rust caches (the E2E cache key is shared across shards; the first shard to save wins, the rest are identical).

## Verified

- `actionlint` clean; YAML anchors in the filter expand to the intended path lists.
- `tsc --noEmit -p tests/e2e/tsconfig.json` passes.
- Loaded the wdio config under Bun and under Node + ts-node (what wdio uses) with `E2E_SHARD` unset, `1/3`, `2/3`, `3/3`, `2/2`: partitions are disjoint and complete. `4/3` and `abc` throw.
- Not verified here: a full CI run. This PR's own run exercises everything except the push-only cache save.

## Not in this PR

Merging crypto-compat into the Ubuntu Rust job, caching apt packages, and replacing the Docker-based cargo-deny action were also identified but left out to keep this reviewable. Separately, `codeql.yml` only triggers on `master` and `v1-0-0`, so CodeQL is not running on PRs to `main`.
