### PR TITLE
chore(deps): bump passkey-rs crates from 0.4 to 0.5

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3686,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "passkey-authenticator"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b065ce31354bcf23a333003c77f0d71f00eb95761b3390a069546e078a7a5b"
+checksum = "20bf5800e3f6287580da985fb88e678f37c078d62242cb536941c44d852ab37c"
 dependencies = [
  "async-trait",
  "coset",
@@ -3700,27 +3700,27 @@ dependencies = [
 
 [[package]]
 name = "passkey-client"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5080bfafe23d139ae8be8b907453aee0b8af3ca7cf25d1f8d7bfcf7b079d3412"
+checksum = "1d99509cbbdfe526c617e8265716fba277562a7d771fef047ac9e25686d1c502"
 dependencies = [
  "ciborium",
  "coset",
  "idna",
+ "itertools",
  "passkey-authenticator",
  "passkey-types",
  "public-suffix",
  "serde",
  "serde_json",
- "typeshare",
  "url",
 ]
 
 [[package]]
 name = "passkey-types"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
+checksum = "c2a1fae06bd6bc619675d30b50cb38ca649837cc9e6a92a00b14743cfbdb1390"
 dependencies = [
  "bitflags 2.13.1",
  "ciborium",
@@ -3734,7 +3734,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "strum",
- "typeshare",
+ "url",
  "zeroize",
 ]
 
@@ -5060,23 +5060,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.119",
 ]
 
@@ -6211,28 +6210,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "typeshare"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1bf9fe204f358ffea7f8f779b53923a20278b3ab8e8d97962c5e1b3a54edb7"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "typeshare-annotation",
-]
-
-[[package]]
-name = "typeshare-annotation"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621963e302416b389a1ec177397e9e62de849a78bd8205d428608553def75350"
-dependencies = [
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "uds_windows"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,9 +4,10 @@ version = "1.0.0-alpha.1"
 description = "Modern, Lightweight, Fast and Free Password Manager"
 authors = ["Alex Chaplinsky"]
 edition = "2021"
-# Floor set by the RustCrypto 0.11 generation (sha2, argon2, digest). The
-# toolchain itself is pinned in rust-toolchain.toml.
-rust-version = "1.85"
+# Floor set by the RustCrypto 0.11 generation (sha2, argon2, digest) and by
+# passkey-rs, whose 0.5 release declares 1.85.1. The toolchain itself is pinned
+# in rust-toolchain.toml.
+rust-version = "1.85.1"
 # Desktop application, never published to crates.io.
 publish = false
 
@@ -45,11 +46,11 @@ url = "2"
 zeroize = "1.8.2"
 argon2 = "0.6"
 sys-locale = "0.3"
-# WebAuthn authenticator core (1Password's passkey-rs, MIT OR Apache-2.0). Held
-# at 0.4 deliberately: 0.5 declares rust-version 1.85.1, above this crate's
-# 1.85 MSRV, so the MSRV-aware resolver refuses it. Revisit with the MSRV.
-passkey-types = "0.4"
-passkey-authenticator = "0.4"
+# WebAuthn authenticator core (1Password's passkey-rs, MIT OR Apache-2.0). Kept
+# in lockstep across passkey-types/-authenticator/-client: the traits pass the
+# crates' own types, so a mixed set does not compile.
+passkey-types = "0.5"
+passkey-authenticator = "0.5"
 # P-256 keys (PKCS#8 <-> COSE) and the COSE key type passkey-types speaks.
 # Both pinned to what passkey-authenticator itself depends on, so exactly one
 # copy of each is linked.
@@ -136,7 +137,7 @@ keyring = { version = "3", features = ["windows-native"] }
 # A real WebAuthn client drives the authenticator through a full ceremony in the
 # passkey tests (origin checks, clientDataJSON, attestation) instead of us
 # hand-rolling CTAP2 requests. Test-only: the app never speaks WebAuthn itself.
-passkey-client = "0.4"
+passkey-client = "0.5"
 # The CredentialStore/UserValidationMethod traits are async, so the tests need
 # a runtime; `rt` (current-thread) + `macros` is the whole of it.
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/src-tauri/src/passkey/key.rs
+++ b/src-tauri/src/passkey/key.rs
@@ -48,6 +48,10 @@ pub fn to_passkey_types(passkey: &models::Passkey) -> Result<passkey_types::Pass
         // Ours are always discoverable: the vault is the credential list, so a
         // sign-in with no allowCredentials must still find them.
         user_handle: Some(decode(&passkey.user_handle, "user handle")?.into()),
+        // Carried so the authenticator can name the account in a UI hint; the
+        // relying party never sees either (see `get_assertion`'s response).
+        username: Some(passkey.user_name.clone()),
+        user_display_name: Some(passkey.user_display_name.clone()),
         counter: (passkey.counter != 0).then_some(passkey.counter),
         extensions: Default::default(),
     })

--- a/src-tauri/src/passkey/mod.rs
+++ b/src-tauri/src/passkey/mod.rs
@@ -13,7 +13,10 @@
 //! from an unlocked session in the first place. That makes registering and
 //! signing in silent, which is the weakest acceptable stance and only tenable
 //! because nothing can reach this module yet: the extension PR adds the
-//! per-ceremony confirm prompt and replaces the check with its answer.
+//! per-ceremony confirm prompt and replaces the check with its answer. The one
+//! ceremony it does refuse is a registration whose excludeCredentials names a
+//! credential we already hold — `passkey-authenticator` leaves that answer to
+//! the verification method.
 //!
 //! ## Signature counters
 //! Passkeys here sync between devices, so a per-device counter would look like
@@ -33,7 +36,7 @@ pub mod store;
 #[cfg(test)]
 mod tests;
 
-use passkey_authenticator::{UserCheck, UserValidationMethod};
+use passkey_authenticator::{UiHint, UserCheck, UserValidationMethod};
 use passkey_types::ctap2::{get_assertion, make_credential, Aaguid, Ctap2Error, StatusCode};
 
 use crate::error::{Error, Result};
@@ -108,10 +111,20 @@ impl UserValidationMethod for UnlockedSession {
 
     async fn check_user<'a>(
         &self,
-        _credential: Option<&'a Self::PasskeyItem>,
+        hint: UiHint<'a, Self::PasskeyItem>,
         _presence: bool,
         _verification: bool,
     ) -> std::result::Result<UserCheck, Ctap2Error> {
+        // `make_credential` no longer refuses an excludeCredentials hit itself
+        // (passkey-authenticator 0.5 hands the decision here, so a UI can say
+        // "you already have one"), so refusing is now ours to do — otherwise a
+        // second registration would silently store a duplicate credential.
+        if matches!(hint, UiHint::InformExcludedCredentialFound(_)) {
+            return Err(Ctap2Error::CredentialExcluded);
+        }
+        // Every other hint is something a device with a display would show;
+        // nothing here can draw, so it is dropped. The extension PR's confirm
+        // prompt is where it becomes the prompt's text.
         Ok(UserCheck {
             presence: true,
             verification: true,

--- a/src-tauri/src/passkey/store.rs
+++ b/src-tauri/src/passkey/store.rs
@@ -250,6 +250,11 @@ impl<V: PasskeyVault> passkey_authenticator::CredentialStore for VaultCredential
         &self,
         ids: Option<&[PublicKeyCredentialDescriptor]>,
         rp_id: &str,
+        // The user handle the ceremony knows about, only ever `Some` on the
+        // exclude-list check of a registration. Ignored, as `MemoryStore` does:
+        // an exclude list is matched on credential id, and narrowing by user
+        // handle would let a site re-register over an account it already has.
+        _user_handle: Option<&[u8]>,
     ) -> std::result::Result<Vec<Self::PasskeyItem>, StatusCode> {
         let found: Vec<_> = self
             .vault
@@ -299,7 +304,7 @@ impl<V: PasskeyVault> passkey_authenticator::CredentialStore for VaultCredential
 
     async fn update_credential(
         &mut self,
-        cred: passkey_types::Passkey,
+        cred: &passkey_types::Passkey,
     ) -> std::result::Result<(), StatusCode> {
         let stored = self
             .vault


### PR DESCRIPTION
## What

Bumps 1Password's passkey-rs crates together: `passkey-types` and `passkey-authenticator` 0.4 → 0.5, and the dev-only `passkey-client` 0.4 → 0.5. Supersedes Dependabot's #381 and #382, which bumped them one at a time and could not compile (the traits pass the crates' own types, so a mixed set fails). `p256` stays 0.13 and `coset` stays 0.3, which is what passkey-rs 0.5 requires; `Cargo.lock` still has exactly one copy of each.

`rust-version` moves 1.85 → 1.85.1 because passkey-authenticator 0.5 declares it. The pinned toolchain (1.90.0) is unaffected.

## API changes migrated (src/passkey)

- `CredentialStore::find_credentials` gained a 4th parameter, `user_handle: Option<&[u8]>`. Ignored, as upstream's own `MemoryStore` does: an exclude list is matched on credential id, and narrowing by user handle would let a site re-register over an account it already holds.
- `CredentialStore::update_credential` now takes `&PasskeyItem` instead of an owned value. The body was already read-only.
- `UserValidationMethod::check_user` now receives a `UiHint<'a, PasskeyItem>` instead of `Option<&PasskeyItem>`.
- `passkey_types::Passkey` gained `username` and `user_display_name`; `to_passkey_types` fills them from the vault record. They live only on the in-memory type and never reach the relying party.

## One behavior change upstream, handled here

passkey-authenticator 0.5 no longer refuses a registration whose `excludeCredentials` names a credential the store already holds. It now calls `check_user(UiHint::InformExcludedCredentialFound(..))`, discards the result, and proceeds. Upstream's own test for this path has the `CredentialExcluded` assertion commented out.

Our existing test `a_second_registration_for_an_excluded_credential_is_refused` caught this on the first build. The refusal now lives in `UnlockedSession::check_user`, which returns `Ctap2Error::CredentialExcluded` on that hint, restoring 0.4 behavior end to end. Without it a second registration would silently store a duplicate credential. The module doc names this one refusal.

**For the browser-extension work:** when `check_user` is replaced with a real confirm prompt, that refusal must be preserved. If the new implementation returns `Ok` for `InformExcludedCredentialFound`, duplicate registration silently returns, and the existing test will fail.

## Stored data compatibility

Unchanged. The vault's `models::Passkey` and its serde attributes, the PKCS#8 ↔ COSE translation in `passkey/key.rs`, and all base64url paths are untouched, and `coset` is the same 0.3.8 so CBOR encoding is bit-for-bit the same. No test, fixture or vector was modified. The round-trip tests pass as-is, including the Bitwarden export/import round trip and the sign-in test that asserts the stored record is untouched.

## Cargo.lock

Only the passkey crates and their own graph moved: passkey-authenticator, passkey-client, passkey-types 0.4 → 0.5; strum/strum_macros 0.25 → 0.27; typeshare and typeshare-annotation removed.

## Verified locally

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --locked`: 284 passed, 0 failed, 2 ignored (same counts as main at 0b28d20)
- `cargo build --locked` ok

Closes #381, #382