### PR TITLE
feat(list): premium search field — flat tinted well that lights up on focus

### DIFF
--- a/src/components/Main/Body/Empty/variants.tsx
+++ b/src/components/Main/Body/Empty/variants.tsx
@@ -10,6 +10,7 @@ import {
   syncFailed
 } from '@/store'
 import { kindOf } from '@/kinds'
+import { chord } from '@/utils/platform'
 import { useTranslation } from 'react-i18next'
 import Logo from '@/assets/images/logo.svg?react'
 import EmptyState from '@/components/elements/EmptyState'
@@ -62,8 +63,8 @@ export function VaultEmpty() {
             { label: t('Import from another app'), onClick: () => openSettings('import') }
       }
       hints={[
-        { keys: '⌘N', label: t('add') },
-        { keys: '⌘K', label: t('commands') }
+        { keys: chord('N'), label: t('add') },
+        { keys: chord('K'), label: t('commands') }
       ]}
     />
   )
@@ -84,9 +85,9 @@ export function SelectEmpty() {
       hints={[
         { keys: '↑↓', label: t('browse') },
         { keys: '⏎', label: t('copy') },
-        { keys: '⌘F', label: t('search') },
-        { keys: '⌘N', label: t('add') },
-        { keys: '⌘K', label: t('commands') }
+        { keys: chord('F'), label: t('search') },
+        { keys: chord('N'), label: t('add') },
+        { keys: chord('K'), label: t('commands') }
       ]}
     />
   )

--- a/src/components/Main/Body/ListColumn/Search.tsx
+++ b/src/components/Main/Body/ListColumn/Search.tsx
@@ -1,32 +1,54 @@
 import type { KeyboardEvent } from 'react'
 import { useStore, setFilterQuery } from '@/store'
 import { useTranslation } from 'react-i18next'
+import { cx } from '@/utils/cx'
+import Kbd from '@/components/elements/Kbd'
 import { CloseGlyph, SearchGlyph } from '../../icons'
+
+// The desktop field's measure: 32px under a mouse. The compact root sends the
+// 44px touch one in its place (`Compact/Vault`). Size only — the surface, its
+// states and their motion below are the same field at either size.
+const DESKTOP = 'mt-3 h-8 gap-2.5 rounded-sm pl-3 pr-1.5'
 
 // The app's one search field: it sits in the list column it filters and spans
 // the column. Esc clears the query, then blurs — the accelerators that act on
 // the rows (↑/↓, ⏎, ⌘⏎) belong to the whole column, so they live one level up
 // in useListKeys and reach this field by bubbling.
-// `className` is the box's own styling, not a layout flag: the field is 28px
-// where a mouse points at it and the compact root swaps in the 44px touch one.
-export default function Search({ className }: { className?: string }) {
+// `className` is the box's measure (height, radius, padding), not a layout
+// flag: the field is 32px where a mouse points at it and the compact root swaps
+// in the 44px touch one.
+export default function Search({ className = DESKTOP }: { className?: string }) {
   const { t } = useTranslation()
   const query = useStore(state => state.filters.query)
+  const empty = query === ''
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Escape') return
-    if (query === '') e.currentTarget.blur()
+    if (empty) e.currentTarget.blur()
     else setFilterQuery('')
   }
 
   return (
     <div
-      className={
-        className ??
-        'mt-3 flex h-7 items-center gap-2.5 rounded-sm border border-line2 bg-field pl-[11px] pr-2 text-text3 transition-colors focus-within:border-accent-line'
-      }
+      className={cx(
+        'group relative flex items-center border bg-tile text-text3',
+        // A flat tinted well with no edge of its own: at rest it reads as a
+        // quiet shape in the ground, not a boxed control. Under the pointer the
+        // tint deepens a step (ink at a low alpha, so it holds on both themes).
+        // Holding the caret it switches on — the tint gives way to the detail
+        // surface, a crisp accent stroke draws the edge and a wide, soft halo
+        // of the same accent lifts it off the column. Hover stands down while
+        // focused so the lit surface never flickers under the pointer.
+        'border-transparent [&:hover:not(:focus-within)]:bg-text/10',
+        'focus-within:border-accent-line focus-within:bg-detail focus-within:ring-3 focus-within:ring-accent-soft',
+        // The slow tier: a field switching on should be seen doing it.
+        'transition-[border-color,background-color,box-shadow] duration-300',
+        className
+      )}
     >
-      <SearchGlyph className="flex-none" />
+      {/* The glyph is the field's mood: muted at rest, ink under the pointer,
+          accent while the field is listening. */}
+      <SearchGlyph className="flex-none transition-colors duration-300 group-hover:text-text2 group-focus-within:text-accent" />
       <input
         type="search"
         name="search"
@@ -35,19 +57,43 @@ export default function Search({ className }: { className?: string }) {
         value={query}
         onChange={e => setFilterQuery(e.target.value)}
         onKeyDown={onKeyDown}
-        className="min-w-0 flex-1 border-0 bg-transparent text-base text-text outline-none placeholder:text-text3 [&::-webkit-search-cancel-button]:hidden"
+        className="min-w-0 flex-1 border-0 bg-transparent text-base text-text caret-accent outline-none placeholder:text-text3 [&::-webkit-search-cancel-button]:hidden"
       />
-      {query !== '' && (
+      {/* One trailing slot, both occupants stacked in its single cell so the
+          hint and the clear button crossfade in place: nothing to the left of
+          them moves when a query arrives or goes. */}
+      <span className="grid flex-none place-items-center [&>*]:col-start-1 [&>*]:row-start-1">
+        {/* The shortcut that lands here, shown while the field is idle and
+            empty; focus fades it and eases it a step to the right, as if the
+            caret's arrival nudged it out. A finger has no ⌘, so no coarse
+            pointer ever sees it — the slot then shrinks to the clear button. */}
+        <span
+          aria-hidden
+          className={cx(
+            'transition-[opacity,transform] duration-300 any-pointer-coarse:hidden group-focus-within:translate-x-1 group-focus-within:opacity-0',
+            !empty && 'translate-x-1 opacity-0'
+          )}
+        >
+          <Kbd>⌘F</Kbd>
+        </span>
+        {/* Always mounted so it can ease in: a query fades and grows it from
+            a dot to a button, clearing does the reverse. Out of reach and out
+            of the tab order while there is nothing to clear. */}
         <button
           type="button"
           onClick={() => setFilterQuery('')}
           aria-label={t('Clear')}
+          aria-hidden={empty}
+          tabIndex={empty ? -1 : 0}
           data-testid="search-clear-button"
-          className="grid h-4 w-4 flex-none place-items-center rounded-full text-text3 hover:text-text"
+          className={cx(
+            'grid h-5 w-5 cursor-pointer place-items-center rounded-full text-text3 transition-[opacity,transform,color,background-color] hover:bg-hover hover:text-text',
+            empty ? 'pointer-events-none scale-75 opacity-0' : 'scale-100 opacity-100'
+          )}
         >
           <CloseGlyph size={12} />
         </button>
-      )}
+      </span>
     </div>
   )
 }

--- a/src/components/Main/Body/ListColumn/Search.tsx
+++ b/src/components/Main/Body/ListColumn/Search.tsx
@@ -1,7 +1,8 @@
-import type { KeyboardEvent } from 'react'
+import { useRef, type KeyboardEvent } from 'react'
 import { useStore, setFilterQuery } from '@/store'
 import { useTranslation } from 'react-i18next'
 import { cx } from '@/utils/cx'
+import { chord } from '@/utils/platform'
 import Kbd from '@/components/elements/Kbd'
 import { CloseGlyph, SearchGlyph } from '../../icons'
 
@@ -21,6 +22,15 @@ export default function Search({ className = DESKTOP }: { className?: string }) 
   const { t } = useTranslation()
   const query = useStore(state => state.filters.query)
   const empty = query === ''
+  const input = useRef<HTMLInputElement>(null)
+
+  // Clearing hands the caret back to the field: the button that was clicked
+  // is about to fade out and leave the tab order, and a focus left on it would
+  // strand the next keystroke on an invisible control.
+  const clear = () => {
+    setFilterQuery('')
+    input.current?.focus()
+  }
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Escape') return
@@ -50,6 +60,7 @@ export default function Search({ className = DESKTOP }: { className?: string }) 
           accent while the field is listening. */}
       <SearchGlyph className="flex-none transition-colors duration-300 group-hover:text-text2 group-focus-within:text-accent" />
       <input
+        ref={input}
         type="search"
         name="search"
         data-testid="search-input"
@@ -74,14 +85,14 @@ export default function Search({ className = DESKTOP }: { className?: string }) 
             !empty && 'translate-x-1 opacity-0'
           )}
         >
-          <Kbd>⌘F</Kbd>
+          <Kbd>{chord('F')}</Kbd>
         </span>
         {/* Always mounted so it can ease in: a query fades and grows it from
             a dot to a button, clearing does the reverse. Out of reach and out
             of the tab order while there is nothing to clear. */}
         <button
           type="button"
-          onClick={() => setFilterQuery('')}
+          onClick={clear}
           aria-label={t('Clear')}
           aria-hidden={empty}
           tabIndex={empty ? -1 : 0}

--- a/src/components/Main/Body/ListColumn/index.tsx
+++ b/src/components/Main/Body/ListColumn/index.tsx
@@ -31,8 +31,8 @@ interface Props {
    */
   header?: string
   /**
-   * The search box's own classes. Absent, it keeps the 28px desktop field; the
-   * compact root sends the 44px touch one.
+   * The search box's measure — height, radius, padding. Absent, it keeps the
+   * 32px desktop field; the compact root sends the 44px touch one.
    */
   search?: string
   /** Extra classes for the scroller, so a shell can reserve room under it. */

--- a/src/components/Main/Compact/Vault/index.tsx
+++ b/src/components/Main/Compact/Vault/index.tsx
@@ -8,10 +8,10 @@ import Tags from '../../Sidebar/Tags'
 import { ROOT_HEADER, TAB_BAR_CLEARANCE, TOUCH } from '../chrome'
 import Heading from '../Heading'
 
-// The 44px search field. Passed as classes rather than asked for by a flag:
-// the box is the same field, dressed for a finger.
-const SEARCH =
-  'mt-4 flex h-11 items-center gap-2.5 rounded-lg border border-line bg-field pl-3.5 pr-2.5 text-text3 transition-colors focus-within:border-accent-line [&_input]:text-md'
+// The 44px search field's measure. Passed as classes rather than asked for by
+// a flag: the box is the same field, dressed for a finger — its surface,
+// states and motion are the field's own (`ListColumn/Search`).
+const SEARCH = 'mt-4 h-11 gap-2.5 rounded-lg pl-3.5 pr-2.5 [&_input]:text-md'
 
 /**
  * The list root — the screen the tab bar comes home to.

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,5 +1,19 @@
 // Sets the `platform` attribute the stylesheets use for OS-specific tweaks.
 // Detected from the browser since the Tauri OS plugin needs src-tauri (PR-5).
+// A PC's desktop webview — the one place the app's chords are held with Ctrl
+// (`useShortcuts` takes either modifier). Read off the UA rather than the
+// Tauri platform so a browser preview and the test runner agree with the
+// desktop: jsdom reports the Node platform ("darwin"), never "Mac", so
+// anything that is not visibly a PC reads as the Apple default.
+const PC = /Win|Linux|X11/.test(navigator.userAgent)
+
+/**
+ * A shortcut hint for `key` as this platform spells it: `⌘F` on Apple
+ * hardware, `Ctrl+F` on a PC. Every hint chip in the app (`Kbd`, the empty
+ * states' hint rows) should go through here rather than hardcoding ⌘.
+ */
+export const chord = (key: string) => (PC ? `Ctrl+${key}` : `⌘${key}`)
+
 export const applyPlatform = () => {
   const ua = navigator.userAgent
   const isMac = /Mac/.test(ua)


### PR DESCRIPTION
## Summary

Facelift for the items list search field, with smooth state transitions.

**Before:** a 28px bordered input on the list background, clear button mounted and unmounted abruptly.

**After:**
- **Rest** — a 32px flat tinted well (the existing `bg-tile` wash), no visible edge; reads as a quiet shape in the column rather than a boxed control.
- **Hover** — the tint deepens one step (ink at low alpha, so it holds on both themes). Hover stands down while focused so the lit surface never flickers under the pointer.
- **Focus** — the field switches on: detail surface, crisp `accent-line` stroke, wide soft `accent-soft` halo, accent glyph and caret. Runs on the design system's 300ms slow tier with `ease-swift`.
- **⌘F hint** — a `Kbd` chip in the trailing slot while idle and empty; fades and eases a step right on focus. Hidden on any coarse pointer, so the phone shell never shows it.
- **Clear button** — always mounted so it can crossfade and scale in when a query arrives; out of the tab order, `aria-hidden` and `pointer-events-none` while empty. Shares one grid cell with the hint, so nothing shifts as the two swap.

The field now owns its surface, states and motion; `ListColumn`'s `search` prop and `Compact/Vault`'s `SEARCH` constant carry measure only (height, radius, padding), so the 44px phone field picks up the same look for free.

## Verification

- `bun run typecheck`, `bun run lint`, full `vitest run` (51 files, 489 tests) pass.
- Screenshotted idle / hover / focus / typed states in light and dark via a throwaway browser harness (Tauri IPC stubbed, driven with Playwright); harness deleted before commit.
- Existing test IDs (`search-input`, `search-clear-button`) and the Esc behaviour are unchanged.