### PR TITLE
chore(deps): bump totp-rs to 6 and windows to 0.62

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -2309,6 +2309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,7 +3736,7 @@ dependencies = [
  "coset",
  "data-encoding",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "indexmap 2.14.1",
  "rand",
  "serde",
@@ -4262,7 +4271,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4809,13 +4818,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5150,7 +5159,7 @@ dependencies = [
  "tokio",
  "totp-rs",
  "url",
- "windows",
+ "windows 0.62.2",
  "zeroize",
  "zxcvbn",
 ]
@@ -5276,7 +5285,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5365,7 +5374,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5563,7 +5572,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.20",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5655,7 +5664,7 @@ dependencies = [
  "uuid",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5681,7 +5690,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5706,7 +5715,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6072,15 +6081,17 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "totp-rs"
-version = "5.7.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e69a15e21b2ff22c415446983978bded3244195f17d59cb113551c1e806f91"
+checksum = "49d0f9b7aa5def86d3a8d8ba926fe8c1990924dd715d2b5fc54a4aa3788c11c1"
 dependencies = [
  "base32",
  "constant_time_eq",
- "hmac",
+ "hmac 0.13.0",
+ "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2 0.11.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -6650,7 +6661,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6674,7 +6685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.20",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6736,11 +6747,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6750,6 +6773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6786,7 +6818,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6831,6 +6874,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6980,6 +7033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7231,7 +7293,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,13 @@ sha2 = "0.11"
 rand = "0.8"
 hex = "0.4"
 base64 = "0.23"
-totp-rs = { version = "5", default-features = false }
+# 6.0 turns what used to be unconditional into features. `alloc` is the one we
+# need — it is what gates base32 secrets. Deliberately *not* `std`: all it adds
+# over `alloc` is the `*_current` helpers that read the clock themselves, and it
+# names `rand?/thread_rng`, which is enough to drag `rand` 0.10 into Cargo.lock
+# beside the 0.8 this crate uses. `commands::generator` passes the timestamp in
+# instead, which it already had to compute for the window countdown.
+totp-rs = { version = "6", default-features = false, features = ["alloc"] }
 zxcvbn = "3"
 log = "0.4.34"
 chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
@@ -128,7 +134,7 @@ objc2-ui-kit = { version = "0.3", default-features = false, features = [
 [target.'cfg(target_os = "windows")'.dependencies]
 # `Media_Ocr` + the imaging/storage stack it needs are for the image scanner:
 # a file path -> SoftwareBitmap -> recognized lines.
-windows = { version = "0.61", features = ["Security_Credentials_UI", "Win32_Foundation", "Win32_System_DataExchange", "Win32_System_Memory", "Media_Ocr", "Graphics_Imaging", "Storage", "Storage_Streams"] }
+windows = { version = "0.62", features = ["Security_Credentials_UI", "Win32_Foundation", "Win32_System_DataExchange", "Win32_System_Memory", "Media_Ocr", "Graphics_Imaging", "Storage", "Storage_Streams"] }
 # Credential Manager storage; retrieval is gated behind Windows Hello (verify-then-read).
 keyring = { version = "3", features = ["windows-native"] }
 

--- a/src-tauri/src/biometrics.rs
+++ b/src-tauri/src/biometrics.rs
@@ -64,9 +64,11 @@ mod imp {
         UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
     };
 
+    // `join` is windows-rs 0.62's name for what used to be `get`: block the
+    // calling thread until the WinRT async operation completes.
     pub fn is_available() -> bool {
         UserConsentVerifier::CheckAvailabilityAsync()
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map(|a| a == UserConsentVerifierAvailability::Available)
             .unwrap_or(false)
     }
@@ -74,7 +76,7 @@ mod imp {
     pub fn authenticate() -> Result<()> {
         let message = HSTRING::from("Confirm your identity");
         let verified = UserConsentVerifier::RequestVerificationAsync(&message)
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map(|r| r == UserConsentVerificationResult::Verified)
             .unwrap_or(false);
         if verified {

--- a/src-tauri/src/commands/generator.rs
+++ b/src-tauri/src/commands/generator.rs
@@ -4,7 +4,7 @@ use rand::seq::SliceRandom;
 use rand::Rng;
 use ssh_key::{private::PrivateKey, Algorithm as SshAlgorithm, HashAlg, LineEnding};
 use std::time::{SystemTime, UNIX_EPOCH};
-use totp_rs::{Algorithm, Secret, TOTP};
+use totp_rs::{Algorithm, Builder, Secret, Totp};
 
 const LOWER: &str = "abcdefghijklmnopqrstuvwxyz";
 const UPPER: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -84,35 +84,49 @@ pub fn generate_ssh_key(comment: Option<String>) -> Result<SshKeyPair> {
     })
 }
 
-fn totp(secret: &str) -> Result<TOTP> {
-    let bytes = Secret::Encoded(secret.to_string())
-        .to_bytes()
+fn totp(secret: &str) -> Result<Totp> {
+    let secret = Secret::try_from_base32(secret)
         .map_err(|e| Error::Other(format!("invalid otp secret: {e:?}")))?;
     // SHA1, 6 digits, 30s period, ±1 window — matches legacy speakeasy defaults.
-    Ok(TOTP::new_unchecked(Algorithm::SHA1, 6, 1, 30, bytes))
+    // `build_noncompliant` skips the RFC secret-length and digit checks, exactly
+    // as the old `new_unchecked` did: stored secrets are whatever the issuer
+    // handed the user, and refusing a short one would lock them out.
+    Ok(Builder::new()
+        .with_algorithm(Algorithm::SHA1)
+        .with_digits(6)
+        .with_skew(1)
+        .with_step_duration(30)
+        .with_secret(secret)
+        .build_noncompliant())
+}
+
+// Seconds since the Unix epoch: the step counter a code is derived from, and the
+// same reading the window countdown is measured against.
+fn unix_now() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| Error::Other(e.to_string()))?
+        .as_secs())
 }
 
 // Generate the current TOTP code for a base32 secret plus seconds left in the window.
 #[tauri::command]
 pub fn generate_otp(secret: String) -> Result<OtpResult> {
-    let code = totp(&secret)?
-        .generate_current()
-        .map_err(|e| Error::Other(e.to_string()))?;
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| Error::Other(e.to_string()))?
-        .as_secs();
+    let now = unix_now()?;
     Ok(OtpResult {
-        code,
+        // `Token`'s Display zero-pads to the configured digit count, which is
+        // exactly the string 5.x's `generate` returned.
+        code: totp(&secret)?.generate(now).to_string(),
         time: 30 - (now % 30) as u32,
     })
 }
 
 #[tauri::command]
 pub fn verify_otp(secret: String, token: String) -> Result<bool> {
-    totp(&secret)?
-        .check_current(&token)
-        .map_err(|e| Error::Other(e.to_string()))
+    // 6.0 returns the matched step instead of a bool, so a caller can reject a
+    // replayed code. Nothing here tracks used steps, so "matched at all" is the
+    // same answer 5.x gave.
+    Ok(totp(&secret)?.check(&token, unix_now()?).is_some())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/scan/ocr_windows.rs
+++ b/src-tauri/src/scan/ocr_windows.rs
@@ -38,26 +38,27 @@ impl Ocr for WindowsOcr {
             .to_str()
             .ok_or_else(|| Error::Other("image path is not valid UTF-8".into()))?;
 
-        // Each `get()` blocks on the WinRT async operation; the whole call
-        // already runs off the UI thread.
+        // Each `join()` blocks on the WinRT async operation (windows-rs 0.62's
+        // name for what used to be `get()`); the whole call already runs off the
+        // UI thread.
         let file = StorageFile::GetFileFromPathAsync(&HSTRING::from(path))
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map_err(failed)?;
         let stream = file
             .OpenAsync(FileAccessMode::Read)
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map_err(failed)?;
         let decoder = BitmapDecoder::CreateAsync(&stream)
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map_err(failed)?;
         let bitmap = decoder
             .GetSoftwareBitmapAsync()
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map_err(failed)?;
         let recognized = self
             .engine
             .RecognizeAsync(&bitmap)
-            .and_then(|op| op.get())
+            .and_then(|op| op.join())
             .map_err(failed)?;
 
         let mut lines = Vec::new();


### PR DESCRIPTION
## What

Two isolated API migrations, superseding Dependabot's #362 and #364 which were opened against the stale `v1-0-0` branch.

## totp-rs 5.7 → 6.0 (`commands/generator.rs`)

| 5.x | 6.0 |
|---|---|
| `TOTP::new_unchecked(alg, digits, skew, step, bytes)` | `Builder::new()…with_secret(..).build_noncompliant()` |
| `Secret::Encoded(s).to_bytes()` | `Secret::try_from_base32(s)` |
| `generate_current() -> Result<String>` | `generate(now) -> Token`, then `to_string()` |
| `check_current(&t) -> Result<bool>` | `check(&t, now) -> Option<u64>`, then `is_some()` |

`build_noncompliant` is deliberate: `build` enforces RFC secret-length and digit checks that `new_unchecked` never did, and refusing a short issuer-supplied secret would lock a user out of an existing account.

**Feature change.** 6.0 splits std/alloc into features, and `default-features = false` alone no longer compiles because base32 decoding needs `alloc`. Only `alloc` is enabled, not `std`: `std` names `rand?/thread_rng`, which is enough to put rand 0.10, rand_core 0.10 and chacha20 into `Cargo.lock` beside our rand 0.8 even though nothing compiles them. `alloc` gives up only the `*_current` clock helpers, and the generator already read the clock for the window countdown, so one `unix_now()` reading now feeds both the code and the countdown.

**Code parity was checked, not assumed:** all six RFC 6238 SHA-1 vectors truncated to 6 digits plus a short `JBSWY3DPEHPK3PXP` secret produce identical codes before and after, cross-checked against an independent HMAC-SHA1 implementation. Both versions decode base32 with the same base32 0.5.1 alphabet.

## windows 0.61 → 0.62 (`biometrics.rs`, `scan/ocr_windows.rs`)

windows-future 0.3 renamed the blocking `IAsyncOperation::get()` to `join()`, same signature. 2 calls in biometrics and 5 in the OCR scanner migrated. Checked against the 0.62.2 sources and unchanged: all 8 enabled feature names, the Win32 clipboard functions in `commands/clipboard.rs`, and the `UserConsentVerifier`, `OcrEngine`, `StorageFile`, `BitmapDecoder` signatures.

`windows 0.61.3` stays in the lockfile alongside 0.62.2 because tauri, tao, wry and webview2-com still require `^0.61`; only our direct dependency moves.

## Cargo.lock

totp-rs 6.0.0 (its sha2 now resolves to the 0.11 already in the tree), constant_time_eq 0.4, sha1 0.11, hmac 0.13 added beside the existing 0.12; windows 0.62.2 plus windows-collections, windows-future, windows-numerics, windows-threading. No second rand or rand_core.

## Verified locally (macOS)

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --locked`: 284 passed, 0 failed, 2 ignored (same as main)
- `cargo build --locked` ok

## Not verified locally

The Windows-only code in `biometrics.rs` and `scan/ocr_windows.rs` cannot be compiled on this macOS host. The `get()` → `join()` change was derived from the actual windows-future 0.3.2 source, but **the Rust (windows-latest) job on this PR is what confirms the Windows build.**

Closes #362, #364