### PR TITLE
chore(deps): bump aes-gcm from 0.10 to 0.11

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,37 +10,37 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.5.2",
  "ctr",
+ "ctutils",
  "ghash",
- "subtle",
 ]
 
 [[package]]
@@ -717,7 +717,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -853,6 +864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -919,7 +936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 
@@ -929,7 +945,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -994,11 +1012,11 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1464,7 +1482,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serde_json",
  "serdect",
@@ -1641,7 +1659,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1986,15 +2004,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -2169,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2628,6 +2646,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3498,12 +3525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "open"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,7 +3647,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
 
@@ -3937,13 +3958,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.1",
  "universal-hash",
 ]
 
@@ -4119,7 +4139,7 @@ checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4129,7 +4149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4140,6 +4160,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-window-handle"
@@ -4317,7 +4343,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature",
  "spki",
@@ -4863,7 +4889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4986,7 +5012,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "ssh-encoding",
 ]
 
@@ -5011,7 +5037,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "sec1",
  "sha2 0.10.9",
@@ -6300,12 +6326,12 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ csv = "1"
 thiserror = "2"
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher-vendored-openssl", "backup"] }
 rusqlite_migration = "1"
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 ring = "0.17"
 sha2 = "0.11"
 rand = "0.8"

--- a/src-tauri/src/crypto/mod.rs
+++ b/src-tauri/src/crypto/mod.rs
@@ -35,6 +35,13 @@ const TAG_LEN: usize = 16;
 const ITERATIONS: u32 = 100_000;
 const KEY_LEN: usize = 32;
 
+/// Borrow `bytes` as a 16-byte GCM nonce. aes-gcm 0.11 models nonces as
+/// `hybrid_array::Array` and deprecates its `from_slice`, so the length check is
+/// ours to make: the decrypt paths take the nonce off the wire as a slice.
+fn to_nonce(bytes: &[u8]) -> Result<Nonce<U16>> {
+    Nonce::<U16>::try_from(bytes).map_err(|_| Error::Crypto("invalid nonce length".into()))
+}
+
 /// `base64( SHA512(pw) )` — the "secret" fed to the cryptor.
 pub fn hash_secret(password: &str) -> String {
     STANDARD.encode(Sha512::digest(password.as_bytes()))
@@ -80,7 +87,7 @@ pub(crate) fn seal_aead(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
     rand::thread_rng().fill_bytes(&mut nonce);
     let sealed = cipher
         .encrypt(
-            Nonce::from_slice(&nonce),
+            &to_nonce(&nonce)?,
             Payload {
                 msg: plaintext,
                 aad: &[],
@@ -102,7 +109,7 @@ pub(crate) fn unseal_aead(key: &[u8], blob: &[u8]) -> Result<Vec<u8>> {
     let cipher = Aes256Gcm16::new_from_slice(key).map_err(err)?;
     cipher
         .decrypt(
-            Nonce::from_slice(nonce),
+            &to_nonce(nonce)?,
             Payload {
                 msg: sealed,
                 aad: &[],
@@ -157,9 +164,7 @@ impl Cryptor {
             aad: &[],
         };
         // aes-gcm returns `ciphertext ‖ tag`; the vault format wants the tag before it.
-        let sealed = cipher
-            .encrypt(Nonce::from_slice(&iv), payload)
-            .map_err(err)?;
+        let sealed = cipher.encrypt(&to_nonce(&iv)?, payload).map_err(err)?;
         let (ciphertext, tag) = sealed.split_at(sealed.len() - TAG_LEN);
 
         let mut out = Vec::with_capacity(SALT_LEN + IV_LEN + TAG_LEN + ciphertext.len());
@@ -190,9 +195,7 @@ impl Cryptor {
             msg: &sealed,
             aad: &[],
         };
-        let plain = cipher
-            .decrypt(Nonce::from_slice(iv), payload)
-            .map_err(err)?;
+        let plain = cipher.decrypt(&to_nonce(iv)?, payload).map_err(err)?;
         String::from_utf8(plain).map_err(err)
     }
 


### PR DESCRIPTION
## What

Bumps `aes-gcm` 0.10.3 → 0.11.1 (RustCrypto 2025 generation: aead 0.6, aes 0.9, cipher 0.5, ghash 0.6, polyval 0.7). Supersedes Dependabot's #367, which was opened against the stale `v1-0-0` branch.

## Code change

`src/crypto/mod.rs` is the only user. In 0.11 the nonce type is a `hybrid_array::Array` whose `from_slice` is deprecated, and CI's clippy runs with `-D warnings`, so the four call sites failed. They now go through one helper:

```rust
fn to_nonce(bytes: &[u8]) -> Result<Nonce<U16>> {
    Nonce::<U16>::try_from(bytes).map_err(|_| Error::Crypto("invalid nonce length".into()))
}
```

The length check is now explicit and surfaces through the module's existing `Error::Crypto` instead of panicking. Two of the four sites take the nonce off the wire as a slice, so the check is real there.

Nothing else needed migrating: `Aead`, `KeyInit::new_from_slice`, `Payload` and `consts::U16` are unchanged, and the `AeadInPlace` → `AeadInOut` rename is covered by the blanket `Aead` impl. The code never used `generate_nonce`/`generate_key`, so aead 0.6's `rand_core 0.10` never touches our call sites and `rand` stays at 0.8.

## Ciphertext format

Unchanged. Same 16-byte nonce, same key derivation, AAD and `salt‖iv‖tag‖ciphertext` layout; only how the nonce bytes are wrapped in a type changed. No test or fixture was modified. The golden-vector tests (`decrypts_golden_fields`, `decrypts_golden_data_blobs`, `decrypts_and_exposes_golden_vault`), which decrypt blobs produced by the independent Node reference in `scripts/crypto-ref.mjs`, pass as-is.

## Cargo.lock

Only aes-gcm's own tree moved. Updated: aead, aes, aes-gcm, ctr, ghash, polyval, universal-hash. Added: cipher 0.5, inout 0.2, rand_core 0.10 (transitive via aead, unused by us), cpubits. Removed: opaque-debug.

## Verified locally

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --locked`: 284 passed, 0 failed, 2 ignored
- `cargo build --locked` ok