### PR TITLE
fix(ios): pin the viewport scale so tapping a field no longer zooms the shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,15 @@
     <!--
       `viewport-fit=cover` lets the shell paint under the notch and the home
       indicator; the safe-area insets it unlocks are what the compact chrome
-      pads itself with. No maximum-scale / user-scalable: pinch zoom stays.
+      pads itself with. `maximum-scale=1` pins the scale: iOS otherwise zooms
+      the page when a field whose text is under 16px is tapped (the 15px
+      passphrase and search fields) and never zooms back, leaving the shell
+      wider than the screen and shorter than it. The app is not a document, so
+      it has nothing to pinch into either.
     -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <title>Swifty</title>
     <!--


### PR DESCRIPTION
## Problem

On the iPhone 17 simulator the compact shell rendered wider than the screen (content touching the edges, horizontal pan, paddings off-screen) and shorter than it (tab bar floating ~95pt above the bottom with the app ground showing beneath).

## Cause

iOS page zoom, not the window. Tauri ignores the desktop width/height on mobile and tao creates the window at the screen bounds; a fresh launch renders the lock screen pixel-perfect. But iOS WebKit zooms the page whenever a focused field's text is under 16px, and WKWebView never zooms back out. Tapping the 15px master-password field left the page at 16/15 scale, which is exactly what the pixel measurements of the buttons and tab pill showed. Under that zoom only ~377 of the 402 layout px fit on screen, and the shell (sized from `visualViewport.height`) ends short of the bottom.

## Fix

Pin the viewport scale in `index.html`:

```
width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover
```

This stops the focus auto-zoom and pinch zoom. The previous comment that deliberately kept pinch zoom is replaced with one explaining why the scale is pinned; the app is not a document and has nothing to zoom into.

## Verify

Rebuild the iOS app, unlock with the password, and check the list fills the screen with no horizontal pan and the tab bar sits 12pt above the home indicator.