### PR TITLE
fix(detail): align value column, editor underlines and header actions

### DIFF
--- a/src/components/Main/Body/Aside/Show/Edit/index.tsx
+++ b/src/components/Main/Body/Aside/Show/Edit/index.tsx
@@ -33,37 +33,37 @@ export default function Edit({ type, revealed }: Props) {
         data-testid="entry-sheet"
         className="-m-4 rounded-xl border border-accent-line p-4"
       >
-        <div className="flex items-start gap-4">
-          <div className="min-w-0 flex-1">
-            <div
-              className={`flex items-center gap-2 whitespace-nowrap ${MONO_TYPE} text-accent`}
-            >
-              <span>{t('Editing')}</span>
-              <span>·</span>
-              <span>{t(kind.label)}</span>
-            </div>
-            <div className="mt-2 flex items-center gap-2.5">
-              <div className="grid h-7 w-7 flex-none place-items-center rounded-lg bg-accent-soft text-accent">
-                <Glyph size={16} />
-              </div>
-              <input
-                name="title"
-                value={title}
-                maxLength={40}
-                autoComplete="off"
-                spellCheck={false}
-                placeholder={t(kind.untitledLabel)}
-                onChange={event => draft.set('title', event.target.value)}
-                className="min-w-0 flex-1 truncate border-b border-line2 bg-transparent text-2xl font-semibold tracking-display text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
-              />
-            </div>
-            {/* Every kind requires a title, so the pane owns this one message. */}
-            {draft.attempted && !title.trim() && (
-              <div className="mt-1.5 pl-[38px] text-base text-bad">{t('Required')}</div>
-            )}
+        {/* The eyebrow shares its line with the actions, so the title input below
+            runs the full content width and its underline ends where the rows do. */}
+        <div className="flex items-center justify-between gap-4">
+          <div
+            className={`flex min-w-0 flex-1 items-center gap-2 truncate whitespace-nowrap ${MONO_TYPE} text-accent`}
+          >
+            <span>{t('Editing')}</span>
+            <span>·</span>
+            <span>{t(kind.label)}</span>
           </div>
           <Actions draft={draft} />
         </div>
+        <div className="mt-2 flex items-center gap-2.5">
+          <div className="grid h-7 w-7 flex-none place-items-center rounded-lg bg-accent-soft text-accent">
+            <Glyph size={16} />
+          </div>
+          <input
+            name="title"
+            value={title}
+            maxLength={40}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={t(kind.untitledLabel)}
+            onChange={event => draft.set('title', event.target.value)}
+            className="min-w-0 flex-1 truncate border-b border-line2 bg-transparent text-2xl font-semibold tracking-display text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
+          />
+        </div>
+        {/* Every kind requires a title, so the pane owns this one message. */}
+        {draft.attempted && !title.trim() && (
+          <div className="mt-1.5 pl-[38px] text-base text-bad">{t('Required')}</div>
+        )}
 
         <div className="mt-3">
           <FieldsProvider

--- a/src/components/Main/Body/Aside/Show/Read.tsx
+++ b/src/components/Main/Body/Aside/Show/Read.tsx
@@ -43,37 +43,39 @@ export default function Read({ entry, revealed }: Props) {
 
   return (
     <div className="mx-auto w-full max-w-[860px]">
-      <div className="flex items-start gap-4">
-        <div className="min-w-0 flex-1">
-          <div className={`flex items-center gap-2 whitespace-nowrap ${MONO_LABEL}`}>
-            <span className="text-text2">{t(kind.label)}</span>
-            {entry.urlHost && (
-              <>
-                <span>/</span>
-                <span>{entry.urlHost}</span>
-              </>
-            )}
-          </div>
-          <div className="mt-2 flex items-center gap-2.5">
-            <div className="grid h-7 w-7 flex-none place-items-center overflow-hidden rounded-lg bg-tile text-text2">
-              {icon ? (
-                <img src={icon} alt="" className="h-full w-full object-cover" />
-              ) : hasBrandMark(entry.cardBrand) ? (
-                <CardBrandMark brand={entry.cardBrand} size={12} />
-              ) : (
-                <Glyph size={16} />
-              )}
-            </div>
-            <h1 className="truncate text-2xl font-semibold tracking-display text-text">
-              {entry.title}
-            </h1>
-          </div>
+      {/* The eyebrow shares its line with the actions, so the title below can
+          run the full content width. */}
+      <div className="flex items-center justify-between gap-4">
+        <div
+          className={`flex min-w-0 flex-1 items-center gap-2 truncate whitespace-nowrap ${MONO_LABEL}`}
+        >
+          <span className="text-text2">{t(kind.label)}</span>
+          {entry.urlHost && (
+            <>
+              <span>/</span>
+              <span>{entry.urlHost}</span>
+            </>
+          )}
         </div>
         <div className="flex flex-none items-center gap-1.5">
           {/* A tombstone cannot be starred — Favorites lists live entries. */}
           {!entry.deletedAt && <Favorite entry={entry} />}
           <Actions entry={entry} revealed={revealed} onDelete={onDelete} />
         </div>
+      </div>
+      <div className="mt-2 flex items-center gap-2.5">
+        <div className="grid h-7 w-7 flex-none place-items-center overflow-hidden rounded-lg bg-tile text-text2">
+          {icon ? (
+            <img src={icon} alt="" className="h-full w-full object-cover" />
+          ) : hasBrandMark(entry.cardBrand) ? (
+            <CardBrandMark brand={entry.cardBrand} size={12} />
+          ) : (
+            <Glyph size={16} />
+          )}
+        </div>
+        <h1 className="truncate text-2xl font-semibold tracking-display text-text">
+          {entry.title}
+        </h1>
       </div>
 
       {revealed && (

--- a/src/components/elements/fields/CustomFields/Row.tsx
+++ b/src/components/elements/fields/CustomFields/Row.tsx
@@ -67,6 +67,9 @@ export default function CustomFieldRow({
           {field.label}
         </span>
       )}
+      {/* The fixed rows' sigil slot and actions slot (see FieldRow), held open
+          so these values start and end where the rows above them do. */}
+      <span className="w-4 flex-none" />
 
       <div className="min-w-0 flex-1">
         {onChange ? (
@@ -88,17 +91,19 @@ export default function CustomFieldRow({
         )}
       </div>
 
-      {editing ? (
-        <IconButton
-          title={t('Remove field')}
-          testid={`remove-extra-${index}`}
-          onClick={onRemove}
-        >
-          <TrashGlyph />
-        </IconButton>
-      ) : (
-        <CopyButton value={field.value} title={t('Copy')} />
-      )}
+      <div className="flex w-[60px] flex-none items-center justify-end gap-1">
+        {editing ? (
+          <IconButton
+            title={t('Remove field')}
+            testid={`remove-extra-${index}`}
+            onClick={onRemove}
+          >
+            <TrashGlyph />
+          </IconButton>
+        ) : (
+          <CopyButton value={field.value} title={t('Copy')} />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/elements/fields/PasswordField.tsx
+++ b/src/components/elements/fields/PasswordField.tsx
@@ -4,6 +4,7 @@ import { openGenerator } from '@/store'
 import type { TKey } from '@/i18n'
 import { relativeDuration, shortDate, toTime } from '@/utils/time'
 import { RefreshGlyph } from '../../Main/icons'
+import IconButton from '../IconButton'
 import StrengthBar from '../StrengthBar'
 import { MONO_LABEL } from '../tokens'
 import Field from './Field'
@@ -47,15 +48,13 @@ export default function PasswordField({
       placeholder="••••••••"
       actions={
         editing ? (
-          <button
-            type="button"
-            data-testid="generate-password-link"
+          <IconButton
+            title={t('Generate')}
+            testid="generate-password-link"
             onClick={() => openGenerator(set)}
-            className="flex cursor-pointer items-center gap-1.5 text-base text-accent hover:brightness-110"
           >
-            <RefreshGlyph size={13} />
-            <span>{t('generate')}</span>
-          </button>
+            <RefreshGlyph />
+          </IconButton>
         ) : undefined
       }
       below={

--- a/src/components/elements/fields/Row.tsx
+++ b/src/components/elements/fields/Row.tsx
@@ -23,6 +23,9 @@ interface Props {
   children: (id: string) => ReactNode
 }
 
+// Where the value column starts: label 96 (w-24) + gap 12 + sigil 16 (w-4) + gap 12.
+const VALUE_START = 'pl-[136px]'
+
 // THE detail-row geometry: a w-24 mono label column, the value, trailing
 // controls, then anything that belongs under the value. Read values and their
 // editors both render through it, so switching modes never moves a row.
@@ -35,16 +38,29 @@ export default function FieldRow({ label, prefix, actions, below, error, childre
     <div className={cx('item px-3.5 py-3', ROW_HAIRLINE)}>
       <div className="flex items-center gap-3">
         {labelled && (
-          <label htmlFor={id} className={`w-24 flex-none ${MONO_LABEL}`}>
-            {t(label)}
-          </label>
+          <>
+            <label htmlFor={id} className={`w-24 flex-none ${MONO_LABEL}`}>
+              {t(label)}
+            </label>
+            {/* Held open with or without a sigil, so every value starts at one x. */}
+            <span className="grid w-4 flex-none place-items-center text-text3">
+              {prefix}
+            </span>
+          </>
         )}
-        {prefix && <span className="flex-none text-text3">{prefix}</span>}
         <div className="min-w-0 flex-1">{children(id)}</div>
-        {actions}
+        {/* Two 28px controls wide (28 + gap 4 + 28), held open so every value —
+            and every editor's underline — ends at one x too. */}
+        {labelled ? (
+          <div className="flex w-[60px] flex-none items-center justify-end gap-1">
+            {actions}
+          </div>
+        ) : (
+          actions
+        )}
       </div>
       {(below || error) && (
-        <div className={cx('mt-1.5 flex flex-col gap-1.5', labelled && 'pl-[108px]')}>
+        <div className={cx('mt-1.5 flex flex-col gap-1.5', labelled && VALUE_START)}>
           {below}
           {error && <span className="text-base text-bad">{error}</span>}
         </div>

--- a/src/test/entry.test.tsx
+++ b/src/test/entry.test.tsx
@@ -133,7 +133,7 @@ describe('Editing in the pane', () => {
         <Generator />
       </>
     )
-    await userEvent.click(screen.getByText('generate'))
+    await userEvent.click(screen.getByTestId('generate-password-link'))
     expect(await screen.findByTestId('generator-dialog')).toBeInTheDocument()
     await screen.findByText('Generated123!')
 
@@ -156,7 +156,7 @@ describe('Editing in the pane', () => {
     )
     store.getState().newEntry('login')
 
-    await userEvent.click(screen.getByText('generate'))
+    await userEvent.click(screen.getByTestId('generate-password-link'))
     expect(await screen.findByTestId('generator-dialog')).toBeInTheDocument()
 
     await userEvent.keyboard('{Escape}')


### PR DESCRIPTION
## Summary

Four alignment fixes in the entry detail pane, from the UI review of the read and edit views. No behaviour changes.

1. **Value column starts at one x.** `FieldRow` now always renders a 16px sigil slot on labelled rows, even without a prefix icon, so Password and Note values line up with URL, Username and Email. The `below` indent (strength bar, rotation stamp, errors) is recomputed from the same numbers.
2. **Editor underlines end at one x.** `FieldRow` reserves a 60px trailing slot (two 28px controls + 4px gap) on labelled rows, empty when a row has no controls. Password's edit-mode "generate" text link becomes an `IconButton` (same testid) so it fits the slot.
3. **Actions no longer straddle eyebrow and title.** Read and edit headers are two rows: eyebrow + action cluster on the first, glyph + title on the second.
4. **Edit title underline shares the panels' right edge.** Follows from 3: the title input now spans the full content width.

Custom-field rows (`CustomFields/Row.tsx`) hand-roll the same geometry, so they adopt both slots to stay aligned with the fixed rows above them on identity entries.

## Test plan

- [x] `bun run typecheck`, `bun run lint` clean
- [x] `bun run test` — 385 passing; two entry tests switched from `getByText('generate')` to the existing `generate-password-link` testid
- [ ] Visual check: login read/edit, card read/edit, identity with custom fields