### PR TITLE
chore(ui): design-system cleanup — tokens, tiers and reuse

### DIFF
--- a/src/components/Main/AddSecret/index.tsx
+++ b/src/components/Main/AddSecret/index.tsx
@@ -66,7 +66,7 @@ export default function AddSecret() {
   return (
     <Modal
       onClose={closeAddPicker}
-      className="w-[640px]"
+      className="w-dialog"
       labelledBy={TITLE_ID}
       testid="add-secret-modal"
     >

--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -44,7 +44,7 @@ export default function Score({ audit }: Props) {
             display tier so it fills the ring. */}
         <div
           data-testid="audit-score"
-          className="text-[34px] font-semibold tracking-display text-text"
+          className="text-3xl font-semibold tracking-display text-text"
         >
           {score.toFixed(1)}
         </div>

--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -1,6 +1,7 @@
 import type { Audit } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import { vaultScore } from '@/utils/vaultScore'
+import { MONO_LABEL } from '@/components/elements/tokens'
 
 interface Props {
   audit: Audit
@@ -47,7 +48,7 @@ export default function Score({ audit }: Props) {
         >
           {score.toFixed(1)}
         </div>
-        <div className="font-mono text-xs uppercase tracking-label text-text3">
+        <div className={MONO_LABEL}>
           {t('Overall Score')}
         </div>
       </div>

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -3,7 +3,7 @@ import type { Audit, AuditItem } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import Score from './Score'
 import Panel from '@/components/elements/Panel'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { MONO_LABEL, ROW_HAIRLINE } from '@/components/elements/tokens'
 
 const count = (audit: Audit, property: keyof AuditItem) =>
   Object.values(audit).filter(item => item[property]).length
@@ -55,7 +55,7 @@ export default function Audit() {
             <div
               key={s.key}
               data-testid={`audit-stat-${s.key}`}
-              className="flex items-center gap-3 px-4 py-3 inset-shadow-hairline last:inset-shadow-none"
+              className={`flex items-center gap-3 px-4 py-3 ${ROW_HAIRLINE}`}
             >
               <span className={`h-[7px] w-[7px] flex-none rounded-full ${s.dot}`} />
               <span className="flex-1 text-base text-text2">{s.label}</span>

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -57,7 +57,7 @@ export default function Audit() {
               data-testid={`audit-stat-${s.key}`}
               className={`flex items-center gap-3 px-4 py-3 ${ROW_HAIRLINE}`}
             >
-              <span className={`h-[7px] w-[7px] flex-none rounded-full ${s.dot}`} />
+              <span className={`h-1.5 w-1.5 flex-none rounded-full ${s.dot}`} />
               <span className="flex-1 text-base text-text2">{s.label}</span>
               <span data-testid="audit-stat-value" className="font-mono text-base text-text">
                 {s.value}

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -55,7 +55,7 @@ export default function Audit() {
             <div
               key={s.key}
               data-testid={`audit-stat-${s.key}`}
-              className="flex items-center gap-3 px-4 py-3 shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none"
+              className="flex items-center gap-3 px-4 py-3 inset-shadow-hairline last:inset-shadow-none"
             >
               <span className={`h-[7px] w-[7px] flex-none rounded-full ${s.dot}`} />
               <span className="flex-1 text-base text-text2">{s.label}</span>

--- a/src/components/Main/Body/Aside/Show/Edit/index.tsx
+++ b/src/components/Main/Body/Aside/Show/Edit/index.tsx
@@ -31,7 +31,7 @@ export default function Edit({ type, revealed }: Props) {
   const tags = Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : []
 
   return (
-    <div className="mx-auto w-full max-w-[860px]">
+    <div className="mx-auto w-full max-w-sheet">
       {/* Negative margin cancels the frame's padding, so the content sits
           exactly where the read view puts it. */}
       <div

--- a/src/components/Main/Body/Aside/Show/Footer.tsx
+++ b/src/components/Main/Body/Aside/Show/Footer.tsx
@@ -5,7 +5,7 @@ import { setFilterQuery } from '@/store'
 import { PlusGlyph } from '@/components/Main/icons'
 import TagsInput from '@/components/elements/TagsInput'
 import { TAG_CHIP } from '@/components/elements/fields/chip'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { MONO_LABEL, MONO_META } from '@/components/elements/tokens'
 import { dateTime, relativeLong, shortDate, toTime } from '@/utils/time'
 
 interface Props {
@@ -77,7 +77,7 @@ export default function Footer({
               type="button"
               data-testid="add-tag-button"
               onClick={onAdd}
-              className="flex h-6 cursor-pointer items-center gap-1 font-mono text-xs text-text3 transition-colors hover:text-text"
+              className={`flex h-6 cursor-pointer items-center gap-1 ${MONO_META} transition-colors hover:text-text`}
             >
               <PlusGlyph size={12} />
               {t('Add tag')}

--- a/src/components/Main/Body/Aside/Show/Read.tsx
+++ b/src/components/Main/Body/Aside/Show/Read.tsx
@@ -41,7 +41,7 @@ export default function Read({ entry, revealed }: Props) {
     fromKind ?? (entry.urlHost ? { text: entry.urlHost } : null)
 
   return (
-    <div className="mx-auto w-full max-w-[860px]">
+    <div className="mx-auto w-full max-w-sheet">
       {/* The eyebrow shares its line with the actions, so the title below can
           run the full content width. */}
       <div className="flex items-center justify-between gap-4">

--- a/src/components/Main/Body/Aside/Show/index.tsx
+++ b/src/components/Main/Body/Aside/Show/index.tsx
@@ -38,7 +38,7 @@ export default function Show({ entry, type, editing }: Props) {
     // always resolves. (`reveal_entry` refuses deleted rows; `editEntry` does
     // too.)
     if (entry && !current && served.current !== entry.id)
-      return <div className="mx-auto min-h-[320px] w-full max-w-[860px]" />
+      return <div className="mx-auto min-h-[320px] w-full max-w-sheet" />
     // Keyed per entry: each editing session starts from a fresh draft. A new
     // entry has no id to key on, so it is keyed by its kind — choosing another
     // kind (the picker again, or a scan that recognized a different one) is a

--- a/src/components/Main/Body/List/Audit/index.tsx
+++ b/src/components/Main/Body/List/Audit/index.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@/store'
 import type { AuditItem, EntryMeta } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import Group from '../Group'
+import { MONO_LABEL } from '@/components/elements/tokens'
 
 export default function AuditList() {
   const { t } = useTranslation()
@@ -11,7 +12,7 @@ export default function AuditList() {
 
   if (!audit)
     return (
-      <div className="px-4 py-6 font-mono text-xs uppercase tracking-label text-text3">
+      <div className={`px-4 py-6 ${MONO_LABEL}`}>
         {t('Loading Results..')}
       </div>
     )

--- a/src/components/Main/Body/List/Group.tsx
+++ b/src/components/Main/Body/List/Group.tsx
@@ -2,6 +2,7 @@ import type { EntryMeta } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import Item from './Item'
+import { MONO_LABEL } from '@/components/elements/tokens'
 
 interface Props {
   title: TKey
@@ -18,7 +19,7 @@ export default function Group({ title, entries }: Props) {
   return (
     <div>
       <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
-        <span className="font-mono text-xs uppercase tracking-label text-text3">
+        <span className={MONO_LABEL}>
           {t(title)}
         </span>
         <span className="h-px flex-1 bg-line" />

--- a/src/components/Main/Body/List/Group.tsx
+++ b/src/components/Main/Body/List/Group.tsx
@@ -2,7 +2,7 @@ import type { EntryMeta } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import Item from './Item'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { MONO_LABEL, MONO_META } from '@/components/elements/tokens'
 
 interface Props {
   title: TKey
@@ -23,7 +23,7 @@ export default function Group({ title, entries }: Props) {
           {t(title)}
         </span>
         <span className="h-px flex-1 bg-line" />
-        <span className="font-mono text-xs text-text3">{entries.length}</span>
+        <span className={MONO_META}>{entries.length}</span>
       </div>
       {entries.map(entry => (
         <Item entry={entry} key={entry.id} />

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -3,6 +3,7 @@ import type { EntryMeta } from '@/lib/commands'
 import type { Kind } from '@/kinds/types'
 import { KIND_TINT } from '@/kinds/tint'
 import { cx } from '@/utils/cx'
+import { MONO_META } from '@/components/elements/tokens'
 
 // What every kind's list row component is handed (see src/kinds/*/ListRow).
 export interface ContentProps {
@@ -48,7 +49,7 @@ export default function Row({ glyph, title, sub, flag, tint }: Props) {
           {flag}
         </div>
         {sub && (
-          <div className="mt-0.5 truncate font-mono text-xs text-text3">
+          <div className={`mt-0.5 truncate ${MONO_META}`}>
             {sub}
           </div>
         )}

--- a/src/components/Main/Body/List/Item/index.tsx
+++ b/src/components/Main/Body/List/Item/index.tsx
@@ -9,6 +9,7 @@ import { StarGlyph } from '../../../icons'
 import { stampOf } from '../order'
 import Flag from './Flag'
 import { flagOf } from './audit'
+import { MONO_META } from '@/components/elements/tokens'
 
 interface Props {
   entry: EntryMeta
@@ -67,7 +68,7 @@ export default function Item({ entry }: Props) {
         </span>
       )}
       {meta && (
-        <span className="flex-none font-mono text-xs text-text3">{meta}</span>
+        <span className={`flex-none ${MONO_META}`}>{meta}</span>
       )}
     </div>
   )

--- a/src/components/Main/Body/List/Item/index.tsx
+++ b/src/components/Main/Body/List/Item/index.tsx
@@ -52,7 +52,7 @@ export default function Item({ entry }: Props) {
       tabIndex={selected ? 0 : -1}
       className={cx(
         'flex cursor-pointer items-center gap-3 border-l-2 py-2.5 pl-[14px] pr-4',
-        'shadow-[inset_0_-1px_0_var(--c-line)]',
+        'inset-shadow-hairline',
         selected
           ? 'border-accent bg-sel'
           : 'border-transparent hover:bg-hover'

--- a/src/components/Main/Generator/Amount.tsx
+++ b/src/components/Main/Generator/Amount.tsx
@@ -4,6 +4,7 @@ import {
   WORDS_RANGE,
   type GeneratorSettings
 } from '@/services/generator'
+import { MONO_LABEL } from '@/components/elements/tokens'
 
 interface Props {
   settings: GeneratorSettings
@@ -20,7 +21,7 @@ export default function Amount({ settings, onChange }: Props) {
 
   return (
     <div className="mt-5 flex items-center gap-3.5">
-      <span className="w-[66px] flex-none font-mono text-xs uppercase tracking-label text-text3">
+      <span className={`w-[66px] flex-none ${MONO_LABEL}`}>
         {t(byWords ? 'Words' : 'Length')}
       </span>
       <input

--- a/src/components/Main/Generator/Dialog.tsx
+++ b/src/components/Main/Generator/Dialog.tsx
@@ -87,7 +87,7 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
         aria-modal="true"
         aria-labelledby="generator-title"
         data-testid="generator-dialog"
-        className="w-[470px] animate-pop overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float"
+        className="w-dialog-sm animate-pop overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float"
         onClick={event => event.stopPropagation()}
       >
         <div className="flex items-center gap-2.5 px-[18px] py-[15px] inset-shadow-hairline">

--- a/src/components/Main/Generator/Dialog.tsx
+++ b/src/components/Main/Generator/Dialog.tsx
@@ -74,7 +74,7 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-50 grid animate-fade place-items-center bg-[var(--scrim)] p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 grid animate-fade place-items-center bg-scrim p-4 backdrop-blur-sm"
       onClick={onClose}
     >
       {/* Announces itself as modal like `elements/Modal` does. Beyond the
@@ -87,10 +87,10 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
         aria-modal="true"
         aria-labelledby="generator-title"
         data-testid="generator-dialog"
-        className="w-[470px] animate-pop overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]"
+        className="w-[470px] animate-pop overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float"
         onClick={event => event.stopPropagation()}
       >
-        <div className="flex items-center gap-2.5 px-[18px] py-[15px] shadow-[inset_0_-1px_0_var(--c-line)]">
+        <div className="flex items-center gap-2.5 px-[18px] py-[15px] inset-shadow-hairline">
           <div id="generator-title" className="flex-1 text-lg font-semibold tracking-display">
             {t('Generate')}
           </div>

--- a/src/components/Main/Generator/Output.tsx
+++ b/src/components/Main/Generator/Output.tsx
@@ -3,6 +3,7 @@ import { cx } from '@/utils/cx'
 import Meter from '@/components/elements/Meter'
 import { LEVEL_INK } from '@/components/elements/levels'
 import { ENTROPY_LABELS } from '@/services/generator'
+import { wellClass } from '@/components/elements/formStyles'
 
 interface Props {
   value: string
@@ -17,7 +18,7 @@ export default function Output({ value, bits, level }: Props) {
     <>
       <div
         data-testid="generator-output"
-        className="min-h-14 rounded-lg border border-line2 bg-field p-4 font-mono text-lg leading-[1.55] break-all"
+        className={`min-h-14 ${wellClass} p-4 font-mono text-lg leading-[1.55] break-all`}
       >
         {value}
       </div>

--- a/src/components/Main/Generator/Output.tsx
+++ b/src/components/Main/Generator/Output.tsx
@@ -18,7 +18,7 @@ export default function Output({ value, bits, level }: Props) {
     <>
       <div
         data-testid="generator-output"
-        className={`min-h-14 ${wellClass} p-4 font-mono text-lg leading-[1.55] break-all`}
+        className={`min-h-14 ${wellClass} p-4 font-mono text-lg leading-relaxed break-all`}
       >
         {value}
       </div>

--- a/src/components/Main/Generator/Ssh/Line.tsx
+++ b/src/components/Main/Generator/Ssh/Line.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import CopyButton from '@/components/elements/CopyButton'
 import { MONO_LABEL } from '@/components/elements/tokens'
+import { wellClass } from '@/components/elements/formStyles'
 import type { TKey } from '@/i18n'
 
 interface Props {
@@ -19,7 +20,7 @@ export default function Line({ label, value, testid }: Props) {
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid={testid}
-          className="min-w-0 flex-1 rounded-lg border border-line2 bg-field px-3 py-2 font-mono text-base leading-[1.55] break-all"
+          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-[1.55] break-all`}
         >
           {value}
         </div>

--- a/src/components/Main/Generator/Ssh/Line.tsx
+++ b/src/components/Main/Generator/Ssh/Line.tsx
@@ -20,7 +20,7 @@ export default function Line({ label, value, testid }: Props) {
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid={testid}
-          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-[1.55] break-all`}
+          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-relaxed break-all`}
         >
           {value}
         </div>

--- a/src/components/Main/Generator/Ssh/Secret.tsx
+++ b/src/components/Main/Generator/Ssh/Secret.tsx
@@ -20,7 +20,7 @@ export default function Secret({ value }: { value: string }) {
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid="generator-ssh-private"
-          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-[1.55] break-all ${
+          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-relaxed break-all ${
             show ? 'max-h-40 overflow-auto whitespace-pre-wrap text-text' : 'text-text2'
           }`}
         >

--- a/src/components/Main/Generator/Ssh/Secret.tsx
+++ b/src/components/Main/Generator/Ssh/Secret.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import CopyButton from '@/components/elements/CopyButton'
 import IconButton from '@/components/elements/IconButton'
 import { MONO_LABEL } from '@/components/elements/tokens'
+import { wellClass } from '@/components/elements/formStyles'
 import { EyeGlyph, EyeOffGlyph } from '../../icons'
 
 // A fixed mask, so the block says nothing about the key it is hiding.
@@ -19,7 +20,7 @@ export default function Secret({ value }: { value: string }) {
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid="generator-ssh-private"
-          className={`min-w-0 flex-1 rounded-lg border border-line2 bg-field px-3 py-2 font-mono text-base leading-[1.55] break-all ${
+          className={`min-w-0 flex-1 ${wellClass} px-3 py-2 font-mono text-base leading-[1.55] break-all ${
             show ? 'max-h-40 overflow-auto whitespace-pre-wrap text-text' : 'text-text2'
           }`}
         >

--- a/src/components/Main/Generator/Ssh/index.tsx
+++ b/src/components/Main/Generator/Ssh/index.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import type { SshKeyPair } from '@/lib/commands'
 import Button from '@/components/elements/Button'
 import { MONO_LABEL } from '@/components/elements/tokens'
+import { inputClass, wellClass } from '@/components/elements/formStyles'
 import { cx } from '@/utils/cx'
 import Line from './Line'
 import Secret from './Secret'
@@ -28,7 +29,7 @@ export default function Ssh({ pair, pending, error, onRetry, comment, onComment 
       {error ? (
         <div
           data-testid="generator-ssh-error"
-          className="flex items-center gap-3 rounded-lg border border-line2 bg-field px-3 py-2.5"
+          className={`flex items-center gap-3 ${wellClass} px-3 py-2.5`}
         >
           <div className="flex-1 font-mono text-xs tracking-label text-bad">
             {t('Could not generate a key.')}
@@ -68,7 +69,7 @@ export default function Ssh({ pair, pending, error, onRetry, comment, onComment 
           placeholder="alice@laptop"
           data-testid="generator-ssh-comment"
           onChange={event => onComment(event.target.value)}
-          className="mt-1 block h-9 w-full rounded-lg border border-line2 bg-field px-3 font-mono text-base text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
+          className={`mt-1 block font-mono ${inputClass}`}
         />
       </div>
     </div>

--- a/src/components/Main/Header/index.tsx
+++ b/src/components/Main/Header/index.tsx
@@ -21,7 +21,7 @@ export default function Header() {
   return (
     <header
       data-tauri-drag-region="deep"
-      className="relative z-10 flex h-[38px] flex-none items-center gap-3.5 border-b border-line bg-[var(--chrome)] pl-[78px] pr-3 backdrop-blur-[14px]"
+      className="relative z-10 flex h-[38px] flex-none items-center gap-3.5 border-b border-line bg-chrome pl-[78px] pr-3 backdrop-blur-[14px]"
     >
       <Controls />
       <div className="flex-1" />

--- a/src/components/Main/Palette/CommandRow.tsx
+++ b/src/components/Main/Palette/CommandRow.tsx
@@ -1,5 +1,6 @@
 import Row from './Row'
 import type { Command } from './commands'
+import { MONO_META } from '@/components/elements/tokens'
 
 interface Props {
   id: string
@@ -25,7 +26,7 @@ export default function CommandRow({ id, command, focused, onRun, onHover }: Pro
       </span>
       <span className="min-w-0 flex-1 truncate text-base text-text2">{command.label}</span>
       {command.shortcut && (
-        <span className="flex-none font-mono text-xs text-text3">{command.shortcut}</span>
+        <span className={`flex-none ${MONO_META}`}>{command.shortcut}</span>
       )}
     </Row>
   )

--- a/src/components/Main/Palette/Input.tsx
+++ b/src/components/Main/Palette/Input.tsx
@@ -19,7 +19,7 @@ interface Props {
 export default function Input({ value, onChange, onKeyDown, listId, activeId }: Props) {
   const { t } = useTranslation()
   return (
-    <div className="flex items-center gap-[11px] px-4 py-3.5 shadow-[inset_0_-1px_0_var(--c-line)]">
+    <div className="flex items-center gap-[11px] px-4 py-3.5 inset-shadow-hairline">
       <SearchGlyph className="flex-none text-text3" />
       <input
         // The palette is mounted only while open, so this focuses on every open.

--- a/src/components/Main/Palette/Panel.tsx
+++ b/src/components/Main/Palette/Panel.tsx
@@ -60,7 +60,7 @@ export default function Panel() {
   return (
     <div
       onClick={closePalette}
-      className="fixed inset-0 z-50 flex items-start justify-center bg-scrim pt-[92px] backdrop-blur-[4px] animate-fade"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-scrim pt-[92px] backdrop-blur-xs animate-fade"
     >
       <div
         data-testid="command-palette"

--- a/src/components/Main/Palette/Panel.tsx
+++ b/src/components/Main/Palette/Panel.tsx
@@ -60,7 +60,7 @@ export default function Panel() {
   return (
     <div
       onClick={closePalette}
-      className="fixed inset-0 z-50 flex items-start justify-center bg-[var(--scrim)] pt-[92px] backdrop-blur-[4px] animate-fade"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-scrim pt-[92px] backdrop-blur-[4px] animate-fade"
     >
       <div
         data-testid="command-palette"
@@ -68,7 +68,7 @@ export default function Panel() {
         aria-modal="true"
         aria-label={t('Run a command')}
         onClick={e => e.stopPropagation()}
-        className="w-[620px] overflow-hidden rounded-xl border border-line2 bg-detail shadow-[var(--shadow)] animate-pop"
+        className="w-[620px] overflow-hidden rounded-xl border border-line2 bg-detail shadow-float animate-pop"
       >
         <Input
           value={query}

--- a/src/components/Main/Palette/Panel.tsx
+++ b/src/components/Main/Palette/Panel.tsx
@@ -68,7 +68,7 @@ export default function Panel() {
         aria-modal="true"
         aria-label={t('Run a command')}
         onClick={e => e.stopPropagation()}
-        className="w-[620px] overflow-hidden rounded-xl border border-line2 bg-detail shadow-float animate-pop"
+        className="w-dialog overflow-hidden rounded-xl border border-line2 bg-detail shadow-float animate-pop"
       >
         <Input
           value={query}

--- a/src/components/Main/Scan/Overlay.tsx
+++ b/src/components/Main/Scan/Overlay.tsx
@@ -12,7 +12,7 @@ export default function Overlay() {
     <div
       data-testid="scan-overlay"
       aria-hidden
-      className="animate-fade pointer-events-none fixed inset-0 z-[1100] grid place-items-center bg-[var(--scrim)] backdrop-blur-sm"
+      className="animate-fade pointer-events-none fixed inset-0 z-[1100] grid place-items-center bg-scrim backdrop-blur-sm"
     >
       <div className="m-6 flex flex-col items-center gap-3 rounded-xl border border-dashed border-accent-line px-10 py-9 text-center">
         <span className="grid h-12 w-12 place-items-center rounded-lg bg-accent-soft text-accent">

--- a/src/components/Main/Scan/Overlay.tsx
+++ b/src/components/Main/Scan/Overlay.tsx
@@ -21,7 +21,7 @@ export default function Overlay() {
         <strong className="text-lg font-semibold tracking-display">
           {t('Drop to scan the card or document')}
         </strong>
-        <span className="max-w-[320px] text-base text-text2">
+        <span className="max-w-xs text-base text-text2">
           {t('Read on this device. The image is never copied or uploaded.')}
         </span>
       </div>

--- a/src/components/Main/Sidebar/Settings/Footer.tsx
+++ b/src/components/Main/Sidebar/Settings/Footer.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useStore } from '@/store'
 import { APP_NAME } from '@/lib/app'
 import { useVaultMeta, vaultHome } from '@/hooks/useAuthMeta'
+import { MONO_META } from '@/components/elements/tokens'
 
 // Version and update state, pinned under the nav. The status line doubles as the
 // "check for updates" control — there is no separate Updates section any more.
@@ -20,7 +21,7 @@ export default function Footer() {
         : t('up to date')
 
   return (
-    <div className="mt-4 flex flex-col items-start gap-0.5 font-mono text-xs text-text3">
+    <div className={`mt-4 flex flex-col items-start gap-0.5 ${MONO_META}`}>
       <div data-testid="settings-version">
         {meta?.version ? `${APP_NAME} ${meta.version}` : APP_NAME}
       </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
@@ -1,4 +1,5 @@
 import { pct } from './useProgress'
+import { MONO_META } from '@/components/elements/tokens'
 
 interface Props {
   done: number
@@ -15,7 +16,7 @@ export default function Progress({ done, total }: Props) {
           style={{ width: `${pct(done, total)}%` }}
         />
       </div>
-      <span className="font-mono text-xs text-text3">
+      <span className={MONO_META}>
         {done} / {total}
       </span>
     </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
@@ -12,7 +12,7 @@ export default function Progress({ done, total }: Props) {
     <div className="flex items-center gap-3">
       <div className="h-2 flex-1 overflow-hidden rounded-full bg-tile">
         <div
-          className="h-full rounded-full bg-accent transition-[width] duration-200"
+          className="h-full rounded-full bg-accent transition-[width] duration-300"
           style={{ width: `${pct(done, total)}%` }}
         />
       </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Result.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Result.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/components/elements/Button'
 import { inputClass } from '@/components/elements/formStyles'
-import { CARD } from '@/components/elements/tokens'
+import { CARD, MONO_META } from '@/components/elements/tokens'
 import Progress from './Progress'
 import RowErrors from './RowErrors'
 import type { useImport } from './useImport'
@@ -20,7 +20,7 @@ export default function Result({ flow }: { flow: ReturnType<typeof useImport> })
 
   return (
     <div className={`${CARD} flex flex-col gap-3 p-4`} data-testid="import-result">
-      <div className="font-mono text-xs text-text3">{fileName(picked.path)}</div>
+      <div className={MONO_META}>{fileName(picked.path)}</div>
 
       {picked.kind === 'swftx' ? (
         <div className="flex flex-wrap items-center gap-3">

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Tiles.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Tiles.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { cx } from '@/utils/cx'
 import type { TKey } from '@/i18n'
 import type { ImportFormat } from '@/lib/commands'
-import { CARD } from '@/components/elements/tokens'
+import { CARD, MONO_META } from '@/components/elements/tokens'
 
 // One tile per source. `format` absent means the Swifty backup tile, which goes
 // through its own picker and password.
@@ -57,7 +57,7 @@ export default function Tiles({ active, disabled, onFormat, onBackup }: Props) {
             {tile.badge}
           </div>
           <div className="mt-3 truncate text-base text-text">{t(tile.name)}</div>
-          <div className="mt-0.5 font-mono text-xs text-text3">{t(tile.hint)}</div>
+          <div className={`mt-0.5 ${MONO_META}`}>{t(tile.hint)}</div>
         </button>
       ))}
     </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Security/GeneratorGroup.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Security/GeneratorGroup.tsx
@@ -6,6 +6,7 @@ import { LENGTH_RANGE } from '@/services/generator'
 import SettingsGroup from '@/components/elements/SettingsGroup'
 import SettingsRow from '@/components/elements/SettingsRow'
 import Toggle from '@/components/elements/Toggle'
+import { MONO_META } from '@/components/elements/tokens'
 
 // The seed values for every new password, shared with the ⌘G generator dialog.
 // `uppercase` stays out of the UI — the dialog always draws from both cases —
@@ -36,7 +37,7 @@ export default function GeneratorGroup() {
               data-testid="settings-generator-length"
               onChange={e => update({ length: Number(e.target.value) })}
             />
-            <span className="w-[68px] flex-none text-right font-mono text-xs text-text3">
+            <span className={`w-[68px] flex-none text-right ${MONO_META}`}>
               {options.length} {t('chars')}
             </span>
           </div>

--- a/src/components/Main/Sidebar/Settings/SettingsModal.tsx
+++ b/src/components/Main/Sidebar/Settings/SettingsModal.tsx
@@ -20,7 +20,7 @@ export default function SettingsModal() {
   return (
     <Modal
       onClose={closeSettings}
-      className="h-[600px] w-[860px]"
+      className="h-[600px] w-sheet"
       labelledBy={TITLE_ID}
       testid="settings-modal"
       hideClose

--- a/src/components/Main/Sidebar/Tags/Menu.tsx
+++ b/src/components/Main/Sidebar/Tags/Menu.tsx
@@ -24,7 +24,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
         {tags.length === 0 ? (
           <div className="px-3.5 py-2.5" data-testid="tags-empty">
             <div className="text-base text-text2">{t('No tags yet')}</div>
-            <div className="mt-1 text-sm text-text3">
+            <div className="mt-1 text-xs text-text3">
               {t('Add tags to an entry and they show up here.')}
             </div>
           </div>

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -34,7 +34,7 @@ export function Main() {
           auto margins so the pop's transform doesn't fight it. */}
       <div
         data-testid="copy-toast"
-        className="copied-notification hidden animate-pop fixed inset-x-0 top-4 z-50 mx-auto w-max rounded-full bg-text px-5 py-2 text-base text-detail shadow-[var(--shadow)]"
+        className="copied-notification hidden animate-pop fixed inset-x-0 top-4 z-50 mx-auto w-max rounded-full bg-text px-5 py-2 text-base text-detail shadow-float"
       >
         {t('Copied to Clipboard')}
       </div>

--- a/src/components/elements/AuthShell.tsx
+++ b/src/components/elements/AuthShell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthMeta } from '@/hooks/useAuthMeta'
 import Back from '@/assets/images/back.svg?react'
+import { MONO_LABEL } from './tokens'
 
 interface Props {
   children: ReactNode
@@ -46,7 +47,7 @@ export default function AuthShell({ children, onBack }: Props) {
           type="button"
           data-testid="go-back-button"
           onClick={onBack}
-          className="absolute bottom-14 left-1/2 flex -translate-x-1/2 items-center gap-1.5 border-0 bg-transparent font-mono text-xs uppercase tracking-label text-text3 transition-colors hover:text-text"
+          className={`absolute bottom-14 left-1/2 flex -translate-x-1/2 items-center gap-1.5 border-0 bg-transparent ${MONO_LABEL} transition-colors hover:text-text`}
         >
           <Back width="13" className="[&_path]:fill-current" />
           {t('Go Back')}

--- a/src/components/elements/AuthShell.tsx
+++ b/src/components/elements/AuthShell.tsx
@@ -56,7 +56,7 @@ export default function AuthShell({ children, onBack }: Props) {
 
       {meta && (
         // A tier below text-xs on purpose: footer chrome, not content.
-        <div className="absolute inset-x-0 bottom-0 flex h-13 items-center justify-center font-mono text-[10px] uppercase tracking-label text-text3">
+        <div className="absolute inset-x-0 bottom-0 flex h-13 items-center justify-center font-mono text-2xs uppercase tracking-label text-text3">
           {meta}
         </div>
       )}

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -77,7 +77,7 @@ export default function Button({
       {/* A chip rather than dimmed text: on an accent fill, opacity is the one
           thing that makes the hint disappear. */}
       {kbd && (
-        <span className="flex-none rounded-[4px] bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 font-mono text-[11px] leading-4">
+        <span className="flex-none rounded-[4px] bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 font-mono text-xs leading-4">
           {kbd}
         </span>
       )}

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -77,7 +77,7 @@ export default function Button({
       {/* A chip rather than dimmed text: on an accent fill, opacity is the one
           thing that makes the hint disappear. */}
       {kbd && (
-        <span className="flex-none rounded-[4px] bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 font-mono text-xs leading-4">
+        <span className="flex-none rounded-xs bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 font-mono text-xs leading-4">
           {kbd}
         </span>
       )}

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -32,13 +32,15 @@ const sizes: Record<Size, string> = {
 
 const blockStyle = 'w-full px-5 py-3 font-mono uppercase tracking-label'
 
+// The solid-fill treatment: light ink, a 1px top highlight, and a hover that
+// brightens the fill itself since there is no border or ground to swap.
+const filled = 'text-accent-fg shadow-[inset_0_1px_0_rgba(255,255,255,0.16)] hover:brightness-[1.09]'
+
 const variants: Record<Variant, string> = {
-  primary:
-    'bg-accent text-accent-fg shadow-[inset_0_1px_0_rgba(255,255,255,0.16)] hover:brightness-[1.09]',
+  primary: `bg-accent ${filled}`,
   ghost: 'border border-line bg-tile text-text hover:bg-hover',
   pale: 'border border-line2 bg-field text-text2 hover:border-accent-line hover:text-text',
-  danger:
-    'bg-bad text-accent-fg shadow-[inset_0_1px_0_rgba(255,255,255,0.16)] hover:brightness-[1.09]'
+  danger: `bg-bad ${filled}`
 }
 
 // Shared token-styled button. Serves both the full-width auth CTAs (`block`) and

--- a/src/components/elements/Dropdown.tsx
+++ b/src/components/elements/Dropdown.tsx
@@ -60,7 +60,7 @@ export function Dropdown({ onBlur, className, children }: DropdownProps) {
         role="menu"
         onKeyDown={onKeyDown}
         className={cx(
-          'animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-[var(--shadow)]',
+          'animate-pop absolute z-20 min-w-[180px] overflow-hidden rounded-xl border border-line2 bg-detail py-1 text-text shadow-float',
           className
         )}
       >

--- a/src/components/elements/EmptyState.tsx
+++ b/src/components/elements/EmptyState.tsx
@@ -75,7 +75,7 @@ export default function EmptyState({
   return (
     <div
       data-testid={testid}
-      className="flex max-w-[320px] flex-col items-center gap-5 text-center animate-pop"
+      className="flex max-w-xs flex-col items-center gap-5 text-center animate-pop"
     >
       <div
         className={cx(

--- a/src/components/elements/EmptyState.tsx
+++ b/src/components/elements/EmptyState.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import Button from './Button'
 import Kbd from './Kbd'
+import { MONO_META } from './tokens'
 
 interface Action {
   label: string
@@ -125,7 +126,7 @@ export default function EmptyState({
             {hints.map(hint => (
               <span key={hint.keys} className="flex items-center gap-1.5">
                 <Kbd>{hint.keys}</Kbd>
-                <span className="font-mono text-xs text-text3">{hint.label}</span>
+                <span className={MONO_META}>{hint.label}</span>
               </span>
             ))}
           </div>

--- a/src/components/elements/Kbd.tsx
+++ b/src/components/elements/Kbd.tsx
@@ -5,7 +5,7 @@ import { MONO_META } from './tokens'
 // inside a filled primary Button use its `kbd` prop instead (borderless).
 export default function Kbd({ children }: { children: ReactNode }) {
   return (
-    <span className={`flex-none rounded-sm border border-line px-[5px] py-px ${MONO_META}`}>
+    <span className={`flex-none rounded-xs border border-line px-[5px] py-px ${MONO_META}`}>
       {children}
     </span>
   )

--- a/src/components/elements/Kbd.tsx
+++ b/src/components/elements/Kbd.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from 'react'
+import { MONO_META } from './tokens'
 
 // Keyboard-hint chip (⌘K, ⏎, esc). Bordered mono micro text on any surface;
 // inside a filled primary Button use its `kbd` prop instead (borderless).
 export default function Kbd({ children }: { children: ReactNode }) {
   return (
-    <span className="flex-none rounded-sm border border-line px-[5px] py-px font-mono text-xs text-text3">
+    <span className={`flex-none rounded-sm border border-line px-[5px] py-px ${MONO_META}`}>
       {children}
     </span>
   )

--- a/src/components/elements/Mascot.tsx
+++ b/src/components/elements/Mascot.tsx
@@ -39,7 +39,7 @@ function Mascot({
   // tints for the verdict, then the eye shapes carry the expression.
   const fill = ok ? 'var(--c-good)' : bad ? 'var(--c-bad)' : color
   const bodyAnim = ok
-    ? 'animate-[cheer_780ms_cubic-bezier(0.2,0.8,0.2,1)_both]'
+    ? 'animate-[cheer_780ms_var(--ease-swift)_both]'
     : bad
       ? 'animate-[deny_540ms_ease_both]'
       : undefined

--- a/src/components/elements/Masterpass/Dots.tsx
+++ b/src/components/elements/Masterpass/Dots.tsx
@@ -48,7 +48,7 @@ export default function Dots({
           <span
             key={i}
             className={cx(
-              'animate-fade flex flex-none items-center justify-center rounded-[3px]',
+              'animate-fade flex flex-none items-center justify-center rounded-xs',
               i >= start && i < end && 'bg-accent-soft'
             )}
             style={{ width: CELL }}

--- a/src/components/elements/Masterpass/Dots.tsx
+++ b/src/components/elements/Masterpass/Dots.tsx
@@ -57,7 +57,7 @@ export default function Dots({
               className={cx(
                 busy && 'animate-[dotwave_1.05s_ease-in-out_infinite]',
                 text === undefined
-                  ? 'h-[7px] w-[7px] rounded-full bg-text/75'
+                  ? 'h-1.5 w-1.5 rounded-full bg-text/75'
                   : 'text-md text-text'
               )}
               style={busy ? WAVE_DELAYS[i % WAVE_DELAYS.length] : undefined}

--- a/src/components/elements/Masterpass/Dots.tsx
+++ b/src/components/elements/Masterpass/Dots.tsx
@@ -58,7 +58,7 @@ export default function Dots({
                 busy && 'animate-[dotwave_1.05s_ease-in-out_infinite]',
                 text === undefined
                   ? 'h-[7px] w-[7px] rounded-full bg-text/75'
-                  : 'text-[15px] text-text'
+                  : 'text-md text-text'
               )}
               style={busy ? WAVE_DELAYS[i % WAVE_DELAYS.length] : undefined}
             >

--- a/src/components/elements/Masterpass/KeyCuts.tsx
+++ b/src/components/elements/Masterpass/KeyCuts.tsx
@@ -29,11 +29,13 @@ export default function KeyCuts({ count, tone = 'idle' }: Props) {
         )}
       />
       <div className="absolute inset-x-0 top-px flex justify-center">
+        {/* 5 + 6 rather than 5.5 each side: the same 12px pitch, but every 1px
+            bar starts on a whole pixel instead of straddling two. */}
         {Array.from({ length: bars }).map((_, i) => (
           <span
             key={i}
             className={cx(
-              'mx-[5.5px] w-px rounded-b-sm transition-all duration-300',
+              'ml-[5px] mr-[6px] w-px rounded-b-sm transition-all duration-300',
               bar
             )}
             style={{ height: HEIGHTS[i % HEIGHTS.length] }}

--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -137,7 +137,7 @@ export default function Masterpass({
         // are both drawn by the cell overlay (see Dots) so they share one
         // geometry, including the selection wash. Only the placeholder renders
         // from here (15px, muted ink).
-        'absolute inset-0 w-full border-0 bg-transparent text-center font-sans text-[15px] tracking-secret text-transparent caret-transparent outline-none selection:bg-transparent placeholder:text-text3',
+        'absolute inset-0 w-full border-0 bg-transparent text-center font-sans text-md tracking-secret text-transparent caret-transparent outline-none selection:bg-transparent placeholder:text-text3',
         lock && 'rounded-xl px-10'
       )}
       placeholder={placeholder || t('Master Password')}

--- a/src/components/elements/Masterpass/index.tsx
+++ b/src/components/elements/Masterpass/index.tsx
@@ -201,7 +201,7 @@ export default function Masterpass({
           'relative mx-auto flex h-12 max-w-[380px] items-stretch rounded-xl border bg-detail transition-all duration-300 [&_button:hover]:bg-hover/60!',
           // The inset shadow is the cut; focus goes a touch deeper. It and the
           // state halo (ring) are both box-shadow, so Tailwind composes them.
-          'shadow-[var(--lockfield-shadow)] focus-within:shadow-[var(--lockfield-shadow-deep)]',
+          'shadow-lockfield focus-within:shadow-lockfield-deep',
           bad
             ? 'border-bad/60 ring-4 ring-bad/10 animate-[nudge_420ms_ease_both]'
             : success

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import { CloseGlyph } from '../Main/icons'
+import IconButton from './IconButton'
 
 const TABBABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
@@ -86,14 +87,14 @@ export default function Modal({
         onClick={e => e.stopPropagation()}
       >
         {!hideClose && (
-          <button
-            type="button"
-            data-testid="modal-close"
+          <IconButton
+            muted
+            testid="modal-close"
             onClick={onClose}
-            className="absolute right-3 top-3 z-10 grid h-7 w-7 cursor-pointer place-items-center rounded-sm text-text3 transition-colors hover:bg-hover hover:text-text"
+            className="absolute right-3 top-3 z-10"
           >
             <CloseGlyph />
-          </button>
+          </IconButton>
         )}
         {children}
       </div>

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -69,7 +69,7 @@ export default function Modal({
 
   return (
     <div
-      className="animate-fade fixed inset-0 z-50 flex items-start justify-center bg-[var(--scrim)] p-4 pt-[10vh] backdrop-blur-sm"
+      className="animate-fade fixed inset-0 z-50 flex items-start justify-center bg-scrim p-4 pt-[10vh] backdrop-blur-sm"
       onClick={onClose}
     >
       <div
@@ -80,7 +80,7 @@ export default function Modal({
         aria-labelledby={labelledBy}
         data-testid={testid}
         className={cx(
-          'animate-pop relative flex max-h-[80vh] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-[var(--shadow)]',
+          'animate-pop relative flex max-h-[80vh] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float',
           className ?? 'w-full max-w-[720px]'
         )}
         onClick={e => e.stopPropagation()}

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -8,7 +8,7 @@ const TABBABLE =
 
 interface Props {
   onClose: () => void
-  // Replaces the card's default sizing (`w-full max-w-[720px]`) rather than
+  // Replaces the card's default sizing (`w-full max-w-dialog-lg`) rather than
   // adding to it, so a narrower dialog does not fight the default width.
   className?: string
   // id of the element that names the dialog, for `aria-labelledby`.
@@ -82,7 +82,7 @@ export default function Modal({
         data-testid={testid}
         className={cx(
           'animate-pop relative flex max-h-[80vh] overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float',
-          className ?? 'w-full max-w-[720px]'
+          className ?? 'w-full max-w-dialog-lg'
         )}
         onClick={e => e.stopPropagation()}
       >

--- a/src/components/elements/PasswordStrength.tsx
+++ b/src/components/elements/PasswordStrength.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import { MIN_LENGTH } from '@/services/strength'
 import { useStrength } from '@/hooks/useStrength'
+import { MONO_META } from './tokens'
 
 const LABELS: TKey[] = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
@@ -42,7 +43,7 @@ export default function PasswordStrength({ password }: Props) {
           />
         ))}
       </div>
-      <div className="mt-1.5 flex justify-between gap-2 font-mono text-xs text-text3">
+      <div className={`mt-1.5 flex justify-between gap-2 ${MONO_META}`}>
         <span data-testid="password-strength-label">
           {score !== null ? t(LABELS[score]) : ''}
         </span>

--- a/src/components/elements/RadioList.tsx
+++ b/src/components/elements/RadioList.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@/utils/cx'
 import { useRadioNav } from '@/hooks/useRadioNav'
-import { CARD, ROW_HAIRLINE } from './tokens'
+import { CARD, MONO_META, ROW_HAIRLINE } from './tokens'
 
 interface Props {
   options: { value: string; label: string; meta?: string }[]
@@ -64,7 +64,7 @@ export default function RadioList({
             </span>
             <span className="min-w-0 flex-1 truncate text-base text-text">{option.label}</span>
             {option.meta && (
-              <span className="flex-none font-mono text-xs text-text3">{option.meta}</span>
+              <span className={`flex-none ${MONO_META}`}>{option.meta}</span>
             )}
           </button>
         )

--- a/src/components/elements/StrengthBar.tsx
+++ b/src/components/elements/StrengthBar.tsx
@@ -2,6 +2,7 @@ import { useStrength } from '@/hooks/useStrength'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import Meter from './Meter'
+import { MONO_META } from './tokens'
 
 const STRENGTH_LABELS: TKey[] = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
@@ -13,7 +14,7 @@ export default function StrengthBar({ password }: { password: string }) {
   return (
     <div className="flex items-center gap-2.5">
       <Meter level={score} />
-      <span className="font-mono text-xs text-text3">
+      <span className={MONO_META}>
         {score !== null ? t(STRENGTH_LABELS[score]) : ''}
       </span>
     </div>

--- a/src/components/elements/Tooltip.tsx
+++ b/src/components/elements/Tooltip.tsx
@@ -33,7 +33,7 @@ export default function Tooltip({ content, children, align = 'center' }: Props) 
         role="tooltip"
         aria-hidden="true"
         className={cx(
-          'pointer-events-none absolute top-full z-50 mt-2 w-max whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-base text-detail opacity-0 shadow-[var(--shadow)] transition-opacity delay-0 group-hover/tt:animate-pop group-hover/tt:opacity-100 group-hover/tt:delay-300 group-hover/tt:[animation-delay:300ms] group-focus-within/tt:animate-pop group-focus-within/tt:opacity-100 group-focus-within/tt:delay-300 group-focus-within/tt:[animation-delay:300ms]',
+          'pointer-events-none absolute top-full z-50 mt-2 w-max whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-base text-detail opacity-0 shadow-float transition-opacity delay-0 group-hover/tt:animate-pop group-hover/tt:opacity-100 group-hover/tt:delay-300 group-hover/tt:[animation-delay:300ms] group-focus-within/tt:animate-pop group-focus-within/tt:opacity-100 group-focus-within/tt:delay-300 group-focus-within/tt:[animation-delay:300ms]',
           align === 'end' ? 'right-0' : 'inset-x-0 mx-auto'
         )}
       >

--- a/src/components/elements/Tooltip.tsx
+++ b/src/components/elements/Tooltip.tsx
@@ -33,7 +33,7 @@ export default function Tooltip({ content, children, align = 'center' }: Props) 
         role="tooltip"
         aria-hidden="true"
         className={cx(
-          'pointer-events-none absolute top-full z-50 mt-2 w-max whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-base text-detail opacity-0 shadow-[var(--shadow)] transition-opacity delay-0 duration-150 group-hover/tt:animate-pop group-hover/tt:opacity-100 group-hover/tt:delay-300 group-hover/tt:[animation-delay:300ms] group-focus-within/tt:animate-pop group-focus-within/tt:opacity-100 group-focus-within/tt:delay-300 group-focus-within/tt:[animation-delay:300ms]',
+          'pointer-events-none absolute top-full z-50 mt-2 w-max whitespace-nowrap rounded-sm bg-text px-2.5 py-1 text-base text-detail opacity-0 shadow-[var(--shadow)] transition-opacity delay-0 group-hover/tt:animate-pop group-hover/tt:opacity-100 group-hover/tt:delay-300 group-hover/tt:[animation-delay:300ms] group-focus-within/tt:animate-pop group-focus-within/tt:opacity-100 group-focus-within/tt:delay-300 group-focus-within/tt:[animation-delay:300ms]',
           align === 'end' ? 'right-0' : 'inset-x-0 mx-auto'
         )}
       >

--- a/src/components/elements/fields/Otp/Dial.tsx
+++ b/src/components/elements/fields/Otp/Dial.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { OTP_PERIOD } from '@/hooks/useOtp'
+import { MONO_META } from '../../tokens'
 
 const R = 48
 const CIRCUMFERENCE = 2 * Math.PI * R // ≈ 301
@@ -33,7 +34,7 @@ export default function Dial({ code, time }: { code: string; time: number }) {
           {`${code.slice(0, 3)} ${code.slice(3)}`}
         </div>
       </div>
-      <div className="font-mono text-xs text-text3">
+      <div className={MONO_META}>
         {t('refreshes in {{n}}s', { n: time })}
       </div>
     </>

--- a/src/components/elements/fields/Passkeys/Row.tsx
+++ b/src/components/elements/fields/Passkeys/Row.tsx
@@ -4,7 +4,7 @@ import { cx } from '@/utils/cx'
 import { shortDate, toTime } from '@/utils/time'
 import { KeyGlyph, TrashGlyph } from '../../../Main/icons'
 import IconButton from '../../IconButton'
-import { ROW_HAIRLINE } from '../../tokens'
+import { MONO_META, ROW_HAIRLINE } from '../../tokens'
 
 interface Props {
   passkey: Passkey
@@ -34,7 +34,7 @@ export default function PasskeyRow({ passkey, onRemove }: Props) {
         <div className="truncate text-base text-text">
           {passkey.rpName || passkey.rpId}
         </div>
-        <div className="mt-0.5 truncate font-mono text-xs text-text3">
+        <div className={`mt-0.5 truncate ${MONO_META}`}>
           {passkey.userName}
           {created !== null &&
             ` · ${t('Created {{time}}', { time: shortDate(created) })}`}

--- a/src/components/elements/fields/PasswordField.tsx
+++ b/src/components/elements/fields/PasswordField.tsx
@@ -8,6 +8,7 @@ import IconButton from '../IconButton'
 import StrengthBar from '../StrengthBar'
 import Field from './Field'
 import { useField, useFields } from './context'
+import { MONO_META } from '../tokens'
 
 // How long this password has been in place. `now` reads as "just now" rather
 // than "changed now ago", and past a week — where the duration runs out — the
@@ -61,7 +62,7 @@ export default function PasswordField({
           <>
             <StrengthBar password={value} />
             {/* A sentence about the password, not a label for one. */}
-            {stamp && <span className="font-mono text-xs text-text3">{stamp}</span>}
+            {stamp && <span className={MONO_META}>{stamp}</span>}
           </>
         )
       }

--- a/src/components/elements/formStyles.ts
+++ b/src/components/elements/formStyles.ts
@@ -8,3 +8,8 @@ const controlBase =
 export const inputClass = `${controlBase} h-9`
 
 export const selectClass = `${controlBase} h-9 appearance-none pr-9`
+
+// A read-only well on the field surface (generated output, key material, an
+// inline error row): the input's edge and ground at the tile radius, with no
+// control sizing — the caller sets padding and type.
+export const wellClass = 'rounded-lg border border-line2 bg-field'

--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -1,6 +1,6 @@
-export const CARD = 'overflow-hidden rounded-lg border border-line bg-[image:var(--card)]'
+export const CARD = 'overflow-hidden rounded-lg border border-line bg-card'
 
-export const ROW_HAIRLINE = 'shadow-[inset_0_-1px_0_var(--c-line)] last:shadow-none'
+export const ROW_HAIRLINE = 'inset-shadow-hairline last:inset-shadow-none'
 
 // A trailing control that stays out of the way until the row is asked about —
 // hovered, or holding the keyboard. Pairs with a `group` on the row itself.
@@ -12,7 +12,7 @@ export const HOVER_ONLY =
 // panel on the detail surface. Each toast places itself — two of them in the
 // same corner would sit on top of each other.
 export const TOAST =
-  'animate-pop fixed z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-[var(--shadow)]'
+  'animate-pop fixed z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-float'
 
 // The mono micro-label face, without an ink. Take this when the label needs a
 // different colour (the accent "EDITING ·" eyebrow) and MONO_LABEL otherwise.

--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -19,3 +19,8 @@ export const TOAST =
 export const MONO_TYPE = 'font-mono text-xs uppercase tracking-label'
 
 export const MONO_LABEL = `${MONO_TYPE} text-text3`
+
+// The mono meta face: counts, timestamps, hints, shortcuts — the same 11px mono
+// as the label tier, muted, but set as ordinary text rather than a tracked
+// uppercase eyebrow.
+export const MONO_META = 'font-mono text-xs text-text3'

--- a/src/kinds/card/Fields/Value.tsx
+++ b/src/kinds/card/Fields/Value.tsx
@@ -88,7 +88,7 @@ export default function Value({
   const { copied, copy } = useCopied()
 
   const caption = label && (
-    <span className="block text-[11px] uppercase tracking-[0.12em] opacity-50">{t(label)}</span>
+    <span className="block text-[11px] uppercase tracking-label opacity-50">{t(label)}</span>
   )
 
   if (set) {

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -68,7 +68,7 @@ export default function Fields() {
           {hasBrandMark(brand) ? (
             <CardBrandMark brand={brand} size={22} tone="light" />
           ) : (
-            <div className="h-7 w-[40px] flex-none rounded-[4px] border border-white/15 bg-white/10" />
+            <div className="h-7 w-[40px] flex-none rounded-xs border border-white/15 bg-white/10" />
           )}
         </div>
 

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -45,8 +45,9 @@ export default function Fields() {
       className={aside ? 'grid grid-cols-[460px_minmax(0,1fr)] items-start gap-3' : undefined}
     >
       {/* Card art: an always-dark plastic-card visual, deliberately off-system.
-          Its gradient, hex inks, 16/4px radii and face letter-spacings imitate a
-          real card, so they are exempt from the type/radius/tracking scales. */}
+          Its gradient, hex inks, 16/4px radii, unleaded type sizes and the
+          number's wide letter-spacing imitate a real card, so they are exempt
+          from the type/radius/tracking scales. */}
       <div className="relative flex h-[288px] w-[460px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_12px_28px_rgba(0,0,0,0.22)]">
         <div className="absolute -right-10 -top-16 h-[240px] w-[240px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
 
@@ -60,7 +61,7 @@ export default function Fields() {
             testid="entry-value-name"
             placeholder="Cardholder"
             maxLength={40}
-            ink="text-[13px] uppercase tracking-[0.12em] opacity-90"
+            ink="text-[13px] uppercase tracking-label opacity-90"
             zone="top"
             className="-mx-1.5 flex-1"
           />
@@ -117,7 +118,7 @@ export default function Fields() {
             ink="text-[13px]"
             flag={
               expired && (
-                <span className="flex-none text-[10px] uppercase tracking-[0.12em] text-[#FF8A8A]">
+                <span className="flex-none text-[10px] uppercase tracking-label text-[#FF8A8A]">
                   {t('Expired')}
                 </span>
               )

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -255,7 +255,6 @@
   --color-good: var(--c-good);
   --color-warn: var(--c-warn);
   --color-bad: var(--c-bad);
-  --color-accent-deep: var(--c-accent-deep);
   --color-touchid: var(--c-touchid);
   --color-brand: var(--c-brand);
 
@@ -408,9 +407,6 @@
   --c-bad: #c9453a;
   /* The macOS Touch ID fingerprint rose (biometric affordances). */
   --c-touchid: #ee5d6f;
-  /* Deep end of the brand gradient; same in both themes (it sits under the
-   * accent, which does adapt). */
-  --c-accent-deep: #2b3a8f;
   /* The brand asterisk's ink (mascot body + rail mark) and the paper its eyes
    * are cut from. Graphite on light ground; flips to chalk on dark. */
   --c-brand: #34373e;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -297,9 +297,11 @@
  * exist: an off-scale class (`text-sm`, `rounded-md`, `tracking-wide`, ...)
  * simply doesn't compile, which keeps the system honest.
  *
- *   Type      xs 11px mono micro (labels/meta/counts/kbd)
+ *   Type      2xs 10px footer chrome (a tier below content)
+ *             xs 11px mono micro (labels/meta/counts/kbd)
  *             base 13px everything readable — hierarchy via weight + ink
- *             lg 16 / xl 20 / 2xl 24 display tiers
+ *             md 15px the passphrase field and its mask
+ *             lg 16 / xl 20 / 2xl 24 display tiers · 3xl 34 the vault score
  *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
  *             secret .08em (revealed secrets, card numbers, TOTP)
  *   Radius    sm 8 controls · lg 12 tiles & cards · xl 14 overlays
@@ -307,16 +309,22 @@
  */
 @theme {
   --text-*: initial;
+  --text-2xs: 10px;
+  --text-2xs--line-height: 1.3;
   --text-xs: 11px;
   --text-xs--line-height: 1.35;
   --text-base: 13px;
   --text-base--line-height: 1.45;
+  --text-md: 15px;
+  --text-md--line-height: 1.4;
   --text-lg: 16px;
   --text-lg--line-height: 1.3;
   --text-xl: 20px;
   --text-xl--line-height: 1.25;
   --text-2xl: 24px;
   --text-2xl--line-height: 1.2;
+  --text-3xl: 34px;
+  --text-3xl--line-height: 1.15;
 
   --tracking-*: initial;
   --tracking-label: 0.12em;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -304,7 +304,7 @@
  *             lg 16 / xl 20 / 2xl 24 display tiers · 3xl 34 the vault score
  *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
  *             secret .08em (revealed secrets, card numbers, TOTP)
- *   Radius    sm 8 controls · lg 12 tiles & cards · xl 14 overlays
+ *   Radius    xs 4 chips & inlays · sm 8 controls · lg 12 tiles & cards · xl 14 overlays
  *   Motion    one duration (160ms), one easing, three shapes (fade/pop/sheet)
  */
 @theme {
@@ -332,6 +332,7 @@
   --tracking-secret: 0.08em;
 
   --radius-*: initial;
+  --radius-xs: 4px;
   --radius-sm: 8px;
   --radius-lg: 12px;
   --radius-xl: 14px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -305,7 +305,9 @@
  *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
  *             secret .08em (revealed secrets, card numbers, TOTP)
  *   Radius    xs 4 chips & inlays · sm 8 controls · lg 12 tiles & cards · xl 14 overlays
- *   Motion    one duration (160ms), one easing, three shapes (fade/pop/sheet)
+ *   Motion    one duration (160ms) — plus a 300ms slow tier for sweeps that
+ *             should be seen moving (the lock field, a progress bar) —
+ *             one easing (ease-swift), three shapes (fade/pop/sheet)
  */
 @theme {
   --text-*: initial;
@@ -337,12 +339,13 @@
   --radius-lg: 12px;
   --radius-xl: 14px;
 
+  --ease-swift: cubic-bezier(0.2, 0.8, 0.2, 1);
   --default-transition-duration: 160ms;
-  --default-transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --default-transition-timing-function: var(--ease-swift);
 
-  --animate-fade: fade 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
-  --animate-pop: pop 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
-  --animate-sheet: sheet 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  --animate-fade: fade 160ms var(--ease-swift) both;
+  --animate-pop: pop 160ms var(--ease-swift) both;
+  --animate-sheet: sheet 160ms var(--ease-swift) both;
 }
 
 /*

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -305,6 +305,9 @@
  *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
  *             secret .08em (revealed secrets, card numbers, TOTP)
  *   Radius    xs 4 chips & inlays · sm 8 controls · lg 12 tiles & cards · xl 14 overlays
+ *   Width     dialog-sm 470 (generator) · dialog 640 (pickers: add, palette)
+ *             dialog-lg 720 (the Modal default) · sheet 860 (settings, the
+ *             entry detail column) — on top of Tailwind's rem container scale
  *   Motion    one duration (160ms) — plus a 300ms slow tier for sweeps that
  *             should be seen moving (the lock field, a progress bar) —
  *             one easing (ease-swift), three shapes (fade/pop/sheet)
@@ -338,6 +341,11 @@
   --radius-sm: 8px;
   --radius-lg: 12px;
   --radius-xl: 14px;
+
+  --container-dialog-sm: 470px;
+  --container-dialog: 640px;
+  --container-dialog-lg: 720px;
+  --container-sheet: 860px;
 
   --ease-swift: cubic-bezier(0.2, 0.8, 0.2, 1);
   --default-transition-duration: 160ms;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -259,6 +259,21 @@
   --color-brand: var(--c-brand);
 
   /*
+   * Surfaces and shadows that are more than a flat colour (see the design vars
+   * on :root below). Named here so `bg-scrim`, `bg-chrome`, `bg-card`,
+   * `shadow-float`, `shadow-lockfield` and `inset-shadow-hairline` compile
+   * instead of every call site spelling out `bg-[var(--scrim)]`.
+   */
+  --color-scrim: var(--scrim);
+  --color-chrome: var(--chrome);
+  --background-image-card: var(--card);
+  --shadow-float: var(--shadow);
+  --shadow-lockfield: var(--lockfield-shadow);
+  --shadow-lockfield-deep: var(--lockfield-shadow-deep);
+  /* The 1px rule under a list row, drawn as a shadow so it costs no layout. */
+  --inset-shadow-hairline: inset 0 -1px 0 var(--c-line);
+
+  /*
    * Per-kind identity inks (see src/kinds). A solid for the glyph and a soft
    * wash for the tile behind it, so `text-kind-card` / `bg-kind-card-soft`
    * compile. One pair per kind in `KINDS` — a new kind adds a new pair here
@@ -424,7 +439,7 @@
   --c-kind-ssh: #7b5ea7;
   --c-kind-ssh-soft: rgba(123, 94, 167, 0.12);
 
-  /* Design vars that aren't color utilities (gradients/shadows/scrims). */
+  /* Gradients, shadows and scrims; exposed as utilities via @theme above. */
   --card: linear-gradient(180deg, #ffffff, #fbfbfc);
   --chrome: rgba(246, 247, 248, 0.92);
   --topglow: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
## Summary

A design-system audit of `theme.css` and the React styling, fixed in 18 focused commits (one per issue), in four steps:

**1. Defects**
- `text-sm` in the tags menu compiled to nothing (the type scale is reset); now `text-xs`.
- Removed the unused `accent-deep` token.
- Dropped the tooltip's 150ms duration override (default is 160ms).

**2. Tokens for raw `var()`**
- New utilities `bg-scrim`, `bg-chrome`, `bg-card`, `shadow-float`, `shadow-lockfield(-deep)`, `inset-shadow-hairline`; 20 call sites take them. The hairline moves to the inset-shadow slot so it composes with outer shadows.

**3. Reuse**
- `ROW_HAIRLINE` and `MONO_LABEL` adopted where their strings were spelled out; new `MONO_META` constant replaces the hand-written meta recipe in 18 files.
- Generator takes `inputClass` (its comment input goes from 12px to the 8px control radius) and a new `wellClass` for read-only wells.
- Modal close is an `IconButton`; Button's primary/danger share one `filled` string.

**4. Ruled tiers (design decisions — see below)**
- Aliases replaced by their token (`tracking-label`, `text-xs`, `max-w-xs`, `backdrop-blur-xs`).
- New type tiers `text-2xs` 10px, `text-md` 15px, `text-3xl` 34px.
- New `rounded-xs` 4px tier; both kbd chips and the passphrase mask cells use it.
- Generator wells use `leading-relaxed` instead of `leading-[1.55]`.
- `--ease-swift` easing token; import progress joins the 300ms slow tier.
- KeyCuts bars sit on whole pixels (5+6px margins instead of 5.5).
- Status dots are 6px everywhere (audit + passphrase were 7px).
- Width tokens `dialog-sm` 470 / `dialog` 640 / `dialog-lg` 720 / `sheet` 860.

## Visual changes to eyeball
- `Kbd` chip corners 8px → 4px; passphrase mask cells 3px → 4px.
- Generator comment input radius 12px → 8px.
- Modal close idle ink `text3` → `text3/70` (IconButton `muted`).
- Command palette width 620px → 640px.
- Audit and passphrase dots 7px → 6px; import progress sweep 200ms → 300ms.

## Deliberately untouched
Card face hex inks and literal 13/24px sizes (exempt; `text-*` tiers also set leading), Mascot's choreographed inline transitions, the 38px header / 30px list-row heights, z-index layers, `cx()` vs template-literal classNames, `size-N` shorthand.

## Verification
`tsc --noEmit`, `eslint --max-warnings 0` and `vitest` (432 tests) pass after every commit; new utilities confirmed present in the built CSS.