### PR TITLE
feat(ui): a compact phone shell with a tab bar and a list-detail stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      `viewport-fit=cover` lets the shell paint under the notch and the home
+      indicator; the safe-area insets it unlocks are what the compact chrome
+      pads itself with. No maximum-scale / user-scalable: pinch zoom stays.
+    -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>Swifty</title>
     <!--
       Pre-paint ground, so the very first frame the webview draws is already

--- a/src/components/Main/AddSecret/index.tsx
+++ b/src/components/Main/AddSecret/index.tsx
@@ -2,8 +2,11 @@ import { useEffect, useRef, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { EntryType } from '@/lib/commands'
 import { useStore, closeAddPicker, startEntry } from '@/store'
+import { useLayout } from '@/hooks/useLayout'
+import { cx } from '@/utils/cx'
 import { KINDS } from '@/kinds'
 import Modal from '@/components/elements/Modal'
+import Sheet from '@/components/elements/Sheet'
 import KindTile from './KindTile'
 import ScanAction from './ScanAction'
 
@@ -27,6 +30,7 @@ const STEP: Record<string, number> = {
 export default function AddSecret() {
   const { t } = useTranslation()
   const open = useStore(state => state.ui.addPicker)
+  const compact = useLayout() === 'compact'
   const grid = useRef<HTMLDivElement>(null)
 
   const tiles = () => Array.from(grid.current?.querySelectorAll('button') ?? [])
@@ -63,29 +67,38 @@ export default function AddSecret() {
     event.preventDefault()
   }
 
-  return (
+  const picker = (
+    <div className={cx('w-full', compact ? 'p-5' : 'p-7')}>
+      <h2 id={TITLE_ID} className="text-lg font-semibold tracking-display">
+        {t('Add a secret')}
+      </h2>
+      <p className="mt-1.5 text-base text-text2">
+        {t('Everything is encrypted before it touches disk.')}
+      </p>
+
+      <div ref={grid} onKeyDown={onKeyDown} className="mt-6 grid grid-cols-2 gap-3">
+        {KINDS.map(kind => (
+          <KindTile key={kind.type} kind={kind} onSelect={() => pick(kind.type)} />
+        ))}
+      </div>
+
+      <ScanAction />
+    </div>
+  )
+
+  // The picker carries its own heading, so the compact frame stays bare.
+  return compact ? (
+    <Sheet onClose={closeAddPicker} labelledBy={TITLE_ID} testid="add-secret-modal">
+      {picker}
+    </Sheet>
+  ) : (
     <Modal
       onClose={closeAddPicker}
       className="w-dialog"
       labelledBy={TITLE_ID}
       testid="add-secret-modal"
     >
-      <div className="w-full p-7">
-        <h2 id={TITLE_ID} className="text-lg font-semibold tracking-display">
-          {t('Add a secret')}
-        </h2>
-        <p className="mt-1.5 text-base text-text2">
-          {t('Everything is encrypted before it touches disk.')}
-        </p>
-
-        <div ref={grid} onKeyDown={onKeyDown} className="mt-6 grid grid-cols-2 gap-3">
-          {KINDS.map(kind => (
-            <KindTile key={kind.type} kind={kind} onSelect={() => pick(kind.type)} />
-          ))}
-        </div>
-
-        <ScanAction />
-      </div>
+      {picker}
     </Modal>
   )
 }

--- a/src/components/Main/Body/DetailPane.tsx
+++ b/src/components/Main/Body/DetailPane.tsx
@@ -1,11 +1,21 @@
+import { useLayout } from '@/hooks/useLayout'
+import { cx } from '@/utils/cx'
 import Aside from './Aside'
 
 // The right pane: hosts the existing Aside (Show / Form / Audit / Empty).
 // Deep detail styling is PR 5 — this provides the scroll surface + padding so
 // the current content stays functional and readable in both themes.
+// Compact drops the desktop gutters: 34px a side is a sixth of a phone.
 export default function DetailPane() {
+  const compact = useLayout() === 'compact'
+
   return (
-    <div className="flex min-w-0 flex-1 flex-col overflow-y-auto bg-detail pt-[26px] px-[34px] pb-[60px] text-text">
+    <div
+      className={cx(
+        'flex min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain bg-detail text-text',
+        compact ? 'px-4 pt-4 pb-10' : 'pt-[26px] px-[34px] pb-[60px]'
+      )}
+    >
       <Aside />
     </div>
   )

--- a/src/components/Main/Body/Empty/variant.ts
+++ b/src/components/Main/Body/Empty/variant.ts
@@ -12,6 +12,15 @@ import { useRows, useVisibleEntries } from '../List/useVisibleEntries'
  */
 export type Variant = 'vault' | 'kind' | 'search' | 'select' | 'health' | 'favorites' | 'archive'
 
+const WHOLE_VIEW: Variant[] = ['vault', 'health', 'favorites', 'archive']
+
+/**
+ * Whether a variant is a whole-view state rather than a filter one. The wide
+ * shell always has a detail pane to put these in; the compact shell has only
+ * the list, so it asks this before showing the hero there itself.
+ */
+export const isWholeView = (variant: Variant) => WHOLE_VIEW.includes(variant)
+
 // Which empty state the app is in, or `null` when there is real content to
 // show — which, for the surfaces that ask, only ever means a scored audit.
 export const useVariant = (): Variant | null => {

--- a/src/components/Main/Body/Empty/variants.tsx
+++ b/src/components/Main/Body/Empty/variants.tsx
@@ -51,7 +51,9 @@ export function VaultEmpty() {
       secondary={
         syncEnabled
           ? { label: t('Restore from Google Drive'), onClick: restore, loading: importing }
-          : { label: t('Import from another app'), onClick: openSettings }
+          : // Wrapped, and named: handed straight to onClick it took the click
+            // event as its section argument and Settings opened on none at all.
+            { label: t('Import from another app'), onClick: () => openSettings('import') }
       }
       hints={[
         { keys: '⌘N', label: t('add') },

--- a/src/components/Main/Body/List/SortMenu.tsx
+++ b/src/components/Main/Body/List/SortMenu.tsx
@@ -14,7 +14,7 @@ const OPTIONS: { mode: SortMode; label: TKey }[] = [
 
 // The list header's sort affordance. The menu is right-anchored under the
 // button so it never runs off the list column's edge.
-export default function SortMenu() {
+export default function SortMenu({ compact }: { compact?: boolean }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const sort = useStore(state => state.sort)
@@ -32,6 +32,7 @@ export default function SortMenu() {
         expanded={open}
         testid="sort-menu"
         onClick={() => setOpen(value => !value)}
+        className={compact ? 'h-11 w-11' : undefined}
       >
         <SortGlyph />
       </IconButton>

--- a/src/components/Main/Body/ListColumn/index.tsx
+++ b/src/components/Main/Body/ListColumn/index.tsx
@@ -1,13 +1,18 @@
+import type { ReactNode } from 'react'
 import { useStore } from '@/store'
 import type { View } from '@/store/uiSlice'
 import { kindOf } from '@/kinds'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
+import { useLayout } from '@/hooks/useLayout'
+import { cx } from '@/utils/cx'
 import KindChips from './KindChips'
 import ActiveTag from './ActiveTag'
 import List from '../List'
 import SortMenu from '../List/SortMenu'
 import Search from './Search'
+import { DetailEmpty } from '../Empty'
+import { useVariant, isWholeView } from '../Empty/variant'
 import { useListKeys } from './useListKeys'
 
 // The middle pane: a title with the sort control, the search field and the kind
@@ -22,12 +27,24 @@ const TITLES: Record<View, TKey> = {
   archive: 'Archive'
 }
 
-export default function ListColumn() {
+interface Props {
+  /**
+   * Extra controls for the title row. The compact shell has no rail to put the
+   * tag filter and the add button on, so it hands them down here instead.
+   */
+  actions?: ReactNode
+}
+
+export default function ListColumn({ actions }: Props) {
   const { t } = useTranslation()
   const view = useStore(state => state.ui.view)
   const type = useStore(state => state.filters.type)
   const health = view === 'health'
   const onKeyDown = useListKeys()
+  const compact = useLayout() === 'compact'
+  // Compact is the only pane on screen, so it also has to carry the hero the
+  // detail pane shows on wide — otherwise an empty vault is a blank screen.
+  const variant = useVariant()
 
   const title = view === 'items' && type ? t(kindOf(type).pluralLabel) : t(TITLES[view])
 
@@ -37,7 +54,10 @@ export default function ListColumn() {
       // field as well as from a row. The audit list has no roving selection to
       // walk, so it is left off there.
       onKeyDown={health ? undefined : onKeyDown}
-      className="flex w-[348px] min-h-0 flex-none flex-col border-r border-line bg-list"
+      className={cx(
+        'flex min-h-0 flex-col bg-list',
+        compact ? 'w-full flex-1' : 'w-[348px] flex-none border-r border-line'
+      )}
     >
       <div className="flex-none px-4 pt-4 pb-2.5">
         <div className="flex items-end gap-2.5">
@@ -50,7 +70,8 @@ export default function ListColumn() {
             </div>
           </div>
           {/* The audit list has its own severity order — nothing to sort. */}
-          {!health && <SortMenu />}
+          {!health && <SortMenu compact={compact} />}
+          {!health && actions}
         </div>
         {/* The audit is not a filtered view of the vault, so neither the query
             nor the chips apply to it. */}
@@ -70,6 +91,7 @@ export default function ListColumn() {
         className="min-h-0 flex-1 overflow-y-auto"
       >
         <List />
+        {compact && variant && isWholeView(variant) && <DetailEmpty variant={variant} />}
       </div>
     </div>
   )

--- a/src/components/Main/Compact/Tab.tsx
+++ b/src/components/Main/Compact/Tab.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+
+// One destination in the bottom bar. 56px tall before the safe-area inset, so
+// the tap target clears 44px even with the label under the glyph.
+export default function Tab({
+  label,
+  testid,
+  selected,
+  onClick,
+  children
+}: {
+  label: string
+  testid: string
+  selected?: boolean
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={selected}
+      data-testid={testid}
+      onClick={onClick}
+      className={cx(
+        'flex h-14 flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 px-1 transition-colors',
+        selected ? 'text-accent' : 'text-text3'
+      )}
+    >
+      {children}
+      <span className="w-full truncate text-center text-2xs font-medium">{label}</span>
+    </button>
+  )
+}

--- a/src/components/Main/Compact/TabBar.tsx
+++ b/src/components/Main/Compact/TabBar.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next'
+import { useStore, setView, openGenerator, openSettings } from '@/store'
+import {
+  ArchiveRailGlyph,
+  DicesRailGlyph,
+  GearRailGlyph,
+  GridRailGlyph,
+  StarRailGlyph
+} from '../icons'
+import Tab from './Tab'
+
+/**
+ * The compact replacement for the 56px rail: the three views plus the two
+ * things the rail's bottom held. The tag filter is not here — it narrows the
+ * list it sits above rather than navigating, so it moved into the list header.
+ */
+export default function TabBar() {
+  const { t } = useTranslation()
+  const view = useStore(state => state.ui.view)
+  const settings = useStore(state => state.ui.settings)
+
+  return (
+    <nav
+      data-testid="tab-bar"
+      className="flex flex-none items-stretch border-t border-line bg-rail pb-[env(safe-area-inset-bottom)]"
+    >
+      <Tab
+        label={t('All Items')}
+        testid="tab-items"
+        selected={view === 'items'}
+        onClick={() => setView('items')}
+      >
+        <GridRailGlyph />
+      </Tab>
+      <Tab
+        label={t('Favorites')}
+        testid="tab-favorites"
+        selected={view === 'favorites'}
+        onClick={() => setView('favorites')}
+      >
+        <StarRailGlyph />
+      </Tab>
+      <Tab
+        label={t('Archive')}
+        testid="tab-archive"
+        selected={view === 'archive'}
+        onClick={() => setView('archive')}
+      >
+        <ArchiveRailGlyph />
+      </Tab>
+      <Tab label={t('Generator')} testid="tab-generator" onClick={() => openGenerator()}>
+        <DicesRailGlyph />
+      </Tab>
+      <Tab
+        label={t('Settings')}
+        testid="tab-settings"
+        selected={settings}
+        onClick={() => openSettings()}
+      >
+        <GearRailGlyph />
+      </Tab>
+    </nav>
+  )
+}

--- a/src/components/Main/Compact/TopBar.tsx
+++ b/src/components/Main/Compact/TopBar.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next'
+import { useStore, setNoEntry } from '@/store'
+import IconButton from '@/components/elements/IconButton'
+import SyncIndicator from '../Header/SyncIndicator'
+import LockButton from '../Header/LockButton'
+import { BackGlyph } from '../icons'
+
+/**
+ * The compact top chrome. No drag region and no traffic-light gutter — there is
+ * no window to move — but it does pad itself past the notch.
+ */
+export default function TopBar({ detail }: { detail: boolean }) {
+  const { t } = useTranslation()
+  // A draft leaves through the editor's own Cancel, which guards unsaved
+  // changes. A second way out up here would be an unguarded one.
+  const writing = useStore(state => state.entries.edit || state.entries.new !== null)
+
+  return (
+    <header className="flex flex-none items-center gap-1.5 border-b border-line bg-chrome px-2 pt-[env(safe-area-inset-top)]">
+      <div className="flex h-14 flex-1 items-center">
+        {detail && !writing && (
+          <IconButton
+            testid="compact-back"
+            label={t('Back')}
+            onClick={setNoEntry}
+            className="h-11 w-11"
+          >
+            <BackGlyph />
+          </IconButton>
+        )}
+      </div>
+      <SyncIndicator />
+      <LockButton />
+    </header>
+  )
+}

--- a/src/components/Main/Compact/index.tsx
+++ b/src/components/Main/Compact/index.tsx
@@ -21,26 +21,31 @@ export default function Compact() {
   const view = useVisualViewport()
 
   return (
-    <div
-      data-testid="compact-shell"
-      style={viewportStyle(view)}
-      className="flex h-full min-h-0 flex-col"
-    >
-      <TopBar detail={detail} />
-      {detail ? (
-        <DetailPane />
-      ) : (
-        <ListColumn
-          actions={
-            <>
-              <Tags compact />
-              <Add compact />
-            </>
-          }
-        />
-      )}
-      {!detail && <TabBar />}
+    <>
+      <div
+        data-testid="compact-shell"
+        style={viewportStyle(view)}
+        className="flex h-full min-h-0 flex-col"
+      >
+        <TopBar detail={detail} />
+        {detail ? (
+          <DetailPane />
+        ) : (
+          <ListColumn
+            actions={
+              <>
+                <Tags compact />
+                <Add compact />
+              </>
+            }
+          />
+        )}
+        {!detail && <TabBar />}
+      </div>
+      {/* A sibling, not a child: the shell's translate would make it the
+          containing block for the sheet's `fixed`, and the sheet already
+          applies the same offset itself — inside, it would move twice. */}
       <SettingsOverlay />
-    </div>
+    </>
   )
 }

--- a/src/components/Main/Compact/index.tsx
+++ b/src/components/Main/Compact/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@/store'
-import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { useVisualViewport, viewportStyle } from '@/hooks/useVisualViewport'
 import ListColumn from '../Body/ListColumn'
 import DetailPane from '../Body/DetailPane'
 import SettingsOverlay from '../Sidebar/Settings/Overlay'
@@ -18,12 +18,12 @@ import TabBar from './TabBar'
  */
 export default function Compact() {
   const detail = useStore(state => state.entries.current !== null || state.entries.new !== null)
-  const height = useVisualViewport()
+  const view = useVisualViewport()
 
   return (
     <div
       data-testid="compact-shell"
-      style={{ height: height ?? undefined }}
+      style={viewportStyle(view)}
       className="flex h-full min-h-0 flex-col"
     >
       <TopBar detail={detail} />

--- a/src/components/Main/Compact/index.tsx
+++ b/src/components/Main/Compact/index.tsx
@@ -1,0 +1,46 @@
+import { useStore } from '@/store'
+import { useVisualViewport } from '@/hooks/useVisualViewport'
+import ListColumn from '../Body/ListColumn'
+import DetailPane from '../Body/DetailPane'
+import SettingsOverlay from '../Sidebar/Settings/Overlay'
+import Tags from '../Sidebar/Tags'
+import Add from '../Sidebar/Add'
+import TopBar from './TopBar'
+import TabBar from './TabBar'
+
+/**
+ * The phone shell: one screen at a time between a slim top bar and the tab bar.
+ *
+ * The list is the root screen; picking an entry — or starting a new one, or
+ * editing — pushes the detail screen over it full width, and the top bar grows
+ * a back control. The tab bar is the list screen's alone: switching view from
+ * inside a detail would drop the selection (and any draft) out from under it.
+ */
+export default function Compact() {
+  const detail = useStore(state => state.entries.current !== null || state.entries.new !== null)
+  const height = useVisualViewport()
+
+  return (
+    <div
+      data-testid="compact-shell"
+      style={{ height: height ?? undefined }}
+      className="flex h-full min-h-0 flex-col"
+    >
+      <TopBar detail={detail} />
+      {detail ? (
+        <DetailPane />
+      ) : (
+        <ListColumn
+          actions={
+            <>
+              <Tags compact />
+              <Add compact />
+            </>
+          }
+        />
+      )}
+      {!detail && <TabBar />}
+      <SettingsOverlay />
+    </div>
+  )
+}

--- a/src/components/Main/Generator/Dialog.tsx
+++ b/src/components/Main/Generator/Dialog.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { copy } from '@/services/copy'
+import { useLayout } from '@/hooks/useLayout'
 import Button from '@/components/elements/Button'
 import IconButton from '@/components/elements/IconButton'
+import Sheet from '@/components/elements/Sheet'
 import { startEntry } from '@/store'
 import type { GeneratorApply, SshApply } from '@/store/generatorSlice'
 import { RefreshGlyph } from '../icons'
@@ -30,6 +32,7 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
   const [mode, setMode] = useState<DialogMode>(ssh ? 'ssh' : settings.mode)
   const key = useSshKey(mode === 'ssh')
   const cardRef = useRef<HTMLDivElement>(null)
+  const compact = useLayout() === 'compact'
   const keys = mode === 'ssh'
 
   // A keypair fills a whole draft, so standalone it opens a new entry rather
@@ -72,6 +75,81 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
     return () => window.removeEventListener('keydown', onKey)
   }, [confirm, onClose])
 
+  const content = (
+    <>
+      <div className="flex items-center gap-2.5 px-[18px] py-[15px] inset-shadow-hairline">
+        <div id="generator-title" className="flex-1 text-lg font-semibold tracking-display">
+          {t('Generate')}
+        </div>
+        {/* Opened for a key, there is nothing to switch to. */}
+        {!ssh && (
+          <Tabs
+            mode={mode}
+            ssh={!apply}
+            onChange={next => {
+              setMode(next)
+              if (next !== 'ssh') update({ mode: next })
+            }}
+          />
+        )}
+      </div>
+      <div className="p-[18px]">
+        {keys ? (
+          <Ssh
+            pair={key.pair}
+            pending={key.pending}
+            error={key.error}
+            onRetry={key.regenerate}
+            comment={key.comment}
+            onComment={key.setComment}
+          />
+        ) : (
+          <>
+            <Output value={value} bits={bits} level={level} />
+            <Amount settings={settings} onChange={update} />
+            <Toggles settings={settings} onChange={update} />
+          </>
+        )}
+        <div className="mt-[18px] flex items-center gap-1.5">
+          <IconButton
+            title={t('Regenerate')}
+            testid="generator-regenerate"
+            onClick={keys ? key.regenerate : regenerate}
+            className="h-9 w-9 border border-line2 hover:border-accent-line"
+          >
+            <RefreshGlyph />
+          </IconButton>
+          <div className="flex-1" />
+          <Button variant="ghost" onClick={onClose}>
+            {t('Cancel')}
+          </Button>
+          <Button
+            testid="generator-use-button"
+            kbd="⏎"
+            onClick={confirm}
+            disabled={keys && !key.ready}
+          >
+            {keys ? (ssh ? t('Use') : t('Save as SSH key')) : t('Use & copy')}
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+
+  // The card carries its own title row, so the compact frame stays bare. It
+  // takes `cardRef` too, so the topmost-dialog check above still finds itself.
+  if (compact)
+    return (
+      <Sheet
+        ref={cardRef}
+        onClose={onClose}
+        labelledBy="generator-title"
+        testid="generator-dialog"
+      >
+        {content}
+      </Sheet>
+    )
+
   return (
     <div
       className="fixed inset-0 z-50 grid animate-fade place-items-center bg-scrim p-4 backdrop-blur-sm"
@@ -90,62 +168,7 @@ export default function Dialog({ apply, ssh, onClose }: Props) {
         className="w-dialog-sm animate-pop overflow-hidden rounded-xl border border-line2 bg-detail text-text shadow-float"
         onClick={event => event.stopPropagation()}
       >
-        <div className="flex items-center gap-2.5 px-[18px] py-[15px] inset-shadow-hairline">
-          <div id="generator-title" className="flex-1 text-lg font-semibold tracking-display">
-            {t('Generate')}
-          </div>
-          {/* Opened for a key, there is nothing to switch to. */}
-          {!ssh && (
-            <Tabs
-              mode={mode}
-              ssh={!apply}
-              onChange={next => {
-                setMode(next)
-                if (next !== 'ssh') update({ mode: next })
-              }}
-            />
-          )}
-        </div>
-        <div className="p-[18px]">
-          {keys ? (
-            <Ssh
-              pair={key.pair}
-              pending={key.pending}
-              error={key.error}
-              onRetry={key.regenerate}
-              comment={key.comment}
-              onComment={key.setComment}
-            />
-          ) : (
-            <>
-              <Output value={value} bits={bits} level={level} />
-              <Amount settings={settings} onChange={update} />
-              <Toggles settings={settings} onChange={update} />
-            </>
-          )}
-          <div className="mt-[18px] flex items-center gap-1.5">
-            <IconButton
-              title={t('Regenerate')}
-              testid="generator-regenerate"
-              onClick={keys ? key.regenerate : regenerate}
-              className="h-9 w-9 border border-line2 hover:border-accent-line"
-            >
-              <RefreshGlyph />
-            </IconButton>
-            <div className="flex-1" />
-            <Button variant="ghost" onClick={onClose}>
-              {t('Cancel')}
-            </Button>
-            <Button
-              testid="generator-use-button"
-              kbd="⏎"
-              onClick={confirm}
-              disabled={keys && !key.ready}
-            >
-              {keys ? (ssh ? t('Use') : t('Save as SSH key')) : t('Use & copy')}
-            </Button>
-          </div>
-        </div>
+        {content}
       </div>
     </div>
   )

--- a/src/components/Main/Sidebar/Add.tsx
+++ b/src/components/Main/Sidebar/Add.tsx
@@ -7,15 +7,17 @@ import { PlusRailGlyph } from '../icons'
 // (Main/AddSecret). Leaving a filtered view is `startEntry`'s job, on commit —
 // doing it here navigated away from whatever the user was looking at even when
 // they then dismissed the picker.
-export default function Add() {
+export default function Add({ compact }: { compact?: boolean }) {
   const { t } = useTranslation()
   // The rail's only action tile: a filled accent wash rather than the
-  // navigation inks, so it reads as "do" and not "go".
+  // navigation inks, so it reads as "do" and not "go". Compact moves it into
+  // the list header, at a touch-sized target.
   return (
     <RailButton
       label={t('Add a secret')}
       onClick={openAddPicker}
       testid="add-entry-button"
+      className={compact ? 'h-11 w-11' : undefined}
       action
     >
       <PlusRailGlyph />

--- a/src/components/Main/Sidebar/Settings/Overlay.tsx
+++ b/src/components/Main/Sidebar/Settings/Overlay.tsx
@@ -1,0 +1,16 @@
+import { useStore } from '@/store'
+import { useLayout } from '@/hooks/useLayout'
+import SettingsModal from './SettingsModal'
+import SettingsSheet from './SettingsSheet'
+
+/**
+ * Settings, framed for whichever shell is up. Mounted by the rail on wide and
+ * by the compact shell on phones — never both, since only one shell renders.
+ */
+export default function SettingsOverlay() {
+  const open = useStore(state => state.ui.settings)
+  const compact = useLayout() === 'compact'
+
+  if (!open) return null
+  return compact ? <SettingsSheet /> : <SettingsModal />
+}

--- a/src/components/Main/Sidebar/Settings/Section.tsx
+++ b/src/components/Main/Sidebar/Settings/Section.tsx
@@ -1,0 +1,22 @@
+import type { ComponentType } from 'react'
+import type { Section as Key } from '@/store/uiSlice'
+import Sync from './Sections/Sync'
+import Security from './Sections/Security'
+import Audit from './Sections/Audit'
+import Import from './Sections/Import'
+import Language from './Sections/Language'
+
+// One place that maps a section key to its pane, so the modal and the compact
+// sheet cannot drift apart over which section shows what.
+const PANES: Record<Key, ComponentType> = {
+  sync: Sync,
+  security: Security,
+  audit: Audit,
+  import: Import,
+  language: Language
+}
+
+export default function Section({ section }: { section: Key }) {
+  const Pane = PANES[section]
+  return <Pane />
+}

--- a/src/components/Main/Sidebar/Settings/SettingsModal.tsx
+++ b/src/components/Main/Sidebar/Settings/SettingsModal.tsx
@@ -3,12 +3,8 @@ import { useStore, closeSettings, setSettingsSection } from '@/store'
 import Modal from '@/components/elements/Modal'
 import IconButton from '@/components/elements/IconButton'
 import Nav from './Nav'
+import Section from './Section'
 import { titleOf } from './sections'
-import Sync from './Sections/Sync'
-import Security from './Sections/Security'
-import Audit from './Sections/Audit'
-import Import from './Sections/Import'
-import Language from './Sections/Language'
 import { CloseGlyph } from '../../icons'
 
 const TITLE_ID = 'settings-title'
@@ -44,11 +40,7 @@ export default function SettingsModal() {
           </IconButton>
         </div>
         <div className="flex-1 overflow-y-auto p-7">
-          {section === 'sync' && <Sync />}
-          {section === 'security' && <Security />}
-          {section === 'audit' && <Audit />}
-          {section === 'import' && <Import />}
-          {section === 'language' && <Language />}
+          <Section section={section} />
         </div>
       </div>
     </Modal>

--- a/src/components/Main/Sidebar/Settings/SettingsSheet.tsx
+++ b/src/components/Main/Sidebar/Settings/SettingsSheet.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+import { cx } from '@/utils/cx'
+import { useStore, closeSettings, setSettingsSection } from '@/store'
+import Sheet from '@/components/elements/Sheet'
+import Footer from './Footer'
+import Section from './Section'
+import { SECTIONS } from './sections'
+
+/**
+ * Settings on a phone: the same panes, with the 220px nav rail flattened into a
+ * scrollable strip of section pills above them.
+ */
+export default function SettingsSheet() {
+  const { t } = useTranslation()
+  const section = useStore(state => state.ui.settingsSection)
+
+  const strip = (
+    <div className="flex flex-none gap-1.5 overflow-x-auto border-b border-line px-3 py-2">
+      {SECTIONS.map(({ key, label, Glyph }) => (
+        <button
+          key={key}
+          type="button"
+          aria-current={key === section ? 'page' : undefined}
+          data-testid={`settings-nav-${key}`}
+          onClick={() => setSettingsSection(key)}
+          className={cx(
+            'flex h-11 flex-none cursor-pointer items-center gap-2 whitespace-nowrap rounded-sm px-3 text-base transition-colors',
+            key === section ? 'bg-accent-soft text-accent' : 'text-text2'
+          )}
+        >
+          <Glyph size={16} />
+          {t(label)}
+        </button>
+      ))}
+    </div>
+  )
+
+  return (
+    <Sheet
+      title={t('Settings')}
+      onClose={closeSettings}
+      testid="settings-modal"
+      toolbar={strip}
+    >
+      <div className="p-5">
+        <Section section={section} />
+        <Footer />
+      </div>
+    </Sheet>
+  )
+}

--- a/src/components/Main/Sidebar/Settings/index.tsx
+++ b/src/components/Main/Sidebar/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useStore, openSettings, closeSettings } from '@/store'
 import RailButton from '@/components/elements/RailButton'
-import SettingsModal from './SettingsModal'
+import Overlay from './Overlay'
 import { GearRailGlyph } from '../../icons'
 
 export default function Settings() {
@@ -19,7 +19,7 @@ export default function Settings() {
       >
         <GearRailGlyph />
       </RailButton>
-      {modal && <SettingsModal />}
+      <Overlay />
     </div>
   )
 }

--- a/src/components/Main/Sidebar/Tags/Menu.tsx
+++ b/src/components/Main/Sidebar/Tags/Menu.tsx
@@ -1,12 +1,20 @@
 import { useTranslation } from 'react-i18next'
 import { useStore, setFilterTag } from '@/store'
+import { cx } from '@/utils/cx'
 import { Dropdown, DropdownItem } from '@/components/elements/Dropdown'
 import { CheckGlyph } from '../../icons'
 import { useTagCounts } from './useTagCounts'
 
 // Hangs off the right edge of the 36px rail tile, floating over the list column
-// — the rail itself is too narrow to hold a menu.
-export default function Menu({ onClose }: { onClose: () => void }) {
+// — the rail itself is too narrow to hold a menu. `className` is where it is
+// pinned, which the compact header changes.
+export default function Menu({
+  onClose,
+  className
+}: {
+  onClose: () => void
+  className?: string
+}) {
   const { t } = useTranslation()
   const active = useStore(state => state.filters.tag)
   const tags = useTagCounts()
@@ -19,7 +27,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div className="absolute left-full top-0 ml-3 w-[220px]">
+    <div className={cx('absolute z-20 w-[220px]', className ?? 'left-full top-0 ml-3')}>
       <Dropdown onBlur={onClose} className="w-full">
         {tags.length === 0 ? (
           <div className="px-3.5 py-2.5" data-testid="tags-empty">

--- a/src/components/Main/Sidebar/Tags/index.tsx
+++ b/src/components/Main/Sidebar/Tags/index.tsx
@@ -8,22 +8,30 @@ import Menu from './Menu'
 // The rail's one filter tile. A tag narrows whatever view is open rather than
 // replacing it, so the tile is lit by an active tag — not by an open menu:
 // what it reports is that the list in front of you is being narrowed.
-export default function Tags() {
+export default function Tags({ compact }: { compact?: boolean }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const tag = useStore(state => state.filters.tag)
 
   return (
-    <div className="relative">
+    <div className="relative flex-none">
       <RailButton
         label={t('Tags')}
         selected={tag !== null}
         onClick={() => setOpen(value => !value)}
         testid="tags-button"
+        className={compact ? 'h-11 w-11' : undefined}
       >
         <TagsRailGlyph />
       </RailButton>
-      {open && <Menu onClose={() => setOpen(false)} />}
+      {/* Compact hangs the tile off the list header instead of the rail, so the
+          menu drops below the trigger rather than out to its side. */}
+      {open && (
+        <Menu
+          onClose={() => setOpen(false)}
+          className={compact ? 'right-0 top-full mt-2' : 'left-full top-0 ml-3'}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/Main/Wide.tsx
+++ b/src/components/Main/Wide.tsx
@@ -1,0 +1,17 @@
+import Sidebar from './Sidebar'
+import Header from './Header'
+import Body from './Body'
+
+// The desktop and iPad shell, unchanged: top chrome over the icon rail, the
+// list column and the detail pane, all on screen at once.
+export default function Wide() {
+  return (
+    <>
+      <Header />
+      <div className="flex min-h-0 flex-1">
+        <Sidebar />
+        <Body />
+      </div>
+    </>
+  )
+}

--- a/src/components/Main/icons.tsx
+++ b/src/components/Main/icons.tsx
@@ -17,6 +17,7 @@ import {
   AtSign,
   Check,
   ChevronDown,
+  ChevronLeft,
   Cloud,
   Copy,
   CreditCard,
@@ -129,3 +130,4 @@ export const StarRailGlyph = glyph(Star, 20)
 export const TagsRailGlyph = glyph(Tags, 20)
 export const ArchiveRailGlyph = glyph(Archive, 20)
 export const DicesRailGlyph = glyph(Dices, 20)
+export const BackGlyph = glyph(ChevronLeft, 20)

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,17 +1,19 @@
 import { useTranslation } from 'react-i18next'
-import Sidebar from './Sidebar'
-import Header from './Header'
-import Body from './Body'
+import { useLayout } from '@/hooks/useLayout'
+import Wide from './Wide'
+import Compact from './Compact'
 import Generator from './Generator'
 import Palette from './Palette'
 import AddSecret from './AddSecret'
 import Scan from './Scan'
 import { useShortcuts } from './useShortcuts'
 
-// Three-pane shell: a full-width top chrome bar over a row of
-// rail (56px) · list column (348px) · detail pane (flex).
+// Two shells, one set of overlays. `Wide` is the three-pane desktop/iPad layout
+// (rail 56px · list 348px · detail flex); `Compact` is the phone one, a screen
+// at a time over a tab bar. The overlays frame themselves for whichever is up.
 export function Main() {
   const { t } = useTranslation()
+  const compact = useLayout() === 'compact'
   useShortcuts()
 
   return (
@@ -19,13 +21,11 @@ export function Main() {
       data-testid="main-view"
       className="flex h-full flex-col overflow-hidden bg-app font-sans text-text select-none"
     >
-      <Header />
-      <div className="flex min-h-0 flex-1">
-        <Sidebar />
-        <Body />
-      </div>
+      {compact ? <Compact /> : <Wide />}
       <Generator />
-      <Palette />
+      {/* ⌘K needs a keyboard to reach and a rail's worth of room to read: on a
+          phone it is neither reachable nor the way anything is found. */}
+      {!compact && <Palette />}
       <AddSecret />
       <Scan />
       {/* `copied-notification` + `hidden` are toggled by services/copy.ts; the

--- a/src/components/elements/AuthShell.tsx
+++ b/src/components/elements/AuthShell.tsx
@@ -18,7 +18,14 @@ export default function AuthShell({ children, onBack }: Props) {
   const { t } = useTranslation()
   const meta = useAuthMeta()
   return (
-    <div className="relative flex h-full flex-col items-center justify-center overflow-hidden bg-app px-10 text-text select-none">
+    // Compact narrows the gutters, pads past the notch and the home indicator,
+    // and reserves the bottom chrome's height so the centered column is never
+    // laid over the "Go Back" link or the footer strip on a short screen. The
+    // column then centers with `my-auto` rather than `justify-center`, which
+    // keeps it scrollable instead of clipped when it still does not fit. At
+    // md: — the same 768px the shell switches on — every one of those is off
+    // again and the wide layout is what it was.
+    <div className="relative flex h-full flex-col items-center overflow-x-hidden overflow-y-auto overscroll-contain bg-app px-5 pt-[env(safe-area-inset-top)] pb-[calc(env(safe-area-inset-bottom)+7rem)] text-text select-none md:px-10 md:pt-0 md:pb-0">
       <div
         aria-hidden
         className="pointer-events-none absolute left-1/2 top-[44%] h-[700px] w-[1200px] max-w-none -translate-x-1/2 -translate-y-1/2"
@@ -40,7 +47,7 @@ export default function AuthShell({ children, onBack }: Props) {
         className="absolute inset-x-0 top-0 h-[38px]"
       />
 
-      <div className="relative w-[560px] max-w-full">{children}</div>
+      <div className="relative my-auto w-[560px] max-w-full">{children}</div>
 
       {onBack && (
         <button

--- a/src/components/elements/Modal.tsx
+++ b/src/components/elements/Modal.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 import { cx } from '@/utils/cx'
+import { useDialogFocus } from '@/hooks/useDialogFocus'
 import { CloseGlyph } from '../Main/icons'
 import IconButton from './IconButton'
-
-const TABBABLE =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 
 interface Props {
   onClose: () => void
@@ -28,45 +26,7 @@ export default function Modal({
   children
 }: Props) {
   const card = useRef<HTMLDivElement>(null)
-
-  const tabbables = () =>
-    Array.from(card.current?.querySelectorAll<HTMLElement>(TABBABLE) ?? [])
-
-  // A modal owns the keyboard while it is up, so focus starts inside it and
-  // goes back to whatever opened it on close — otherwise the tab order resumes
-  // at the top of the document.
-  useEffect(() => {
-    const trigger = document.activeElement as HTMLElement | null
-    const first = tabbables()[0]
-    if (first) first.focus()
-    else card.current?.focus()
-    return () => trigger?.focus()
-  }, [])
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      // Only the topmost dialog owns the keyboard: a stacked one (the generator
-      // over Settings) would otherwise be closed from underneath by Escape, or
-      // have its focus pulled back down by the trap below.
-      const dialogs = document.querySelectorAll('[role="dialog"]')
-      if (dialogs[dialogs.length - 1] !== card.current) return
-      // Escape closes every modal — the scrim and the X are pointer-only exits.
-      if (e.key === 'Escape') return onClose()
-      // Arrow keys are left alone: the add-secret picker steers its grid with
-      // them.
-      if (e.key !== 'Tab') return
-      const all = tabbables()
-      if (all.length === 0) return
-      const edge = e.shiftKey ? all[0] : all[all.length - 1]
-      const inside = card.current?.contains(document.activeElement)
-      if (!inside || document.activeElement === edge) {
-        e.preventDefault()
-        ;(e.shiftKey ? all[all.length - 1] : all[0]).focus()
-      }
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [onClose])
+  useDialogFocus(card, onClose)
 
   return (
     <div

--- a/src/components/elements/Sheet.tsx
+++ b/src/components/elements/Sheet.tsx
@@ -1,6 +1,7 @@
-import { useEffect, type ReactNode, type Ref } from 'react'
+import { useRef, type ReactNode, type Ref } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { useDialogFocus } from '@/hooks/useDialogFocus'
+import { useVisualViewport, viewportStyle } from '@/hooks/useVisualViewport'
 import { CloseGlyph } from '../Main/icons'
 import IconButton from './IconButton'
 
@@ -15,6 +16,7 @@ interface Props {
   testid?: string
   /** Pinned under the bar, outside the scroller (a section switcher, say). */
   toolbar?: ReactNode
+  /** The frame element, for a caller that runs its own topmost-dialog check. */
   ref?: Ref<HTMLDivElement>
   children: ReactNode
 }
@@ -24,8 +26,9 @@ interface Props {
  *
  * A phone has no room for a 470–860px card floating on a scrim, so the same
  * content takes the whole screen instead: safe-area padded, its own close
- * control in a 44px bar, and one scroller sized to the visible viewport so a
- * focused field is not left under the keyboard.
+ * control in a 44px bar, and one scroller pinned to the visible viewport so a
+ * focused field is not left under the keyboard. It is as modal as the card:
+ * focus starts inside, Tab stays inside, and closing hands focus back.
  */
 export default function Sheet({
   onClose,
@@ -37,30 +40,30 @@ export default function Sheet({
   children
 }: Props) {
   const { t } = useTranslation()
-  const height = useVisualViewport()
+  const view = useVisualViewport()
+  const frame = useRef<HTMLDivElement>(null)
+  useDialogFocus(frame, onClose)
 
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape' || event.defaultPrevented) return
-      event.preventDefault()
-      onClose()
-    }
-    window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [onClose])
+  // One node, two refs: the focus trap's and whatever the caller asked for.
+  const setFrame = (node: HTMLDivElement | null) => {
+    frame.current = node
+    if (typeof ref === 'function') ref(node)
+    else if (ref) ref.current = node
+  }
 
   return (
     <div
-      ref={ref}
+      ref={setFrame}
       role="dialog"
       aria-modal="true"
+      tabIndex={-1}
       aria-label={title}
       aria-labelledby={title ? undefined : labelledBy}
       data-testid={testid}
       // Which frame won, for anything asking (tests, styling hooks) without
       // having to read class names off the element.
       data-frame="sheet"
-      style={{ height: height ?? undefined }}
+      style={viewportStyle(view)}
       className="animate-fade fixed inset-0 z-50 flex flex-col bg-detail pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-text"
     >
       <div className="flex h-14 flex-none items-center gap-1 border-b border-line px-2">

--- a/src/components/elements/Sheet.tsx
+++ b/src/components/elements/Sheet.tsx
@@ -57,6 +57,9 @@ export default function Sheet({
       aria-label={title}
       aria-labelledby={title ? undefined : labelledBy}
       data-testid={testid}
+      // Which frame won, for anything asking (tests, styling hooks) without
+      // having to read class names off the element.
+      data-frame="sheet"
       style={{ height: height ?? undefined }}
       className="animate-fade fixed inset-0 z-50 flex flex-col bg-detail pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-text"
     >

--- a/src/components/elements/Sheet.tsx
+++ b/src/components/elements/Sheet.tsx
@@ -1,0 +1,83 @@
+import { useEffect, type ReactNode, type Ref } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { CloseGlyph } from '../Main/icons'
+import IconButton from './IconButton'
+
+interface Props {
+  onClose: () => void
+  /**
+   * Shown in the bar beside the close control. Left out where the body already
+   * carries its own heading, so the sheet does not say it twice.
+   */
+  title?: string
+  labelledBy?: string
+  testid?: string
+  /** Pinned under the bar, outside the scroller (a section switcher, say). */
+  toolbar?: ReactNode
+  ref?: Ref<HTMLDivElement>
+  children: ReactNode
+}
+
+/**
+ * The compact frame for what the wide shell shows as a centered dialog.
+ *
+ * A phone has no room for a 470–860px card floating on a scrim, so the same
+ * content takes the whole screen instead: safe-area padded, its own close
+ * control in a 44px bar, and one scroller sized to the visible viewport so a
+ * focused field is not left under the keyboard.
+ */
+export default function Sheet({
+  onClose,
+  title,
+  labelledBy,
+  testid,
+  toolbar,
+  ref,
+  children
+}: Props) {
+  const { t } = useTranslation()
+  const height = useVisualViewport()
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return
+      event.preventDefault()
+      onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      aria-labelledby={title ? undefined : labelledBy}
+      data-testid={testid}
+      style={{ height: height ?? undefined }}
+      className="animate-fade fixed inset-0 z-50 flex flex-col bg-detail pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-text"
+    >
+      <div className="flex h-14 flex-none items-center gap-1 border-b border-line px-2">
+        <IconButton
+          muted
+          testid="modal-close"
+          label={t('Close')}
+          onClick={onClose}
+          className="h-11 w-11"
+        >
+          <CloseGlyph size={18} />
+        </IconButton>
+        {title && (
+          <h1 className="min-w-0 flex-1 truncate text-lg font-semibold tracking-display">
+            {title}
+          </h1>
+        )}
+      </div>
+      {toolbar}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
+    </div>
+  )
+}

--- a/src/hooks/useDialogFocus.ts
+++ b/src/hooks/useDialogFocus.ts
@@ -1,0 +1,56 @@
+import { useEffect, type RefObject } from 'react'
+
+const TABBABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+const tabbables = (root: HTMLElement | null) =>
+  Array.from(root?.querySelectorAll<HTMLElement>(TABBABLE) ?? [])
+
+/**
+ * The keyboard contract every dialog frame shares — the centered `Modal` and
+ * the full-screen `Sheet` alike.
+ *
+ * A dialog owns the keyboard while it is up: focus starts inside it, Tab cycles
+ * within it, Escape closes it, and focus goes back to whatever opened it on
+ * close — otherwise the tab order resumes at the top of the document, behind
+ * the dialog. Only the topmost `[role="dialog"]` reacts, so a stacked one (the
+ * generator over Settings) is neither closed from underneath by Escape nor has
+ * its focus pulled back down by the trap.
+ */
+export function useDialogFocus(dialog: RefObject<HTMLElement | null>, onClose: () => void) {
+  useEffect(() => {
+    const trigger = document.activeElement as HTMLElement | null
+    const first = tabbables(dialog.current)[0]
+    if (first) first.focus()
+    else dialog.current?.focus()
+    return () => trigger?.focus()
+  }, [dialog])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Something nearer the key already handled it (a field's own Esc, the
+      // generator's own listener) — acting again would close twice.
+      if (e.defaultPrevented) return
+      const dialogs = document.querySelectorAll('[role="dialog"]')
+      if (dialogs[dialogs.length - 1] !== dialog.current) return
+      // Escape closes every dialog — the scrim and the X are pointer-only exits.
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        return onClose()
+      }
+      // Arrow keys are left alone: the add-secret picker steers its grid with
+      // them.
+      if (e.key !== 'Tab') return
+      const all = tabbables(dialog.current)
+      if (all.length === 0) return
+      const edge = e.shiftKey ? all[0] : all[all.length - 1]
+      const inside = dialog.current?.contains(document.activeElement)
+      if (!inside || document.activeElement === edge) {
+        e.preventDefault()
+        ;(e.shiftKey ? all[all.length - 1] : all[0]).focus()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [dialog, onClose])
+}

--- a/src/hooks/useLayout.ts
+++ b/src/hooks/useLayout.ts
@@ -1,0 +1,30 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Which shell the window is wide enough for.
+ *
+ * `compact` is the phone shell (one screen at a time, a bottom tab bar);
+ * `wide` is the three-pane desktop/iPad shell. 768px is the cut because a
+ * landscape phone still belongs on the compact side of it while the smallest
+ * iPad in portrait does not.
+ */
+export type Layout = 'compact' | 'wide'
+
+export const COMPACT_QUERY = '(max-width: 767px)'
+
+// jsdom and a server render have no matchMedia; both fall back to `wide`, which
+// is the shell every existing test and the desktop window already assume.
+const media = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(COMPACT_QUERY)
+    : null
+
+const subscribe = (onChange: () => void) => {
+  const query = media()
+  query?.addEventListener('change', onChange)
+  return () => query?.removeEventListener('change', onChange)
+}
+
+const snapshot = (): Layout => (media()?.matches ? 'compact' : 'wide')
+
+export const useLayout = (): Layout => useSyncExternalStore(subscribe, snapshot, () => 'wide')

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,4 +1,11 @@
-import { useSyncExternalStore } from 'react'
+import { useSyncExternalStore, type CSSProperties } from 'react'
+
+export interface VisualViewport {
+  /** The height still visible above the on-screen keyboard. */
+  height: number
+  /** How far iOS has panned the visible area down from the layout viewport's top. */
+  offsetTop: number
+}
 
 const viewport = () => (typeof window === 'undefined' ? null : (window.visualViewport ?? null))
 
@@ -12,16 +19,39 @@ const subscribe = (onChange: () => void) => {
   }
 }
 
-const snapshot = () => viewport()?.height ?? null
+// `useSyncExternalStore` re-renders on every snapshot that is not `===` the
+// last, so the object is reused until one of its two numbers actually moves.
+let last: VisualViewport | null = null
+const snapshot = (): VisualViewport | null => {
+  const view = viewport()
+  if (!view) return (last = null)
+  if (last?.height !== view.height || last.offsetTop !== view.offsetTop) {
+    last = { height: view.height, offsetTop: view.offsetTop }
+  }
+  return last
+}
 
 /**
- * The height still visible above the on-screen keyboard.
+ * The part of the page the user can actually see once the keyboard is up.
  *
- * iOS does not shrink the layout viewport when the keyboard comes up, so a
+ * iOS does not shrink the layout viewport when the keyboard comes up: a
  * `height: 100%` shell keeps its full height and pushes the focused input under
- * the keys. Sizing the compact shell and its sheets from this instead keeps the
- * caret in view. Null where the API is absent (desktop webviews, jsdom), and
- * callers then leave the height to CSS.
+ * the keys, and when the caret then has to be scrolled into view iOS pans the
+ * visible area down instead, leaving anything anchored to the layout top out
+ * of sight. Sizing the compact shell and its sheets from this — height and
+ * offset both, see [`viewportStyle`] — keeps the caret in view. Null where the
+ * API is absent (desktop webviews, jsdom), and callers then leave it to CSS.
  */
-export const useVisualViewport = (): number | null =>
+export const useVisualViewport = (): VisualViewport | null =>
   useSyncExternalStore(subscribe, snapshot, () => null)
+
+// The inline style that pins an element to the visible area: its height, and a
+// translate for however far iOS has panned it. Both callers (the compact shell,
+// the sheet frame) need the same two lines, so they live here.
+export const viewportStyle = (view: VisualViewport | null): CSSProperties | undefined =>
+  view
+    ? {
+        height: view.height,
+        transform: view.offsetTop ? `translateY(${view.offsetTop}px)` : undefined
+      }
+    : undefined

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react'
+
+const viewport = () => (typeof window === 'undefined' ? null : (window.visualViewport ?? null))
+
+const subscribe = (onChange: () => void) => {
+  const view = viewport()
+  view?.addEventListener('resize', onChange)
+  view?.addEventListener('scroll', onChange)
+  return () => {
+    view?.removeEventListener('resize', onChange)
+    view?.removeEventListener('scroll', onChange)
+  }
+}
+
+const snapshot = () => viewport()?.height ?? null
+
+/**
+ * The height still visible above the on-screen keyboard.
+ *
+ * iOS does not shrink the layout viewport when the keyboard comes up, so a
+ * `height: 100%` shell keeps its full height and pushes the focused input under
+ * the keys. Sizing the compact shell and its sheets from this instead keeps the
+ * caret in view. Null where the API is absent (desktop webviews, jsdom), and
+ * callers then leave the height to CSS.
+ */
+export const useVisualViewport = (): number | null =>
+  useSyncExternalStore(subscribe, snapshot, () => null)

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -114,6 +114,7 @@
   "Update check failed.": "Update check failed.",
   "Discard changes?": "Discard changes?",
   "Close": "Close",
+  "Back": "Back",
   "Run a command": "Run a command",
   "No results": "No results",
   "Lock vault": "Lock vault",

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -42,13 +42,17 @@ export default function Fields() {
 
   return (
     <div
-      className={aside ? 'grid grid-cols-[460px_minmax(0,1fr)] items-start gap-3' : undefined}
+      // Compact has no room for the art and the rest of the fields side by
+      // side, so below 768px the pair stacks instead.
+      className={
+        aside ? 'grid grid-cols-1 items-start gap-3 md:grid-cols-[460px_minmax(0,1fr)]' : undefined
+      }
     >
       {/* Card art: an always-dark plastic-card visual, deliberately off-system.
           Its gradient, hex inks, 16/4px radii, unleaded type sizes and the
           number's wide letter-spacing imitate a real card, so they are exempt
           from the type/radius/tracking scales. */}
-      <div className="relative flex h-[288px] w-[460px] flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_12px_28px_rgba(0,0,0,0.22)]">
+      <div className="relative flex h-[288px] w-[460px] max-w-full flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_12px_28px_rgba(0,0,0,0.22)]">
         <div className="absolute -right-10 -top-16 h-[240px] w-[240px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
 
         <div className="relative flex items-start justify-between gap-4">
@@ -92,7 +96,9 @@ export default function Fields() {
           placeholder={CARD_MASK}
           required
           maxLength={23}
-          ink="text-[24px] tracking-[0.14em]"
+          // A shrunk card cannot hold 19 glyphs at 24px; below 768px it steps
+          // down a tier so the number still fits its plastic.
+          ink="text-[19px] tracking-[0.14em] md:text-[24px]"
           className="-mx-1.5 self-stretch"
         />
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -158,6 +158,22 @@
     height: 100%;
   }
 
+  /*
+   * Touch manners. `manipulation` drops the 300ms double-tap-to-zoom wait (the
+   * app has nothing to zoom into); `overscroll-behavior: none` stops the whole
+   * shell from rubber-banding when a list hits its end; the tap highlight is
+   * WebKit's grey flash, which the app's own hover/active inks already replace.
+   */
+  html,
+  body {
+    overscroll-behavior: none;
+  }
+
+  #root {
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
   body {
     margin: 0;
     background: var(--c-app);

--- a/src/test/compact.test.tsx
+++ b/src/test/compact.test.tsx
@@ -107,7 +107,11 @@ describe('overlay frames', () => {
   it('gives settings a sheet on compact and the modal on wide', () => {
     const { unmount } = renderWithStore(<Main />, { store: seed() })
     act(() => openSettings())
-    expect(screen.getByTestId('settings-modal')).toHaveAttribute('data-frame', 'sheet')
+    const sheet = screen.getByTestId('settings-modal')
+    expect(sheet).toHaveAttribute('data-frame', 'sheet')
+    // Outside the shell: a translated ancestor would become the containing
+    // block for the sheet's `fixed` and stack the keyboard offset twice.
+    expect(screen.getByTestId('compact-shell')).not.toContainElement(sheet)
     unmount()
 
     setLayout('wide')

--- a/src/test/compact.test.tsx
+++ b/src/test/compact.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Main from '@/components/Main'
+import AuthShell from '@/components/elements/AuthShell'
+import { revealEntry } from '@/lib/commands'
+import { makeStore, useStore, openPalette, openSettings, openAddPicker } from '@/store'
+import { renderWithStore, withEntries, loginEntry, loginMeta } from './utils'
+import { setLayout } from './layout'
+
+const seed = () => {
+  const store = makeStore()
+  withEntries([loginMeta({ id: 'l1', title: 'Google' }), loginMeta({ id: 'l2', title: 'Airbnb' })])
+  return store
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setLayout('compact')
+})
+
+describe('compact shell', () => {
+  it('replaces the rail with a tab bar and puts add and tags in the list header', () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    expect(screen.getByTestId('compact-shell')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-bar')).toBeInTheDocument()
+    expect(screen.queryByTestId('view-items')).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-entry-button')).toBeInTheDocument()
+    expect(screen.getByTestId('tags-button')).toBeInTheDocument()
+  })
+
+  it('pushes the detail screen on select and comes back from it', async () => {
+    vi.mocked(revealEntry).mockResolvedValue(loginEntry({ id: 'l1', title: 'Google' }))
+    renderWithStore(<Main />, { store: seed() })
+
+    expect(screen.getAllByTestId('entry-item')).toHaveLength(2)
+    expect(screen.queryByTestId('compact-back')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Google'))
+    expect(screen.getByRole('heading', { name: 'Google' })).toBeInTheDocument()
+    // One screen at a time: the list and the tab bar are gone while it is up.
+    expect(screen.queryByTestId('entry-item')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('tab-bar')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('compact-back'))
+    expect(useStore.getState().entries.current).toBeNull()
+    expect(screen.getAllByTestId('entry-item')).toHaveLength(2)
+  })
+
+  it('lands a new entry on the detail screen, without an unguarded way back', async () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    await userEvent.click(screen.getByTestId('add-entry-button'))
+    await userEvent.click(screen.getByTestId('add-kind-login'))
+
+    expect(useStore.getState().entries.new).toBe('login')
+    expect(screen.getByTestId('entry-sheet')).toBeInTheDocument()
+    // Cancel/Discard in the editor is the only exit, so a draft cannot be
+    // dropped by a stray tap on the bar.
+    expect(screen.queryByTestId('compact-back')).not.toBeInTheDocument()
+    expect(screen.getByTestId('cancel-entry-button')).toBeInTheDocument()
+  })
+
+  it('switches view from the tab bar', async () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    await userEvent.click(screen.getByTestId('tab-favorites'))
+    expect(useStore.getState().ui.view).toBe('favorites')
+    expect(screen.getByTestId('list-title')).toHaveTextContent('Favorites')
+
+    await userEvent.click(screen.getByTestId('tab-archive'))
+    expect(useStore.getState().ui.view).toBe('archive')
+
+    await userEvent.click(screen.getByTestId('tab-items'))
+    expect(useStore.getState().ui.view).toBe('items')
+  })
+
+  it('opens the generator and settings from the tab bar', async () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    await userEvent.click(screen.getByTestId('tab-generator'))
+    expect(screen.getByTestId('generator-dialog')).toHaveAttribute('data-frame', 'sheet')
+
+    await userEvent.keyboard('{Escape}')
+    await userEvent.click(screen.getByTestId('tab-settings'))
+    expect(useStore.getState().ui.settings).toBe(true)
+  })
+
+  it('shows the empty-vault hero on the one pane it has', () => {
+    const store = makeStore()
+    withEntries([])
+    renderWithStore(<Main />, { store })
+
+    expect(screen.getAllByText('Your vault is empty')).toHaveLength(1)
+  })
+
+  it('leaves the command palette out', () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    act(() => openPalette())
+    expect(screen.queryByPlaceholderText('Run a command')).not.toBeInTheDocument()
+  })
+})
+
+describe('overlay frames', () => {
+  it('gives settings a sheet on compact and the modal on wide', () => {
+    const { unmount } = renderWithStore(<Main />, { store: seed() })
+    act(() => openSettings())
+    expect(screen.getByTestId('settings-modal')).toHaveAttribute('data-frame', 'sheet')
+    unmount()
+
+    setLayout('wide')
+    renderWithStore(<Main />, { store: seed() })
+    act(() => openSettings())
+    expect(screen.getByTestId('settings-modal')).not.toHaveAttribute('data-frame')
+  })
+
+  it('gives the add picker a sheet on compact', () => {
+    renderWithStore(<Main />, { store: seed() })
+    act(() => openAddPicker())
+    expect(screen.getByTestId('add-secret-modal')).toHaveAttribute('data-frame', 'sheet')
+  })
+})
+
+describe('AuthShell on compact', () => {
+  it('renders its column and the back affordance', () => {
+    const onBack = vi.fn()
+    renderWithStore(
+      <AuthShell onBack={onBack}>
+        <div>Unlock</div>
+      </AuthShell>
+    )
+
+    expect(screen.getByText('Unlock')).toBeInTheDocument()
+    expect(screen.getByTestId('go-back-button')).toBeInTheDocument()
+  })
+})

--- a/src/test/layout.ts
+++ b/src/test/layout.ts
@@ -1,0 +1,21 @@
+import { COMPACT_QUERY, type Layout } from '@/hooks/useLayout'
+
+/**
+ * jsdom ships no matchMedia at all, so `useLayout` would otherwise fall back to
+ * `wide` by accident rather than by measurement. `setup.ts` installs the wide
+ * stub before every test; a compact test opts in by calling this again.
+ */
+export const setLayout = (layout: Layout) => {
+  const compact = layout === 'compact'
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: compact && query === COMPACT_QUERY,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    }) as unknown as MediaQueryList) as typeof window.matchMedia
+}

--- a/src/test/modal.test.tsx
+++ b/src/test/modal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Settings from '@/components/Main/Sidebar/Settings'
 import Modal from '@/components/elements/Modal'
+import Sheet from '@/components/elements/Sheet'
 import { renderWithStore } from './utils'
 
 const openSettings = async () => {
@@ -57,5 +58,46 @@ describe('Modal focus management', () => {
     await userEvent.keyboard('{Escape}')
 
     expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// The compact frame is a dialog too, so it owes the keyboard the same contract.
+describe('Sheet focus management', () => {
+  const renderSheet = (onClose = vi.fn()) => {
+    const result = render(
+      <Sheet onClose={onClose} testid="sheet">
+        <input aria-label="first" />
+        <button type="button">last</button>
+      </Sheet>
+    )
+    return { ...result, sheet: screen.getByTestId('sheet') }
+  }
+
+  it('moves focus inside when it opens', () => {
+    const { sheet } = renderSheet()
+    expect(sheet.contains(document.activeElement)).toBe(true)
+  })
+
+  it('keeps Tab from leaving the sheet', async () => {
+    const { sheet } = renderSheet()
+    screen.getByText('last').focus()
+    await userEvent.tab()
+    expect(sheet.contains(document.activeElement)).toBe(true)
+  })
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    const onClose = vi.fn()
+    const { unmount } = renderSheet(onClose)
+    expect(trigger).not.toHaveFocus()
+
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+
+    unmount()
+    expect(trigger).toHaveFocus()
+    trigger.remove()
   })
 })

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,8 +1,14 @@
 import '@testing-library/jest-dom/vitest'
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
+import { setLayout } from './layout'
 
 // jsdom implements no layout, so it ships no scrollIntoView.
 Element.prototype.scrollIntoView = vi.fn()
+
+// Every suite starts on the wide shell — the one the desktop window and all the
+// pre-existing tests assume. A compact test calls `setLayout('compact')` itself.
+setLayout('wide')
+beforeEach(() => setLayout('wide'))
 
 // The Rust backend is built in parallel; mock the whole command/event layer so
 // screens render without a live backend. Individual tests override as needed.

--- a/src/test/useLayout.test.ts
+++ b/src/test/useLayout.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useLayout } from '@/hooks/useLayout'
-import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { useVisualViewport, viewportStyle } from '@/hooks/useVisualViewport'
 import { setLayout } from './layout'
 
 describe('useLayout', () => {
@@ -28,12 +28,32 @@ describe('useVisualViewport', () => {
     expect(renderHook(() => useVisualViewport()).result.current).toBeNull()
   })
 
-  it('reports the visible height when the API is there', () => {
+  const install = (height: number, offsetTop: number) =>
     Object.defineProperty(window, 'visualViewport', {
       configurable: true,
-      value: { height: 640, addEventListener: () => {}, removeEventListener: () => {} }
+      value: { height, offsetTop, addEventListener: () => {}, removeEventListener: () => {} }
     })
-    expect(renderHook(() => useVisualViewport()).result.current).toBe(640)
+  const uninstall = () =>
     Object.defineProperty(window, 'visualViewport', { configurable: true, value: undefined })
+
+  it('reports the visible height and how far iOS panned it', () => {
+    install(640, 120)
+    expect(renderHook(() => useVisualViewport()).result.current).toEqual({
+      height: 640,
+      offsetTop: 120
+    })
+    uninstall()
+  })
+
+  it('turns that into a height plus a translate, and no translate when unpanned', () => {
+    expect(viewportStyle(null)).toBeUndefined()
+    expect(viewportStyle({ height: 640, offsetTop: 0 })).toEqual({
+      height: 640,
+      transform: undefined
+    })
+    expect(viewportStyle({ height: 640, offsetTop: 120 })).toEqual({
+      height: 640,
+      transform: 'translateY(120px)'
+    })
   })
 })

--- a/src/test/useLayout.test.ts
+++ b/src/test/useLayout.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useLayout } from '@/hooks/useLayout'
+import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { setLayout } from './layout'
+
+describe('useLayout', () => {
+  it('reads wide when the compact query does not match', () => {
+    expect(renderHook(() => useLayout()).result.current).toBe('wide')
+  })
+
+  it('reads compact when the query matches', () => {
+    setLayout('compact')
+    expect(renderHook(() => useLayout()).result.current).toBe('compact')
+  })
+
+  it('falls back to wide where matchMedia is missing', () => {
+    const original = window.matchMedia
+    // @ts-expect-error — modelling a webview without the API at all.
+    delete window.matchMedia
+    expect(renderHook(() => useLayout()).result.current).toBe('wide')
+    window.matchMedia = original
+  })
+})
+
+describe('useVisualViewport', () => {
+  it('is null where the API is absent', () => {
+    expect(renderHook(() => useVisualViewport()).result.current).toBeNull()
+  })
+
+  it('reports the visible height when the API is there', () => {
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: { height: 640, addEventListener: () => {}, removeEventListener: () => {} }
+    })
+    expect(renderHook(() => useVisualViewport()).result.current).toBe(640)
+    Object.defineProperty(window, 'visualViewport', { configurable: true, value: undefined })
+  })
+})


### PR DESCRIPTION
Part of the iOS port (PR 2 of 5). Below 768px CSS width the app renders a phone shell; at 768px and up (iPad, desktop) the existing three-pane shell renders unchanged. Frontend only, no new dependencies.

## What's here
- `useLayout()` in `src/hooks/useLayout.ts` returns `compact` or `wide` from a single media query via `useSyncExternalStore`, falling back to `wide` where `matchMedia` is missing (jsdom, the desktop tests).
- `Main/index.tsx` picks `Main/Wide.tsx` (the previous Header + Sidebar + Body tree, moved verbatim) or `Main/Compact/`: a top bar with a back control, one screen at a time (list or detail), and a bottom tab bar (All Items, Favorites, Archive, Generator, Settings) padded for the home indicator. The tag filter and the add button move into the list header on compact. The palette is not mounted on compact.
- `elements/Sheet.tsx` is the compact frame for what wide shows as a centered dialog: full screen, safe-area padded, a 44px close control, and a scroller sized from `visualViewport` so the iOS keyboard does not hide the focused field. Settings, the add-secret picker and the generator dialog reuse their existing bodies inside it.
- `index.html` viewport gains `viewport-fit=cover` (no `maximum-scale`, pinch zoom stays). `theme.css` adds `overscroll-behavior: none`, `touch-action: manipulation` and a transparent tap highlight.
- `AuthShell` narrows its gutters, pads for the safe areas and reserves room for the footer so the lock, setup and restore screens fit a 320px-wide phone. Every compact rule resets at `md:`, so wide is byte-identical.

## Two bugs fixed along the way
- The empty-vault hero passed `openSettings` straight to `onClick`, so the click event became the section argument and Settings opened on no section. It now opens the import section it names.
- The card kind rendered a fixed 460px card art and grid column, overflowing a phone by about 100px. It now caps at the container width and stacks below `md:`.

## Verified
`bun run typecheck`, `bun run lint` (0 warnings), `bun run test` (49 files, 447 tests). New coverage in `src/test/useLayout.test.ts` and `src/test/compact.test.tsx`: tab bar replaces the rail, list to detail and back, no unguarded exit from a new draft, tab switching sets the view, settings opens as a sheet on compact and as the modal on wide, palette absent on compact. `src/test/setup.ts` installs a default wide `matchMedia` stub so pre-existing suites are unaffected; none were modified.

## Not verified
No visual check was possible on the build machine. Safe-area insets against a real notch, `visualViewport` under the iOS keyboard, and how the edit forms reflow at 390px need a device or simulator.