### PR TITLE
ci(ios): App Store build and TestFlight upload workflow

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,0 +1,197 @@
+# Builds the iOS App Store IPA and uploads it to App Store Connect, where it
+# becomes a TestFlight build and, once submitted and approved, an App Store
+# release. iOS has no updater plugin and no `latest.json`: the App Store is the
+# update channel, so nothing here touches the updater artifacts that
+# .github/workflows/release.yml produces for desktop.
+#
+# One-time secret setup and the per-release procedure: docs/releasing-ios.md.
+#
+# tauri-action's iOS support is experimental, so this calls the Tauri CLI
+# directly instead.
+#
+# Repository secrets used:
+#   APPLE_API_ISSUER            App Store Connect API key issuer id (a UUID)
+#   APPLE_API_KEY               App Store Connect API key id (the <ID> in AuthKey_<ID>.p8)
+#   APPLE_API_KEY_P8            base64 of the AuthKey_<ID>.p8 private key file
+#                               (used for automatic signing AND the altool upload)
+#   APPLE_TEAM_ID               Apple Developer team id; exported as
+#                               APPLE_DEVELOPMENT_TEAM. Already set on this repo for
+#                               desktop notarization. If it is ever unset, the
+#                               fallback below matches bundle.iOS.developmentTeam in
+#                               src-tauri/tauri.conf.json.
+#   GOOGLE_OAUTH_IOS_CLIENT_ID  Google iOS OAuth client id for Drive sync, exported as
+#                               GOOGLE_OAUTH_CLIENT_ID and baked in at compile time
+#                               (src-tauri/src/sync/auth.rs). iOS OAuth clients have no
+#                               client secret, so GOOGLE_OAUTH_CLIENT_SECRET is
+#                               deliberately not set here.
+#
+# Signing is fully automatic: the App Store Connect API key lets Xcode create
+# and download the Apple Distribution certificate and the App Store provisioning
+# profile on the runner. No .p12 or .mobileprovision secrets are needed.
+
+name: Release iOS
+
+# Manual, or on a version tag — same triggers as the desktop release, so one
+# `v*` tag ships every platform. The tag/release name comes from `version` in
+# src-tauri/tauri.conf.json, exactly as in release.yml.
+on:
+  workflow_dispatch:
+  push:
+    tags: ['v*']
+
+jobs:
+  release-ios:
+    runs-on: macos-latest # Xcode + the iOS SDK only exist on macOS runners
+    permissions:
+      contents: write # attach the IPA to the GitHub release for the tag
+      id-token: write # OIDC token for SLSA build-provenance attestation (T-CI-4)
+      attestations: write # record the provenance attestation
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same pinned toolchain as ci.yml, release.yml and local dev
+      # (rust-toolchain.toml is the single source of truth).
+      - name: Install pinned Rust toolchain (from rust-toolchain.toml)
+        run: rustup toolchain install
+
+      - name: Add the iOS device target
+        run: rustup target add aarch64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # Frontend toolchain is bun (matches ci.yml and the bun-based
+      # beforeBuildCommand in tauri.conf.json; the repo ships bun.lock).
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.3
+
+      - run: bun install --frozen-lockfile
+
+      # `tauri ios build` runs `pod install` against src-tauri/gen/apple.
+      # CocoaPods ships on the GitHub macOS images; install it only if that
+      # ever changes.
+      - name: Verify CocoaPods
+        run: |
+          set -euo pipefail
+          if ! command -v pod >/dev/null 2>&1; then
+            brew install cocoapods
+          fi
+          pod --version
+
+      # The Xcode project is committed (src-tauri/gen/apple). Fail loudly here
+      # rather than deep inside the Tauri CLI if it is ever missing, since
+      # `tauri ios init` is a local, interactive step.
+      - name: Check the Xcode project is present
+        run: |
+          set -euo pipefail
+          if [ ! -d src-tauri/gen/apple ]; then
+            echo "::error::src-tauri/gen/apple is missing; run 'bun run tauri ios init' and commit it" >&2
+            exit 1
+          fi
+
+      # One key file serves two consumers with different lookup rules:
+      #   * the Tauri CLI / Xcode read the path in APPLE_API_KEY_PATH;
+      #   * altool ignores that and only searches ./private_keys,
+      #     ~/private_keys, ~/.private_keys and ~/.appstoreconnect/private_keys
+      #     for AuthKey_<KEY_ID>.p8.
+      # So it is written under $RUNNER_TEMP (outside the workspace, so it can
+      # never be picked up by a build or committed) and copied to
+      # ~/private_keys. Both copies are deleted at the end of the job.
+      - name: Write the App Store Connect API key
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_API_KEY" ] || [ -z "$APPLE_API_KEY_P8" ]; then
+            echo "::error::APPLE_API_KEY and APPLE_API_KEY_P8 must be set (see docs/releasing-ios.md)" >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/private_keys" "$HOME/private_keys"
+          KEY_PATH="$RUNNER_TEMP/private_keys/AuthKey_$APPLE_API_KEY.p8"
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$KEY_PATH"
+          cp "$KEY_PATH" "$HOME/private_keys/AuthKey_$APPLE_API_KEY.p8"
+          chmod 600 "$KEY_PATH" "$HOME/private_keys/AuthKey_$APPLE_API_KEY.p8"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      # --build-number sets CFBundleVersion. App Store Connect rejects an
+      # upload whose build number is not strictly greater than every previous
+      # upload of the same version string, and github.run_number only ever
+      # increases for this workflow — so re-running a release (or shipping a
+      # rebuild of the same version) never collides.
+      - name: Build the App Store IPA
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          # APPLE_API_KEY_PATH is exported by the previous step via $GITHUB_ENV.
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID || 'UFBL3F444A' }}
+          # Google Drive sync OAuth client, read via option_env! at compile time.
+          # iOS clients are public: there is no client secret to set.
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_IOS_CLIENT_ID }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          bun run tauri ios build --ci \
+            --export-method app-store-connect \
+            --build-number "$BUILD_NUMBER"
+
+      # Path is src-tauri/gen/apple/build/<arch>/<productName>.ipa; resolved by
+      # glob so it does not have to be kept in sync with productName.
+      - name: Locate the IPA
+        id: ipa
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ipas=(src-tauri/gen/apple/build/*.ipa src-tauri/gen/apple/build/*/*.ipa)
+          if [ ${#ipas[@]} -eq 0 ]; then
+            echo "::error::no .ipa found under src-tauri/gen/apple/build" >&2
+            exit 1
+          fi
+          echo "path=${ipas[0]}" >> "$GITHUB_OUTPUT"
+          echo "Built ${ipas[0]}"
+
+      # Uploaded before the App Store step so the IPA is still retrievable if
+      # App Store Connect rejects it.
+      - name: Upload the IPA as a workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: swifty-ios-ipa
+          path: ${{ steps.ipa.outputs.path }}
+          if-no-files-found: error
+
+      - name: Upload to App Store Connect (TestFlight)
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+        run: |
+          xcrun altool --upload-app --type ios --file "$IPA_PATH" \
+            --apiKey "$APPLE_API_KEY" --apiIssuer "$APPLE_API_ISSUER"
+
+      # Same tag derivation as release.yml. The desktop workflow creates the
+      # release as a draft; if it has not run (or was not triggered by a tag)
+      # there is nothing to attach to and the artifact above is the only copy,
+      # which is not an error.
+      - name: Attach the IPA to the GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+        run: |
+          set -euo pipefail
+          TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "$IPA_PATH" --clobber
+          else
+            echo "::notice::no GitHub release $TAG (yet); the IPA is available as the swifty-ios-ipa artifact"
+          fi
+
+      # --- SLSA build provenance (T-CI-4) ---------------------------------
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ steps.ipa.outputs.path }}
+
+      - name: Remove the App Store Connect API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys" "$HOME/private_keys"

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -98,7 +98,8 @@ jobs:
       #     for AuthKey_<KEY_ID>.p8.
       # So it is written under $RUNNER_TEMP (outside the workspace, so it can
       # never be picked up by a build or committed) and copied to
-      # ~/private_keys. Both copies are deleted at the end of the job.
+      # ~/private_keys. Both copies are deleted as soon as the upload step is
+      # done with them, well before the job ends.
       - name: Write the App Store Connect API key
         env:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
@@ -151,15 +152,6 @@ jobs:
           echo "path=${ipas[0]}" >> "$GITHUB_OUTPUT"
           echo "Built ${ipas[0]}"
 
-      # Uploaded before the App Store step so the IPA is still retrievable if
-      # App Store Connect rejects it.
-      - name: Upload the IPA as a workflow artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: swifty-ios-ipa
-          path: ${{ steps.ipa.outputs.path }}
-          if-no-files-found: error
-
       - name: Upload to App Store Connect (TestFlight)
         env:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -169,29 +161,66 @@ jobs:
           xcrun altool --upload-app --type ios --file "$IPA_PATH" \
             --apiKey "$APPLE_API_KEY" --apiIssuer "$APPLE_API_ISSUER"
 
-      # Same tag derivation as release.yml. The desktop workflow creates the
-      # release as a draft; if it has not run (or was not triggered by a tag)
-      # there is nothing to attach to and the artifact above is the only copy,
-      # which is not an error.
-      - name: Attach the IPA to the GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IPA_PATH: ${{ steps.ipa.outputs.path }}
-        run: |
-          set -euo pipefail
-          TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" "$IPA_PATH" --clobber
-          else
-            echo "::notice::no GitHub release $TAG (yet); the IPA is available as the swifty-ios-ipa artifact"
-          fi
+      # The build and the altool upload are the only consumers of the key, so
+      # it is deleted here rather than at the end of the job: nothing that runs
+      # after this point — including third-party actions — sees it on disk.
+      # `always()` covers a failed or skipped build too.
+      - name: Remove the App Store Connect API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys" "$HOME/private_keys"
+
+      # Retained and attested even when the upload above fails, so a build that
+      # App Store Connect rejects is still downloadable and still carries
+      # provenance. Both are skipped when the IPA was never produced.
+      - name: Upload the IPA as a workflow artifact
+        if: ${{ !cancelled() && steps.ipa.outputs.path != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: swifty-ios-ipa
+          path: ${{ steps.ipa.outputs.path }}
+          if-no-files-found: error
 
       # --- SLSA build provenance (T-CI-4) ---------------------------------
       - name: Attest build provenance
+        if: ${{ !cancelled() && steps.ipa.outputs.path != '' }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ steps.ipa.outputs.path }}
 
-      - name: Remove the App Store Connect API key
-        if: always()
-        run: rm -rf "$RUNNER_TEMP/private_keys" "$HOME/private_keys"
+      # A tag run attaches to the tag that triggered it, which is the revision
+      # that was just built. A manual run has no tag, so it falls back to the
+      # version in the config the way release.yml does — but that release may
+      # have been built from an older revision, so a manual run never replaces
+      # an IPA that is already attached. Either way, no release yet (the
+      # desktop workflow creates it as a draft) is not an error: the artifact
+      # above is then the only copy.
+      - name: Attach the IPA to the GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+          PUSHED_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "$PUSHED_TAG" ]; then
+            TAG="$PUSHED_TAG"
+          else
+            TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
+          fi
+
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::no GitHub release $TAG (yet); the IPA is available as the swifty-ios-ipa artifact"
+            exit 0
+          fi
+
+          if [ -n "$PUSHED_TAG" ]; then
+            # Re-running a tag rebuilds that same tag, so replacing is safe.
+            gh release upload "$TAG" "$IPA_PATH" --clobber
+            exit 0
+          fi
+
+          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          if grep -Fxq "$(basename "$IPA_PATH")" <<<"$ASSETS"; then
+            echo "::warning::$TAG already has an IPA and this run was not triggered by that tag; leaving it in place. This build is the swifty-ios-ipa artifact"
+            exit 0
+          fi
+          gh release upload "$TAG" "$IPA_PATH"

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -218,8 +218,11 @@ jobs:
             exit 0
           fi
 
-          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
-          if grep -Fxq "$(basename "$IPA_PATH")" <<<"$ASSETS"; then
+          # Any .ipa counts, whatever it is called: a rename or a productName
+          # change must not let a second IPA onto the same release.
+          ATTACHED=$(gh release view "$TAG" --json assets \
+            --jq '[.assets[].name | select(endswith(".ipa"))] | length')
+          if [ "$ATTACHED" -gt 0 ]; then
             echo "::warning::$TAG already has an IPA and this run was not triggered by that tag; leaving it in place. This build is the swifty-ios-ipa artifact"
             exit 0
           fi

--- a/docs/releasing-ios.md
+++ b/docs/releasing-ios.md
@@ -99,10 +99,17 @@ it. If `APPLE_TEAM_ID` is ever removed, the workflow falls back to the literal
    for the same version always produces an acceptable new build.
 
 4. **TestFlight processing** takes roughly 5–30 minutes after the upload step
-   succeeds. The build then appears under **TestFlight → iOS builds**. It also
-   attaches the IPA to the draft GitHub release for the tag (created by the
-   desktop workflow) and always uploads it as the `swifty-ios-ipa` workflow
-   artifact.
+   succeeds. The build then appears under **TestFlight → iOS builds**. The IPA
+   is always kept as the `swifty-ios-ipa` workflow artifact — including when
+   App Store Connect rejects the upload — and is also attached to the draft
+   GitHub release for the tag (created by the desktop workflow).
+
+   A tag run attaches to the tag that triggered it. A manual run builds the
+   default branch, which may be ahead of the released version, so it attaches
+   to `v<version from tauri.conf.json>` only when that release does not already
+   carry an IPA; otherwise it logs a warning and leaves the existing asset
+   alone. To replace the IPA on a release, re-run the workflow by pushing (or
+   re-pushing) that tag.
 
 5. **Export compliance** must be answered for the build — see below. Until it
    is answered the build stays in "Missing Compliance" and cannot be

--- a/docs/releasing-ios.md
+++ b/docs/releasing-ios.md
@@ -1,0 +1,167 @@
+# Releasing Swifty for iOS
+
+The `.github/workflows/release-ios.yml` workflow builds the App Store IPA and
+uploads it to App Store Connect, where it appears as a TestFlight build. There
+is no updater plugin on iOS: the App Store is the update channel, so this
+workflow produces no `latest.json` and no updater artifacts. Desktop releases
+are a separate workflow (`.github/workflows/release.yml`).
+
+App identity: bundle id `pro.getswifty.app`, team `UFBL3F444A`, minimum iOS
+16.0.
+
+## One-time setup
+
+### 1. Apple Developer Program
+
+A paid Apple Developer Program membership is required; a free account cannot
+sign for distribution. The team id (`UFBL3F444A`) is the same one already used
+for macOS notarization.
+
+### 2. App Store Connect app record
+
+In App Store Connect, **Apps → +  → New App**:
+
+- Platform: iOS
+- Bundle ID: `pro.getswifty.app` (register the App ID in the Developer portal
+  first if it is not offered; no special capabilities are needed — Face ID
+  requires only the usage string, not an entitlement)
+- Name, primary language, SKU: free choice
+
+The record must exist before the first upload; `altool` rejects an IPA whose
+bundle id has no app record.
+
+### 3. App Store Connect API key
+
+**Users and Access → Integrations → App Store Connect API → Team Keys →
+Generate API Key**:
+
+- Access: **App Manager** (needed both to sign — the key lets Xcode create the
+  Apple Distribution certificate and the App Store provisioning profile on the
+  CI runner — and to upload builds)
+- Download `AuthKey_<KEYID>.p8`. **It can only be downloaded once.** Keep a
+  copy in a password manager.
+- Note the **Issuer ID** (a UUID, shown above the key list) and the **Key ID**.
+
+Because signing is automatic, no `.p12` certificate and no
+`.mobileprovision` profile have to be exported or stored as secrets.
+
+### 4. Google iOS OAuth client (Drive sync)
+
+In the Google Cloud console for the existing Swifty project, **APIs & Services
+→ Credentials → Create credentials → OAuth client ID → iOS**, with bundle id
+`pro.getswifty.app`. iOS OAuth clients are public: there is **no client
+secret**, and none must be set in CI. Copy the client id into the
+`GOOGLE_OAUTH_IOS_CLIENT_ID` secret; the build maps it to the
+`GOOGLE_OAUTH_CLIENT_ID` env var that `src-tauri/src/sync/auth.rs` reads at
+compile time.
+
+### 5. Repository secrets
+
+Add under **Settings → Secrets and variables → Actions**:
+
+| Secret | Value |
+| --- | --- |
+| `APPLE_API_ISSUER` | App Store Connect API **Issuer ID** (UUID) |
+| `APPLE_API_KEY` | App Store Connect API **Key ID** (the `<KEYID>` in `AuthKey_<KEYID>.p8`) |
+| `APPLE_API_KEY_P8` | base64 of the `AuthKey_<KEYID>.p8` file |
+| `APPLE_TEAM_ID` | `UFBL3F444A` — **already set** for desktop notarization; reused here as `APPLE_DEVELOPMENT_TEAM` |
+| `GOOGLE_OAUTH_IOS_CLIENT_ID` | Google iOS OAuth client id (no secret) |
+
+Base64 the key file (macOS):
+
+```sh
+base64 -i ~/Downloads/AuthKey_ABC1234567.p8 | pbcopy
+```
+
+Line wrapping in the output is fine; the workflow's `base64 --decode` accepts
+it. If `APPLE_TEAM_ID` is ever removed, the workflow falls back to the literal
+`UFBL3F444A`, which matches `bundle.iOS.developmentTeam` in
+`src-tauri/tauri.conf.json`.
+
+## Per-release procedure
+
+1. **Bump the version** in `src-tauri/tauri.conf.json`, `package.json` and
+   `src-tauri/Cargo.toml` (they must stay in sync; the tag and the release name
+   are derived from `tauri.conf.json`).
+
+   App Store Connect requires `CFBundleShortVersionString` to be at most three
+   dot-separated non-negative integers. A pre-release version such as
+   `1.0.0-alpha.1` is fine for desktop but **will be rejected on upload**, so
+   iOS releases must be cut from a plain `MAJOR.MINOR.PATCH` version.
+
+2. **Tag and push**: `git tag v<version> && git push origin v<version>`. This
+   triggers both `Release` (desktop) and `Release iOS`. The iOS workflow can
+   also be started manually from the Actions tab (`workflow_dispatch`) — GitHub
+   only offers that for workflows on the default branch.
+
+3. **Watch the run.** `CFBundleVersion` is set to the workflow run number
+   (`--build-number`), which is strictly increasing, so re-running the workflow
+   for the same version always produces an acceptable new build.
+
+4. **TestFlight processing** takes roughly 5–30 minutes after the upload step
+   succeeds. The build then appears under **TestFlight → iOS builds**. It also
+   attaches the IPA to the draft GitHub release for the tag (created by the
+   desktop workflow) and always uploads it as the `swifty-ios-ipa` workflow
+   artifact.
+
+5. **Export compliance** must be answered for the build — see below. Until it
+   is answered the build stays in "Missing Compliance" and cannot be
+   distributed to testers.
+
+6. **App Store submission**: **Apps → Swifty → iOS App → + Version**, fill in
+   what's new, screenshots and the review notes (include test-vault credentials
+   if the reviewer needs them), select the processed build, then **Add for
+   Review → Submit**.
+
+## Export compliance
+
+Swifty encrypts the user's vault with standard, published algorithms:
+AES-256-GCM, Argon2id and SQLCipher. That is **not** an exemption. The common
+`ITSAppUsesNonExemptEncryption = false` shortcut is wrong for this app and must
+**not** be added to `Info.ios.plist`.
+
+Answer the App Store Connect questionnaire as:
+
+- Does your app use encryption? **Yes.**
+- Does it qualify for any of the listed exemptions? **No.** The exemptions
+  cover apps that only use the encryption built into Apple's OS, only make
+  HTTPS calls, or only use encryption for authentication or DRM. Swifty ships
+  its own cryptography for user data at rest, so none of them apply.
+- Which algorithms? **Standard encryption algorithms instead of, or in addition
+  to, using or accessing the encryption in Apple's operating system** — i.e.
+  standard published algorithms, no proprietary or non-standard cryptography.
+
+This classification (mass-market software using standard algorithms) requires
+an **annual self-classification report to the US Bureau of Industry and
+Security (BIS) and the ENC Encryption Request Coordinator**, filed by 1
+February each year for the previous calendar year. See
+<https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations>.
+
+## App Store privacy nutrition labels
+
+Under **App Privacy**, declare **Data Not Collected**:
+
+- The vault is local to the device; nothing is sent to a Swifty-operated
+  server (there is none).
+- Drive sync uploads the *encrypted* vault to the user's **own** Google
+  account, chosen by the user. It is not collected by the developer and is not
+  linked to the user by us.
+- No analytics, no crash reporting, no advertising identifiers, no third-party
+  SDKs that collect data.
+
+The only user-facing permission is biometrics: the `NSFaceIDUsageDescription`
+string in `src-tauri/Info.ios.plist` (Face ID / Touch ID is used to unlock the
+local vault). Face ID usage does not itself require a privacy label entry, as
+no biometric data leaves the device or reaches the app.
+
+## Troubleshooting
+
+- **"No suitable application records were found"** — the App Store Connect app
+  record for `pro.getswifty.app` does not exist yet (step 2).
+- **Invalid `CFBundleShortVersionString`** — the version has a pre-release
+  suffix; see step 1 of the release procedure.
+- **`src-tauri/gen/apple is missing`** — the Xcode project is committed to the
+  repo; regenerate it locally with `bun run tauri ios init` and commit.
+- **Signing failures** — usually an API key without the App Manager role, or a
+  key that was revoked; generate a new one and update `APPLE_API_KEY`,
+  `APPLE_API_ISSUER` and `APPLE_API_KEY_P8` together.


### PR DESCRIPTION
Part of the iOS port (PR 4 of 5). Adds the release path for iOS: a GitHub Actions workflow that builds the App Store IPA with the Tauri CLI and uploads it to App Store Connect, plus an owner runbook.

## What's here
- `.github/workflows/release-ios.yml`: runs on `v*` tags and manual dispatch, on `macos-latest`. Installs the pinned toolchain and the `aarch64-apple-ios` target, builds with `tauri ios build --ci --export-method app-store-connect --build-number <run number>`, uploads the IPA as a workflow artifact, pushes it to TestFlight with `xcrun altool`, attaches it to the GitHub release if the desktop workflow created one, and attests build provenance. Signing is automatic via an App Store Connect API key, so no `.p12` or `.mobileprovision` secrets are needed. The key is written under `$RUNNER_TEMP`, copied to `~/private_keys` for altool, and removed with `if: always()`.
- `docs/releasing-ios.md`: one-time setup (Developer Program, App Store Connect record, API key, Google iOS OAuth client), per-release steps, and the export-compliance answer: Swifty uses standard encryption for its own data, which is not exempt, so `ITSAppUsesNonExemptEncryption=false` must not be set.

## Secrets the owner must add
`APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_P8` (base64 `.p8`), `GOOGLE_OAUTH_IOS_CLIENT_ID`. `APPLE_TEAM_ID` is reused from desktop notarization.

## Depends on
The iOS build PR (`feat/ios-build`) for `bundle.iOS`, `Info.ios.plist` and the committed `src-tauri/gen/apple` project. The workflow fails loudly if `gen/apple` is missing, so merging this first is harmless but the workflow cannot succeed until that PR lands.

## Known gotcha
`tauri.conf.json` is at `1.0.0-alpha.1`. App Store Connect only accepts up to three dot-separated integers in `CFBundleShortVersionString`, so the first iOS upload needs a plain `x.y.z` version. Documented in the runbook.

Validated with `python3 yaml.safe_load` and `actionlint` (clean). Not run end to end: it needs the Apple secrets.