### PR TITLE
chore(deps): group passkey-rs bumps and ignore p256/coset/rand majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,25 @@ updates:
         patterns:
           - 'tauri'
           - 'tauri-*'
+      # 1Password's passkey-rs crates share one release train; bumping one
+      # alone breaks the CredentialStore trait impls in src/passkey.
+      passkey-rs:
+        patterns:
+          - 'passkey-*'
+    ignore:
+      # passkey-rs requires p256 ^0.13. 0.14 would link a second copy and
+      # break the COSE key bridge. Lift once passkey-rs moves to p256 0.14.
+      - dependency-name: p256
+        versions: ['>=0.14']
+      # passkey-rs caps coset at 0.4.0, so 0.4.x gains nothing and splits the
+      # tree. Lift together with the p256 rule.
+      - dependency-name: coset
+        versions: ['>=0.4']
+      # rand 0.9+ moves to a new rand_core generation. passkey-rs (rand ^0.8),
+      # p256 0.13 and ssh-key 0.6 (rand_core 0.6) are not there yet, so a lone
+      # bump leaves two rand generations and breaks every RNG handoff.
+      - dependency-name: rand
+        versions: ['>=0.9']
 
   # GitHub Actions used by ci.yml / release.yml / codeql.yml.
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,10 +45,10 @@ updates:
       # break the COSE key bridge. Lift once passkey-rs moves to p256 0.14.
       - dependency-name: p256
         versions: ['>=0.14']
-      # passkey-rs caps coset at 0.4.0, so 0.4.x gains nothing and splits the
-      # tree. Lift together with the p256 rule.
+      # passkey-rs caps coset at 0.4.0 (inclusive), so 0.4.0 itself is fine
+      # but anything above it splits the tree. Lift together with the p256 rule.
       - dependency-name: coset
-        versions: ['>=0.4']
+        versions: ['>0.4.0']
       # rand 0.9+ moves to a new rand_core generation. passkey-rs (rand ^0.8),
       # p256 0.13 and ssh-key 0.6 (rand_core 0.6) are not there yet, so a lone
       # bump leaves two rand generations and breaks every RNG handoff.


### PR DESCRIPTION
## Why

After #378 pointed Dependabot at `main`, it opened p256 0.14 (#379), coset 0.4 (#380), passkey-authenticator 0.5 (#381) and passkey-client 0.5 (#382) as four separate PRs, and all four fail CI. The passkey-rs crates only compile when bumped together, and passkey-rs itself pins `p256 ^0.13` and `coset <=0.4.0`, so #379 and #380 can never merge on their own.

## Changes to `dependabot.yml` (cargo ecosystem)

- **Group `passkey-*`** so passkey-types, passkey-authenticator and passkey-client move in one PR.
- **Ignore `p256 >=0.14`** and **`coset >=0.4`** until passkey-rs supports them. Each rule carries a comment naming the blocker so it is easy to lift.
- **Ignore `rand >=0.9`**. rand 0.9+ moves to a new rand_core generation. passkey-rs (`rand ^0.8`), p256 0.13 and ssh-key 0.6 (`rand_core 0.6`) are not there yet, so a lone bump would leave two rand generations in the tree and break every call that hands an RNG to p256 or ssh-key.

## Repo side

The `rust` and `ci` labels referenced by the config did not exist, so Dependabot posted a "labels could not be found" error on every PR. Both labels are now created.

## Housekeeping done alongside

Closed the eight remaining `v1-0-0` PRs (#362, #363, #364, #365, #367, #369, #370, #371) and #379, #380 with a comment. Their bumps are being landed against `main` in dedicated PRs: npm majors, aes-gcm 0.11, totp-rs 6 + windows 0.62, passkey-rs 0.5. rand 0.10 is deferred per the ignore rule above.