### PR TITLE
fix(ios): sit the floating tab bar 20px off the bottom edge, level with its side gutters

### DIFF
--- a/src/components/Main/Compact/chrome.ts
+++ b/src/components/Main/Compact/chrome.ts
@@ -6,17 +6,25 @@
 export const TOUCH = 'h-11 w-11'
 
 /**
- * The floating tab bar's geometry, in the one place both it and the screens it
- * hovers over can read it: a 64px pill, 12px off the safe-area bottom, inset
- * 20px a side.
+ * Where floating bottom chrome sits: the same 20px off every edge. Deliberately
+ * not `env(safe-area-inset-bottom)` — that is UIKit's docked-content margin
+ * (34pt on a home-indicator phone), and a pill lifted by it plus a gap floats
+ * visibly higher than its side gutters. iOS's own floating tab bar sits a few
+ * points above the home indicator (13pt from the edge), which 20px clears.
  */
-export const TAB_BAR = 'inset-x-5 bottom-[calc(env(safe-area-inset-bottom)+12px)] h-16'
+const EDGE = 'inset-x-5 bottom-5'
+
+/**
+ * The floating tab bar's geometry, in the one place both it and the screens it
+ * hovers over can read it: a 64px pill on [`EDGE`].
+ */
+export const TAB_BAR = `${EDGE} h-16`
 
 /**
  * What a root screen's scroller reserves under its content so the last row can
  * be scrolled clear of the bar it slides under (bar + its offset + a breath).
  */
-export const TAB_BAR_CLEARANCE = 'pb-[calc(env(safe-area-inset-bottom)+120px)]'
+export const TAB_BAR_CLEARANCE = 'pb-32'
 
 /**
  * The face of a screen's bottom action: an accent slab a thumb can land on
@@ -27,23 +35,21 @@ export const ACTION_BUTTON =
   'absolute flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-accent text-md font-medium text-accent-fg shadow-float transition-opacity disabled:cursor-default'
 
 /**
- * A pushed screen's bottom action, on the same footing: a 54px button, 12px off
- * the safe-area bottom, inset 20px a side — the tab bar's own gutters, so the
- * two never look like they were measured by different people.
+ * A pushed screen's bottom action, on the same footing: a 54px button on
+ * [`EDGE`] — the tab bar's own gutters, so the two never look like they were
+ * measured by different people.
  */
-export const PRIMARY_ACTION =
-  'inset-x-5 bottom-[calc(env(safe-area-inset-bottom)+12px)] h-[54px]'
+export const PRIMARY_ACTION = `${EDGE} h-[54px]`
 
 /** What that screen's scroller reserves under its content for the button. */
-export const PRIMARY_CLEARANCE = 'pb-[calc(env(safe-area-inset-bottom)+94px)]'
+export const PRIMARY_CLEARANCE = 'pb-[102px]'
 
 /**
  * The same action on a *root* screen, which keeps its tab bar: the button is
- * lifted clear of the pill (64px + its 12px offset + a 12px gap) rather than
+ * lifted clear of the pill (64px + its 20px offset + a 12px gap) rather than
  * sharing the bottom edge with it.
  */
-export const ROOT_ACTION =
-  'z-10 inset-x-5 bottom-[calc(env(safe-area-inset-bottom)+88px)] h-[54px]'
+export const ROOT_ACTION = 'z-10 inset-x-5 bottom-24 h-[54px]'
 
 /** What that root's scroller reserves: the button, and the bar under it. */
-export const ROOT_CLEARANCE = 'pb-[calc(env(safe-area-inset-bottom)+170px)]'
+export const ROOT_CLEARANCE = 'pb-[178px]'


### PR DESCRIPTION
## What

On iOS the floating tab bar (and the two bottom action buttons that share its footing) sat about 46pt above the screen edge while its side gutters were 20px, so it read as floating too high. After #410 removed the 96pt safe-area shortfall, this remaining gap came from the CSS itself: `env(safe-area-inset-bottom) + 12px`.

## Why

`env(safe-area-inset-bottom)` is UIKit's margin for docked content (34pt on a home-indicator iPhone). Native iOS floating tab bars don't honor the full inset; they sit a few points above the home indicator, which only reaches 13pt from the edge. Lifting our pill by the full inset plus a gap put it visibly higher than its own horizontal insets.

## Change

`src/components/Main/Compact/chrome.ts` only:

- New shared `EDGE` footing: `inset-x-5 bottom-5`, so bottom chrome is 20px off the edge, level with the sides.
- `TAB_BAR` and `PRIMARY_ACTION` use it. `ROOT_ACTION` is lifted 64 + 20 + 12 = 96px (`bottom-24`).
- Scroll clearances recomputed from the new offsets: `TAB_BAR_CLEARANCE` 128px, `PRIMARY_CLEARANCE` 102px, `ROOT_CLEARANCE` 178px.

Sheets, the form editor and the auth shell keep their `env(safe-area-inset-bottom)` padding. Those are scroll content ending above the indicator, not floating chrome. Home-button phones (inset 0) move from 12px to 20px.

## Checks

- `bun run lint`, `bun run typecheck` clean
- `bun run test`: 488 passed
- Not yet verified on the simulator from this workspace; worth a look at Settings, a pushed detail screen (Copy button) and the Generator root (Use button) to confirm the three sit on one line and nothing scrolls under the pill without clearance.