### PR TITLE
chore: bump app version to 1.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swifty",
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.1",
   "description": "Modern, Lightweight, Fast and Free Password Manager",
   "type": "module",
   "repository": "https://github.com/swiftyapp/swifty.git",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "swifty"
-version = "0.9.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swifty"
-version = "0.9.0"
+version = "1.0.0-alpha.1"
 description = "Modern, Lightweight, Fast and Free Password Manager"
 authors = ["Alex Chaplinsky"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Swifty",
-  "version": "0.9.0",
+  "version": "1.0.0-alpha.1",
   "identifier": "pro.getswifty.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Starts the v1 pre-release track: sets the app version to `1.0.0-alpha.1` across every manifest that declares it. Alphas and betas can now iterate toward the stable `1.0.0`, and semver ordering keeps each one below the final release so the updater will offer users the eventual stable build.

## Changes

- `package.json` — `version` → 1.0.0-alpha.1
- `src-tauri/tauri.conf.json` — `version` → 1.0.0-alpha.1 (drives `getVersion()`, so the unlock screen and settings footer will show "Swifty 1.0.0-alpha.1")
- `src-tauri/Cargo.toml` — crate `version` → 1.0.0-alpha.1
- `src-tauri/Cargo.lock` — `swifty` package entry updated to match

## Notes

- `cargo metadata --offline` accepts the updated manifest/lockfile without rewriting anything.
- The release workflow already handles this: it triggers on any `v*` tag and derives the tag/release name from `tauri.conf.json`, so `v1.0.0-alpha.1` needs no workflow change.
- `prerelease` in `release.yml` is intentionally left `false`: the updater reads `releases/latest/download/latest.json`, and GitHub's "latest" excludes prereleases, so marking alphas as prereleases would stop installed alphas from being offered the next one.
- Windows MSI does not support pre-release suffixes; Tauri's bundler trims it to `1.0.0` for the MSI only. NSIS, macOS and Linux bundles keep the full string. Worth verifying the first alpha-to-alpha MSI upgrade.
- Unit-test mocks of `getVersion()` (`src/test/setup.ts`) return a fixed placeholder and are intentionally unchanged.