### PR TITLE
chore: bump app version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swifty",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "description": "Modern, Lightweight, Fast and Free Password Manager",
   "type": "module",
   "repository": "https://github.com/swiftyapp/swifty.git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "swifty"
-version = "1.0.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifty"
-version = "1.0.0"
+version = "0.9.0"
 description = "Modern, Lightweight, Fast and Free Password Manager"
 authors = ["Alex Chaplinsky"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Swifty",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "identifier": "pro.getswifty.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Sets the app version to 0.9.0 (down from 1.0.0) across every manifest that declares it.

## Changes

- `package.json` — `version` → 0.9.0
- `src-tauri/tauri.conf.json` — `version` → 0.9.0 (this is what `getVersion()` returns, so it drives the version shown on the unlock screen and in the settings footer)
- `src-tauri/Cargo.toml` — crate `version` → 0.9.0
- `src-tauri/Cargo.lock` — `swifty` package entry updated to match

## Notes

- `cargo metadata --offline` accepts the updated manifest/lockfile without rewriting anything.
- Unit-test mocks of `getVersion()` (`src/test/setup.ts`) return a fixed placeholder and are intentionally unchanged.
- Since this is a downgrade, users already on a 1.0.0 build will not be offered 0.9.0 by the updater.