### PR TITLE
refactor(ui): drop monospace from the UI, route micro type through shared tokens

### DIFF
--- a/src/components/Main/Body/Aside/Audit/Score.tsx
+++ b/src/components/Main/Body/Aside/Audit/Score.tsx
@@ -1,7 +1,7 @@
 import type { Audit } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import { vaultScore } from '@/utils/vaultScore'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 
 interface Props {
   audit: Audit
@@ -48,7 +48,7 @@ export default function Score({ audit }: Props) {
         >
           {score.toFixed(1)}
         </div>
-        <div className={MONO_LABEL}>
+        <div className={LABEL}>
           {t('Overall Score')}
         </div>
       </div>

--- a/src/components/Main/Body/Aside/Audit/index.tsx
+++ b/src/components/Main/Body/Aside/Audit/index.tsx
@@ -3,7 +3,7 @@ import type { Audit, AuditItem } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import Score from './Score'
 import Panel from '@/components/elements/Panel'
-import { MONO_LABEL, ROW_HAIRLINE } from '@/components/elements/tokens'
+import { LABEL, ROW_HAIRLINE } from '@/components/elements/tokens'
 
 const count = (audit: Audit, property: keyof AuditItem) =>
   Object.values(audit).filter(item => item[property]).length
@@ -44,7 +44,7 @@ export default function Audit() {
 
   return (
     <div className="mx-auto flex max-w-[420px] flex-col items-center py-4">
-      <div className={MONO_LABEL}>{t('Password Audit')}</div>
+      <div className={LABEL}>{t('Password Audit')}</div>
       <div className="mt-6">
         <Score audit={audit} />
       </div>
@@ -59,7 +59,7 @@ export default function Audit() {
             >
               <span className={`h-1.5 w-1.5 flex-none rounded-full ${s.dot}`} />
               <span className="flex-1 text-base text-text2">{s.label}</span>
-              <span data-testid="audit-stat-value" className="font-mono text-base text-text">
+              <span data-testid="audit-stat-value" className="text-base tabular-nums text-text">
                 {s.value}
               </span>
             </div>

--- a/src/components/Main/Body/Aside/Show/Edit/index.tsx
+++ b/src/components/Main/Body/Aside/Show/Edit/index.tsx
@@ -1,7 +1,7 @@
 import type { Entry, EntryType } from '@/lib/commands'
 import { kindOf } from '@/kinds'
 import { useTranslation } from 'react-i18next'
-import { MONO_TYPE } from '@/components/elements/tokens'
+import { LABEL_TYPE } from '@/components/elements/tokens'
 import Actions from './Actions'
 import Body from './Body'
 import Title from './Title'
@@ -40,7 +40,7 @@ export default function Edit({ type, revealed }: Props) {
             runs the full content width and its underline ends where the rows do. */}
         <div className="flex items-center justify-between gap-4">
           <div
-            className={`flex min-w-0 flex-1 items-center gap-2 truncate whitespace-nowrap ${MONO_TYPE} text-accent`}
+            className={`flex min-w-0 flex-1 items-center gap-2 truncate whitespace-nowrap ${LABEL_TYPE} text-accent`}
           >
             <span>{t('Editing')}</span>
             <span>·</span>

--- a/src/components/Main/Body/Aside/Show/Eyebrow.tsx
+++ b/src/components/Main/Body/Aside/Show/Eyebrow.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { Entry, EntryMeta } from '@/lib/commands'
 import { kindOf } from '@/kinds'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 
 interface Props {
   entry: EntryMeta
@@ -11,7 +11,7 @@ interface Props {
   className?: string
 }
 
-// What the entry is, in one mono line: the kind, and — once it can say so — the
+// What the entry is, in one micro line: the kind, and — once it can say so — the
 // host it belongs to, or, for a document whose type is encrypted, what kind of
 // document it is. Both shells draw it; only its place in the header differs.
 export default function Eyebrow({ entry, revealed, className }: Props) {
@@ -25,7 +25,7 @@ export default function Eyebrow({ entry, revealed, className }: Props) {
     fromKind ?? (entry.urlHost ? { text: entry.urlHost } : null)
 
   return (
-    <div className={`${className} ${MONO_LABEL}`}>
+    <div className={`${className} ${LABEL}`}>
       <span className="text-text2">{t(kind.label)}</span>
       {segment && (
         <>

--- a/src/components/Main/Body/Aside/Show/Footer.tsx
+++ b/src/components/Main/Body/Aside/Show/Footer.tsx
@@ -5,7 +5,7 @@ import { setFilterQuery } from '@/store'
 import { PlusGlyph } from '@/components/Main/icons'
 import TagsInput from '@/components/elements/TagsInput'
 import { TAG_CHIP } from '@/components/elements/fields/chip'
-import { MONO_LABEL, MONO_META } from '@/components/elements/tokens'
+import { LABEL, META, META_TYPE } from '@/components/elements/tokens'
 import { dateTime, relativeLong, shortDate, toTime } from '@/utils/time'
 
 interface Props {
@@ -39,7 +39,8 @@ const stamp = (label: TKey, iso: string | undefined, spell: Stamp[2]): Stamp | n
 // the content, a small label over each value — but structured, so it never
 // reads as a sentence tacked on under the rows. Tags take the left, where the
 // title sits in the header; the timestamps hold the right, under the header's
-// actions, and stay there whether or not there are tags.
+// actions, and stay there whether or not there are tags. Every cell has the
+// same two lines, so the labels share one baseline and the values another.
 export default function Footer({
   tags,
   onTags,
@@ -80,7 +81,7 @@ export default function Footer({
               type="button"
               data-testid="add-tag-button"
               onClick={onAdd}
-              className={`flex h-6 cursor-pointer items-center gap-1 ${MONO_META} transition-colors hover:text-text`}
+              className={`flex h-6 cursor-pointer items-center gap-1 ${META} transition-colors hover:text-text`}
             >
               <PlusGlyph size={12} />
               {t('Add tag')}
@@ -106,7 +107,18 @@ export default function Footer({
         <div className="ml-auto flex flex-none gap-10 @max-[420px]:ml-0 @max-[420px]:gap-6">
           {stamps.map(([label, iso, spell]) => (
             <Cell key={label} label={label} className="text-right @max-[420px]:text-left">
-              <span title={dateTime(iso)}>{spell(iso)}</span>
+              {/* Chip-height like the tags beside it, so the value sits on the
+                  same line as the chip text and the cells end together. A step
+                  up from the label in ink and weight, but still short of the
+                  content's full ink: within the footer the value is the
+                  information and the label only says what it is a value of,
+                  yet the footer as a whole stays meta to the rows above it. */}
+              <span
+                className={`flex h-6 items-center justify-end ${META_TYPE} font-medium text-text2 @max-[420px]:justify-start`}
+                title={dateTime(iso)}
+              >
+                {spell(iso)}
+              </span>
             </Cell>
           ))}
         </div>
@@ -115,11 +127,12 @@ export default function Footer({
   )
 }
 
-// One footer cell: the mono micro-label over the value, the way the rows pair
-// theirs — only stacked, since the footer is a strip rather than a column. The
-// value is a tier up from the label (base over xs, as in the rows): uppercase
-// and tracking make an 11px label read larger than it is, so at the same size
-// it was the label that drew the eye. Secondary stays a matter of ink.
+// One footer cell: the micro-label over the value, the way the rows pair theirs
+// — only stacked, since the footer is a strip rather than a column, and flush:
+// the value's own line height is all the air the pair needs. Every cell is
+// built the same, so a row of them lines up twice: labels with labels, values
+// with values. What sits under the label is the caller's (chips, an input, a
+// date) and stays a tier down from the content above.
 function Cell({
   label,
   className,
@@ -132,8 +145,8 @@ function Cell({
   const { t } = useTranslation()
   return (
     <div className={className}>
-      <div className={MONO_LABEL}>{t(label)}</div>
-      <div className="mt-1 font-mono text-base text-text2">{children}</div>
+      <div className={LABEL}>{t(label)}</div>
+      <div>{children}</div>
     </div>
   )
 }

--- a/src/components/Main/Body/List/Audit/index.tsx
+++ b/src/components/Main/Body/List/Audit/index.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@/store'
 import type { AuditItem, EntryMeta } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import Group from '../Group'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 
 export default function AuditList() {
   const { t } = useTranslation()
@@ -12,7 +12,7 @@ export default function AuditList() {
 
   if (!audit)
     return (
-      <div className={`px-4 py-6 ${MONO_LABEL}`}>
+      <div className={`px-4 py-6 ${LABEL}`}>
         {t('Loading Results..')}
       </div>
     )

--- a/src/components/Main/Body/List/Group.tsx
+++ b/src/components/Main/Body/List/Group.tsx
@@ -2,14 +2,14 @@ import type { EntryMeta } from '@/lib/commands'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import Item from './Item'
-import { MONO_LABEL, MONO_META } from '@/components/elements/tokens'
+import { LABEL, META } from '@/components/elements/tokens'
 
 interface Props {
   title: TKey
   entries: EntryMeta[]
 }
 
-// A labelled run of entries in the audit list — one severity ("Weak"). A mono
+// A labelled run of entries in the audit list — one severity ("Weak"). A muted
 // header (label + hairline rule + count) over its rows; rendered only when the
 // group has members. The entry list itself is flat, so this is the only caller.
 export default function Group({ title, entries }: Props) {
@@ -19,11 +19,11 @@ export default function Group({ title, entries }: Props) {
   return (
     <div>
       <div className="flex items-center gap-2 px-4 pb-1.5 pt-3">
-        <span className={MONO_LABEL}>
+        <span className={LABEL}>
           {t(title)}
         </span>
         <span className="h-px flex-1 bg-line" />
-        <span className={MONO_META}>{entries.length}</span>
+        <span className={META}>{entries.length}</span>
       </div>
       {entries.map(entry => (
         <Item entry={entry} key={entry.id} />

--- a/src/components/Main/Body/List/Item/Flag.tsx
+++ b/src/components/Main/Body/List/Item/Flag.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@/utils/cx'
 import { useTranslation } from 'react-i18next'
 import type { FlagKind } from './audit'
+import { META_TYPE } from '@/components/elements/tokens'
 
 // An audit verdict as a row badge: a bordered pill in `currentColor`, so one
 // ink token sets both the label and the outline.
@@ -9,7 +10,7 @@ export default function Flag({ kind }: { kind: FlagKind }) {
   return (
     <span
       className={cx(
-        'flex-none rounded-sm border border-current px-1.5 font-mono text-xs opacity-85',
+        `flex-none rounded-sm border border-current px-1.5 ${META_TYPE} opacity-85`,
         kind === 'weak' ? 'text-bad' : 'text-warn'
       )}
     >

--- a/src/components/Main/Body/List/Item/Row.tsx
+++ b/src/components/Main/Body/List/Item/Row.tsx
@@ -3,7 +3,7 @@ import type { EntryMeta } from '@/lib/commands'
 import type { Kind } from '@/kinds/types'
 import { KIND_TINT } from '@/kinds/tint'
 import { cx } from '@/utils/cx'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 // What every kind's list row component is handed (see src/kinds/*/ListRow).
 export interface ContentProps {
@@ -23,7 +23,7 @@ interface Props {
 }
 
 // Shared inner layout for every list item, whatever its kind: a rounded glyph
-// tile, the title (with an optional audit flag beside it), and an optional mono
+// tile, the title (with an optional audit flag beside it), and an optional muted
 // secondary line. The kind-specific bits (which glyph, which secondary text)
 // live in src/kinds so this stays a single source of truth for spacing and
 // typography.
@@ -50,7 +50,7 @@ export default function Row({ glyph, title, sub, flag, tint }: Props) {
           {flag}
         </div>
         {sub && (
-          <div className={`mt-0.5 truncate ${MONO_META}`}>
+          <div className={`mt-0.5 truncate ${META}`}>
             {sub}
           </div>
         )}

--- a/src/components/Main/Body/List/Item/index.tsx
+++ b/src/components/Main/Body/List/Item/index.tsx
@@ -9,7 +9,7 @@ import { StarGlyph } from '../../../icons'
 import { stampOf } from '../order'
 import Flag from './Flag'
 import { flagOf } from './audit'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 interface Props {
   entry: EntryMeta
@@ -72,7 +72,7 @@ export default function Item({ entry }: Props) {
         </span>
       )}
       {meta && (
-        <span className={`flex-none ${MONO_META}`}>{meta}</span>
+        <span className={`flex-none ${META}`}>{meta}</span>
       )}
     </div>
   )

--- a/src/components/Main/Body/ListColumn/Chip.tsx
+++ b/src/components/Main/Body/ListColumn/Chip.tsx
@@ -1,5 +1,6 @@
 import { cx } from '@/utils/cx'
 import { CloseGlyph } from '../../icons'
+import { META_TYPE } from '@/components/elements/tokens'
 
 interface Props {
   label: string
@@ -14,7 +15,7 @@ interface Props {
   title?: string
 }
 
-// A single filter chip: a token-bordered pill with a label and a mono count.
+// A single filter chip: a token-bordered pill with a label and a muted count.
 // Selected chips switch to the accent palette.
 export default function Chip({ label, count, selected, onClick, testid, dismiss, title }: Props) {
   return (
@@ -25,7 +26,7 @@ export default function Chip({ label, count, selected, onClick, testid, dismiss,
       title={title}
       onClick={onClick}
       className={cx(
-        'flex h-6 flex-none items-center gap-1.5 rounded-sm border px-[9px] text-xs whitespace-nowrap',
+        `flex h-6 flex-none items-center gap-1.5 rounded-sm border px-[9px] ${META_TYPE} whitespace-nowrap`,
         selected
           ? 'border-accent-line bg-accent-soft text-accent'
           : 'border-line bg-transparent text-text2 hover:border-line2'
@@ -39,7 +40,7 @@ export default function Chip({ label, count, selected, onClick, testid, dismiss,
       ) : (
         <span
           data-testid={testid ? `${testid}-count` : undefined}
-          className="font-mono text-xs opacity-60"
+          className={`${META_TYPE} opacity-60`}
         >
           {count}
         </span>

--- a/src/components/Main/Body/ListColumn/index.tsx
+++ b/src/components/Main/Body/ListColumn/index.tsx
@@ -19,7 +19,7 @@ interface Props {
   actions?: ReactNode
   /**
    * Replaces the 20px title block. The compact root sends its large title —
-   * same words (`useListTitle`), a mono eyebrow above them.
+   * same words (`useListTitle`), a micro eyebrow above them.
    */
   heading?: ReactNode
   /**

--- a/src/components/Main/Generator/Amount.tsx
+++ b/src/components/Main/Generator/Amount.tsx
@@ -4,7 +4,7 @@ import {
   WORDS_RANGE,
   type GeneratorSettings
 } from '@/services/generator'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 
 interface Props {
   settings: GeneratorSettings
@@ -21,7 +21,7 @@ export default function Amount({ settings, onChange }: Props) {
 
   return (
     <div className="mt-5 flex items-center gap-3.5">
-      <span className={`w-[66px] flex-none ${MONO_LABEL}`}>
+      <span className={`w-[66px] flex-none ${LABEL}`}>
         {t(byWords ? 'Words' : 'Length')}
       </span>
       <input
@@ -37,7 +37,7 @@ export default function Amount({ settings, onChange }: Props) {
         }}
         className="h-1.5 flex-1 accent-accent"
       />
-      <span className="w-[58px] flex-none text-right font-mono text-base text-text2">
+      <span className="w-[58px] flex-none text-right text-base tabular-nums text-text2">
         {value} {t(byWords ? 'words' : 'chars')}
       </span>
     </div>

--- a/src/components/Main/Generator/Output.tsx
+++ b/src/components/Main/Generator/Output.tsx
@@ -4,6 +4,7 @@ import Meter from '@/components/elements/Meter'
 import { LEVEL_INK } from '@/components/elements/levels'
 import { ENTROPY_LABELS } from '@/services/generator'
 import { wellClass } from '@/components/elements/formStyles'
+import { META_TYPE } from '@/components/elements/tokens'
 
 interface Props {
   value: string
@@ -18,13 +19,13 @@ export default function Output({ value, bits, level }: Props) {
     <>
       <div
         data-testid="generator-output"
-        className={`min-h-14 ${wellClass} p-4 font-mono text-lg leading-relaxed break-all`}
+        className={`min-h-14 ${wellClass} p-4 text-lg leading-relaxed tracking-secret break-all`}
       >
         {value}
       </div>
       <div className="mt-3 flex items-center gap-2.5">
         <Meter level={level} />
-        <span className={cx('font-mono text-xs', LEVEL_INK[level])}>
+        <span className={cx(META_TYPE, LEVEL_INK[level])}>
           {t(ENTROPY_LABELS[level])} · {bits} {t('bits')}
         </span>
       </div>

--- a/src/components/Main/Generator/Ssh/Line.tsx
+++ b/src/components/Main/Generator/Ssh/Line.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import CopyButton from '@/components/elements/CopyButton'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 import { wellClass } from '@/components/elements/formStyles'
 import type { TKey } from '@/i18n'
 
@@ -16,7 +16,7 @@ export default function Line({ label, value, testid }: Props) {
   const { t } = useTranslation()
   return (
     <div>
-      <div className={MONO_LABEL}>{t(label)}</div>
+      <div className={LABEL}>{t(label)}</div>
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid={testid}

--- a/src/components/Main/Generator/Ssh/Secret.tsx
+++ b/src/components/Main/Generator/Ssh/Secret.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import CopyButton from '@/components/elements/CopyButton'
 import IconButton from '@/components/elements/IconButton'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 import { wellClass } from '@/components/elements/formStyles'
 import { EyeGlyph, EyeOffGlyph } from '../../icons'
 
@@ -16,7 +16,7 @@ export default function Secret({ value }: { value: string }) {
 
   return (
     <div>
-      <div className={MONO_LABEL}>{t('Private key')}</div>
+      <div className={LABEL}>{t('Private key')}</div>
       <div className="mt-1 flex items-start gap-1.5">
         <div
           data-testid="generator-ssh-private"

--- a/src/components/Main/Generator/Ssh/index.tsx
+++ b/src/components/Main/Generator/Ssh/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { SshKeyPair } from '@/lib/commands'
 import Button from '@/components/elements/Button'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL, META_TYPE } from '@/components/elements/tokens'
 import { inputClass, wellClass } from '@/components/elements/formStyles'
 import { cx } from '@/utils/cx'
 import Line from './Line'
@@ -31,7 +31,7 @@ export default function Ssh({ pair, pending, error, onRetry, comment, onComment 
           data-testid="generator-ssh-error"
           className={`flex items-center gap-3 ${wellClass} px-3 py-2.5`}
         >
-          <div className="flex-1 font-mono text-xs tracking-label text-bad">
+          <div className={`flex-1 ${META_TYPE} tracking-label text-bad`}>
             {t('Could not generate a key.')}
           </div>
           <Button size="md" variant="ghost" testid="generator-ssh-retry" onClick={onRetry}>
@@ -56,7 +56,7 @@ export default function Ssh({ pair, pending, error, onRetry, comment, onComment 
         </div>
       )}
       <div>
-        <label htmlFor="generator-ssh-comment" className={MONO_LABEL}>
+        <label htmlFor="generator-ssh-comment" className={LABEL}>
           {t('Comment')}
         </label>
         <input
@@ -69,7 +69,7 @@ export default function Ssh({ pair, pending, error, onRetry, comment, onComment 
           placeholder="alice@laptop"
           data-testid="generator-ssh-comment"
           onChange={event => onComment(event.target.value)}
-          className={`mt-1 block font-mono ${inputClass}`}
+          className={`mt-1 block ${inputClass}`}
         />
       </div>
     </div>

--- a/src/components/Main/Palette/CommandRow.tsx
+++ b/src/components/Main/Palette/CommandRow.tsx
@@ -1,6 +1,6 @@
 import Row from './Row'
 import type { Command } from './commands'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 interface Props {
   id: string
@@ -26,7 +26,7 @@ export default function CommandRow({ id, command, focused, onRun, onHover }: Pro
       </span>
       <span className="min-w-0 flex-1 truncate text-base text-text2">{command.label}</span>
       {command.shortcut && (
-        <span className={`flex-none ${MONO_META}`}>{command.shortcut}</span>
+        <span className={`flex-none ${META}`}>{command.shortcut}</span>
       )}
     </Row>
   )

--- a/src/components/Main/Sidebar/Settings/Footer.tsx
+++ b/src/components/Main/Sidebar/Settings/Footer.tsx
@@ -3,10 +3,12 @@ import { useStore } from '@/store'
 import { APP_NAME } from '@/lib/app'
 import { isMobile } from '@/lib/platform'
 import { useVaultMeta, vaultHome } from '@/hooks/useAuthMeta'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 // Version and update state, pinned under the nav. The status line doubles as the
 // "check for updates" control — there is no separate Updates section any more.
+// Two lines of the meta tier: the app and its version a shade up, since that is
+// the line someone came here to read, the status muted beneath it.
 export default function Footer() {
   const { t } = useTranslation()
   const meta = useVaultMeta()
@@ -24,8 +26,8 @@ export default function Footer() {
   const home = meta ? vaultHome(meta.configured) : null
 
   return (
-    <div className={`mt-4 flex flex-col items-start gap-0.5 ${MONO_META}`}>
-      <div data-testid="settings-version">
+    <div className={`mt-4 flex flex-col items-start gap-0.5 ${META}`}>
+      <div data-testid="settings-version" className="text-text2">
         {meta?.version ? `${APP_NAME} ${meta.version}` : APP_NAME}
       </div>
       {isMobile ? (
@@ -38,7 +40,7 @@ export default function Footer() {
           title={t('Check for updates')}
           data-testid="settings-update-status"
           onClick={() => runUpdateCheck()}
-          className="cursor-pointer text-left transition-colors hover:text-text2"
+          className="cursor-pointer text-left transition-colors hover:text-text"
         >
           {status}
           {home && ` · ${home}`}

--- a/src/components/Main/Sidebar/Settings/Sections/Audit.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Audit.tsx
@@ -6,7 +6,7 @@ import SettingsRow from '@/components/elements/SettingsRow'
 import Toggle from '@/components/elements/Toggle'
 import Button from '@/components/elements/Button'
 import ScoreRing from '@/components/elements/ScoreRing'
-import { ROW_HAIRLINE } from '@/components/elements/tokens'
+import { META_TYPE, ROW_HAIRLINE } from '@/components/elements/tokens'
 
 export default function Audit() {
   const { t } = useTranslation()
@@ -55,7 +55,7 @@ export default function Audit() {
           </div>
           <div
             data-testid="settings-audit-counts"
-            className="min-w-0 flex-1 font-mono text-xs text-text2"
+            className={`min-w-0 flex-1 ${META_TYPE} text-text2`}
           >
             {counts.weak} {t('weak')} · {counts.reused} {t('reused')} · {counts.breached}{' '}
             {t('breached')}

--- a/src/components/Main/Sidebar/Settings/Sections/Import/DropZone.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/DropZone.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { isMobile } from '@/lib/platform'
 import { pickImportFile } from '@/lib/commands'
 import { DownloadGlyph } from '../../../../icons'
+import { META_TYPE } from '@/components/elements/tokens'
 
 interface Props {
   onDrop: (path: string) => void
@@ -56,7 +57,7 @@ export default function DropZone({ onDrop }: Props) {
         <div className="text-base text-text2">
           {isMobile ? t('Or choose an export file') : t('Or drop an export file here')}
         </div>
-        <div className="font-mono text-xs">
+        <div className={META_TYPE}>
           {t('csv, json — parsed locally, never uploaded')}
         </div>
       </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Progress.tsx
@@ -1,5 +1,5 @@
 import { pct } from './useProgress'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 interface Props {
   done: number
@@ -16,7 +16,7 @@ export default function Progress({ done, total }: Props) {
           style={{ width: `${pct(done, total)}%` }}
         />
       </div>
-      <span className={MONO_META}>
+      <span className={META}>
         {done} / {total}
       </span>
     </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Result.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Result.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from '@/components/elements/Button'
 import { inputClass } from '@/components/elements/formStyles'
-import { CARD, MONO_META } from '@/components/elements/tokens'
+import { CARD, META } from '@/components/elements/tokens'
 import Progress from './Progress'
 import RowErrors from './RowErrors'
 import type { useImport } from './useImport'
@@ -20,7 +20,7 @@ export default function Result({ flow }: { flow: ReturnType<typeof useImport> })
 
   return (
     <div className={`${CARD} flex flex-col gap-3 p-4`} data-testid="import-result">
-      <div className={MONO_META}>{fileName(picked.path)}</div>
+      <div className={META}>{fileName(picked.path)}</div>
 
       {picked.kind === 'swftx' ? (
         <div className="flex flex-wrap items-center gap-3">

--- a/src/components/Main/Sidebar/Settings/Sections/Import/Tiles.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/Tiles.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { cx } from '@/utils/cx'
 import type { TKey } from '@/i18n'
 import type { ImportFormat } from '@/lib/commands'
-import { CARD, MONO_META } from '@/components/elements/tokens'
+import { CARD, META, META_TYPE } from '@/components/elements/tokens'
 
 // One tile per source. `format` absent means the Swifty backup tile, which goes
 // through its own picker and password.
@@ -53,11 +53,11 @@ export default function Tiles({ active, disabled, onFormat, onBackup }: Props) {
             disabled && 'cursor-default opacity-50'
           )}
         >
-          <div className="grid h-10 w-10 place-items-center rounded-sm bg-tile font-mono text-xs text-text2">
+          <div className={`grid h-10 w-10 place-items-center rounded-sm bg-tile ${META_TYPE} text-text2`}>
             {tile.badge}
           </div>
           <div className="mt-3 truncate text-base text-text">{t(tile.name)}</div>
-          <div className={`mt-0.5 ${MONO_META}`}>{t(tile.hint)}</div>
+          <div className={`mt-0.5 ${META}`}>{t(tile.hint)}</div>
         </button>
       ))}
     </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/index.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 import { useImport } from './useImport'
 import Tiles from './Tiles'
 import DropZone from './DropZone'
@@ -17,7 +17,7 @@ export default function Import() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className={MONO_LABEL}>{t('Bring secrets from')}</div>
+      <div className={LABEL}>{t('Bring secrets from')}</div>
       <Tiles
         active={active}
         disabled={flow.running}

--- a/src/components/Main/Sidebar/Settings/Sections/Language.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Language.tsx
@@ -8,7 +8,7 @@ import SettingsGroup from '@/components/elements/SettingsGroup'
 import SettingsRow from '@/components/elements/SettingsRow'
 import Segmented from '@/components/elements/Segmented'
 import RadioList from '@/components/elements/RadioList'
-import { MONO_LABEL } from '@/components/elements/tokens'
+import { LABEL } from '@/components/elements/tokens'
 
 const THEMES: { value: ThemePreference; label: TKey }[] = [
   { value: 'light', label: 'Light' },
@@ -33,7 +33,7 @@ export default function Language() {
   return (
     <>
       <section className="mb-7">
-        <div className={`${MONO_LABEL} mb-2`}>{t('Language')}</div>
+        <div className={`${LABEL} mb-2`}>{t('Language')}</div>
         <RadioList
           name="locale"
           value={i18n.resolvedLanguage ?? ''}
@@ -52,7 +52,6 @@ export default function Language() {
           label={formatLabel}
           control={
             <Segmented
-              mono
               name={formatLabel}
               options={DATE_FORMATS.map(value => ({ value, label: value }))}
               value={format}

--- a/src/components/Main/Sidebar/Settings/Sections/Security/GeneratorGroup.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Security/GeneratorGroup.tsx
@@ -6,7 +6,7 @@ import { LENGTH_RANGE } from '@/services/generator'
 import SettingsGroup from '@/components/elements/SettingsGroup'
 import SettingsRow from '@/components/elements/SettingsRow'
 import Toggle from '@/components/elements/Toggle'
-import { MONO_META } from '@/components/elements/tokens'
+import { META } from '@/components/elements/tokens'
 
 // The seed values for every new password, shared with the ⌘G generator dialog.
 // `uppercase` stays out of the UI — the dialog always draws from both cases —
@@ -37,7 +37,7 @@ export default function GeneratorGroup() {
               data-testid="settings-generator-length"
               onChange={e => update({ length: Number(e.target.value) })}
             />
-            <span className={`w-[68px] flex-none text-right ${MONO_META}`}>
+            <span className={`w-[68px] flex-none text-right ${META}`}>
               {options.length} {t('chars')}
             </span>
           </div>

--- a/src/components/Main/Sidebar/Settings/Sections/Security/SessionGroup.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Security/SessionGroup.tsx
@@ -52,7 +52,6 @@ export default function SessionGroup() {
         description={t('Idle time before the vault seals itself')}
         control={
           <Segmented
-            mono
             name={lockLabel}
             options={LOCK_OPTIONS}
             value={lock}
@@ -66,7 +65,6 @@ export default function SessionGroup() {
         description={t('Copied secrets are wiped after this delay')}
         control={
           <Segmented
-            mono
             name={clipboardLabel}
             options={clipboardOptions(t)}
             value={clipboard}

--- a/src/components/Main/Sidebar/Tags/Menu.tsx
+++ b/src/components/Main/Sidebar/Tags/Menu.tsx
@@ -4,6 +4,7 @@ import { cx } from '@/utils/cx'
 import { Dropdown, DropdownItem } from '@/components/elements/Dropdown'
 import { CheckGlyph } from '../../icons'
 import { useTagCounts } from './useTagCounts'
+import { META, META_TYPE } from '@/components/elements/tokens'
 
 // Hangs off the right edge of the 36px rail tile, floating over the list column
 // — the rail itself is too narrow to hold a menu. `className` is where it is
@@ -32,7 +33,7 @@ export default function Menu({
         {tags.length === 0 ? (
           <div className="px-3.5 py-2.5" data-testid="tags-empty">
             <div className="text-base text-text2">{t('No tags yet')}</div>
-            <div className="mt-1 text-xs text-text3">
+            <div className={`mt-1 ${META}`}>
               {t('Add tags to an entry and they show up here.')}
             </div>
           </div>
@@ -46,7 +47,7 @@ export default function Menu({
                 <span className="min-w-0 flex-1 truncate">{tag}</span>
                 <span
                   data-testid={`tag-option-${tag}-count`}
-                  className="flex-none font-mono text-xs opacity-60"
+                  className={`flex-none ${META_TYPE} opacity-60`}
                 >
                   {count}
                 </span>

--- a/src/components/elements/AuthShell.tsx
+++ b/src/components/elements/AuthShell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuthMeta } from '@/hooks/useAuthMeta'
 import Back from '@/assets/images/back.svg?react'
-import { MONO_LABEL } from './tokens'
+import { LABEL } from './tokens'
 
 interface Props {
   children: ReactNode
@@ -12,7 +12,7 @@ interface Props {
 // The shared full-height, centered auth ground: a neutral background (via the
 // `bg-app` token, so it reads in both light and dark) with a soft radial glow
 // behind a max-560px centered column, an optional bottom "Go Back" link and
-// the mono footer strip (version + vault home, from useAuthMeta). Reused by
+// the footer strip (version + vault home, from useAuthMeta). Reused by
 // the lock, setup and restore screens.
 export default function AuthShell({ children, onBack }: Props) {
   const { t } = useTranslation()
@@ -54,7 +54,7 @@ export default function AuthShell({ children, onBack }: Props) {
           type="button"
           data-testid="go-back-button"
           onClick={onBack}
-          className={`absolute bottom-14 left-1/2 flex -translate-x-1/2 items-center gap-1.5 border-0 bg-transparent ${MONO_LABEL} transition-colors hover:text-text`}
+          className={`absolute bottom-14 left-1/2 flex -translate-x-1/2 items-center gap-1.5 border-0 bg-transparent ${LABEL} transition-colors hover:text-text`}
         >
           <Back width="13" className="[&_path]:fill-current" />
           {t('Go Back')}
@@ -63,7 +63,7 @@ export default function AuthShell({ children, onBack }: Props) {
 
       {meta && (
         // A tier below text-xs on purpose: footer chrome, not content.
-        <div className="absolute inset-x-0 bottom-0 flex h-13 items-center justify-center font-mono text-2xs uppercase tracking-label text-text3">
+        <div className="absolute inset-x-0 bottom-0 flex h-13 items-center justify-center text-2xs uppercase tracking-label text-text3">
           {meta}
         </div>
       )}

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
+import { META_TYPE } from './tokens'
 
 type Variant = 'primary' | 'ghost' | 'pale' | 'danger'
 // Two control heights, per the design system: md 28px (inline actions, pairs
@@ -9,7 +10,7 @@ type Size = 'md' | 'lg'
 interface Props {
   variant?: Variant
   size?: Size
-  // Full-width auth call-to-action treatment (taller, mono uppercase) used by the
+  // Full-width auth call-to-action treatment (taller, tracked uppercase) used by the
   // lock/setup/restore flows. Overrides `size`.
   block?: boolean
   // Borderless keyboard hint rendered after the label (e.g. '⏎', '⌘⏎').
@@ -30,7 +31,7 @@ const sizes: Record<Size, string> = {
   lg: 'h-9 px-4'
 }
 
-const blockStyle = 'w-full px-5 py-3 font-mono uppercase tracking-label'
+const blockStyle = 'w-full px-5 py-3 uppercase tracking-label'
 
 // The solid-fill treatment: light ink, a 1px top highlight, and a hover that
 // brightens the fill itself since there is no border or ground to swap.
@@ -77,7 +78,9 @@ export default function Button({
       {/* A chip rather than dimmed text: on an accent fill, opacity is the one
           thing that makes the hint disappear. */}
       {kbd && (
-        <span className="flex-none rounded-xs bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 font-mono text-xs leading-4">
+        <span
+          className={`flex-none rounded-xs bg-[color-mix(in_srgb,currentColor_14%,transparent)] px-1 ${META_TYPE} leading-4`}
+        >
           {kbd}
         </span>
       )}

--- a/src/components/elements/EmptyState.tsx
+++ b/src/components/elements/EmptyState.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
 import Button from './Button'
 import Kbd from './Kbd'
-import { MONO_META } from './tokens'
+import { META } from './tokens'
 
 interface Action {
   label: string
@@ -126,7 +126,7 @@ export default function EmptyState({
             {hints.map(hint => (
               <span key={hint.keys} className="flex items-center gap-1.5">
                 <Kbd>{hint.keys}</Kbd>
-                <span className={MONO_META}>{hint.label}</span>
+                <span className={META}>{hint.label}</span>
               </span>
             ))}
           </div>

--- a/src/components/elements/Error.tsx
+++ b/src/components/elements/Error.tsx
@@ -1,3 +1,4 @@
+import { META_TYPE } from './tokens'
 interface Props {
   error?: string | null
 }
@@ -7,7 +8,7 @@ export default function Error({ error }: Props) {
   return (
     <div
       data-testid="form-error"
-      className="mt-2.5 text-center font-mono text-xs tracking-label text-bad"
+      className={`mt-2.5 text-center ${META_TYPE} tracking-label text-bad`}
     >
       {error}
     </div>

--- a/src/components/elements/Eyebrow.tsx
+++ b/src/components/elements/Eyebrow.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { LABEL_TYPE } from './tokens'
 
 type Tone = 'muted' | 'bad'
 
@@ -10,7 +11,7 @@ interface Props {
   testid?: string
 }
 
-// Mono, uppercase, letter-spaced status line. Shared by every auth screen
+// Small, uppercase, letter-spaced status line. Shared by every auth screen
 // (lock / setup / restore) as its eyebrow; the tone alone carries state.
 export default function Eyebrow({
   children,
@@ -21,7 +22,7 @@ export default function Eyebrow({
   const text = tone === 'bad' ? 'text-bad' : 'text-text3'
 
   return (
-    <div className="flex items-center justify-center font-mono text-xs uppercase tracking-label">
+    <div className={`flex items-center justify-center ${LABEL_TYPE}`}>
       {/* The shimmer gradient IS the ink — the solid ink class would paint
           over it (color beats background-clip), so they're exclusive. */}
       <span data-testid={testid} className={busy ? 'shimmer-text' : text}>

--- a/src/components/elements/Kbd.tsx
+++ b/src/components/elements/Kbd.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
-import { MONO_META } from './tokens'
+import { META } from './tokens'
 
-// Keyboard-hint chip (⌘K, ⏎, esc). Bordered mono micro text on any surface;
+// Keyboard-hint chip (⌘K, ⏎, esc). Bordered micro text on any surface;
 // inside a filled primary Button use its `kbd` prop instead (borderless).
 export default function Kbd({ children }: { children: ReactNode }) {
   return (
-    <span className={`flex-none rounded-xs border border-line px-[5px] py-px ${MONO_META}`}>
+    <span className={`flex-none rounded-xs border border-line px-[5px] py-px ${META}`}>
       {children}
     </span>
   )

--- a/src/components/elements/PasswordStrength.tsx
+++ b/src/components/elements/PasswordStrength.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import { MIN_LENGTH } from '@/services/strength'
 import { useStrength } from '@/hooks/useStrength'
-import { MONO_META } from './tokens'
+import { META } from './tokens'
 
 const LABELS: TKey[] = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
@@ -43,7 +43,7 @@ export default function PasswordStrength({ password }: Props) {
           />
         ))}
       </div>
-      <div className={`mt-1.5 flex justify-between gap-2 ${MONO_META}`}>
+      <div className={`mt-1.5 flex justify-between gap-2 ${META}`}>
         <span data-testid="password-strength-label">
           {score !== null ? t(LABELS[score]) : ''}
         </span>

--- a/src/components/elements/RadioList.tsx
+++ b/src/components/elements/RadioList.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@/utils/cx'
 import { useRadioNav } from '@/hooks/useRadioNav'
-import { CARD, MONO_META, ROW_HAIRLINE } from './tokens'
+import { CARD, META, ROW_HAIRLINE } from './tokens'
 
 interface Props {
   options: { value: string; label: string; meta?: string }[]
@@ -11,7 +11,7 @@ interface Props {
 }
 
 // A single-choice list on the card surface — the long-form alternative to
-// Segmented, when options need room or a mono value on the right (languages,
+// Segmented, when options need room or a meta value on the right (languages,
 // timeouts, sort orders).
 export default function RadioList({
   options,
@@ -66,7 +66,7 @@ export default function RadioList({
             </span>
             <span className="min-w-0 flex-1 truncate text-base text-text">{option.label}</span>
             {option.meta && (
-              <span className={`flex-none ${MONO_META}`}>{option.meta}</span>
+              <span className={`flex-none ${META}`}>{option.meta}</span>
             )}
           </button>
         )

--- a/src/components/elements/ScoreRing.tsx
+++ b/src/components/elements/ScoreRing.tsx
@@ -39,8 +39,8 @@ export default function ScoreRing({ score, size = 30, testid }: Props) {
         x="18"
         y="21.5"
         textAnchor="middle"
-        fontFamily="var(--font-mono)"
         fontSize="9"
+        fontWeight="600"
         fill="currentColor"
       >
         {score === null ? '—' : score}

--- a/src/components/elements/Segmented.tsx
+++ b/src/components/elements/Segmented.tsx
@@ -5,8 +5,6 @@ interface Props<T extends string> {
   options: { value: T; label: string }[]
   value: T
   onChange: (value: T) => void
-  // Mono labels, for numeric/unit values like "10 m".
-  mono?: boolean
   // Names the radiogroup for screen readers — usually the row's own label,
   // which is otherwise only visually associated with the control.
   name?: string
@@ -21,7 +19,6 @@ export default function Segmented<T extends string>({
   options,
   value,
   onChange,
-  mono,
   name,
   testidPrefix,
   className
@@ -54,8 +51,7 @@ export default function Segmented<T extends string>({
             data-testid={testidPrefix && `${testidPrefix}-${option.value}`}
             onClick={() => onChange(option.value)}
             className={cx(
-              'cursor-pointer rounded-sm px-2.5 py-[3px] text-base transition-colors',
-              mono && 'font-mono',
+              'cursor-pointer rounded-sm px-2.5 py-[3px] text-base tabular-nums transition-colors',
               active ? 'bg-accent-soft text-text' : 'text-text3 hover:text-text'
             )}
           >

--- a/src/components/elements/SettingsGroup.tsx
+++ b/src/components/elements/SettingsGroup.tsx
@@ -1,18 +1,18 @@
 import type { ReactNode } from 'react'
 import { cx } from '@/utils/cx'
-import { CARD, MONO_LABEL } from './tokens'
+import { CARD, LABEL } from './tokens'
 
 interface Props {
   label: string
   children: ReactNode
 }
 
-// A titled block of SettingsRows: mono uppercase heading above one card. Groups
+// A titled block of SettingsRows: uppercase micro heading above one card. Groups
 // own the gap below them so a settings page is just a stack of these.
 export default function SettingsGroup({ label, children }: Props) {
   return (
     <section className="mb-7">
-      <div className={cx(MONO_LABEL, 'mb-2')}>{label}</div>
+      <div className={cx(LABEL, 'mb-2')}>{label}</div>
       <div className={CARD}>{children}</div>
     </section>
   )

--- a/src/components/elements/StrengthBar.tsx
+++ b/src/components/elements/StrengthBar.tsx
@@ -2,7 +2,7 @@ import { useStrength } from '@/hooks/useStrength'
 import { useTranslation } from 'react-i18next'
 import type { TKey } from '@/i18n'
 import Meter from './Meter'
-import { MONO_META } from './tokens'
+import { META } from './tokens'
 
 const STRENGTH_LABELS: TKey[] = ['Very weak', 'Weak', 'Fair', 'Strong', 'Very strong']
 
@@ -14,7 +14,7 @@ export default function StrengthBar({ password }: { password: string }) {
   return (
     <div className="flex items-center gap-2.5">
       <Meter level={score} />
-      <span className={MONO_META}>
+      <span className={META}>
         {score !== null ? t(STRENGTH_LABELS[score]) : ''}
       </span>
     </div>

--- a/src/components/elements/TagsInput.tsx
+++ b/src/components/elements/TagsInput.tsx
@@ -1,5 +1,6 @@
 import { useState, type KeyboardEvent } from 'react'
 import { TAG_CHIP } from './fields/chip'
+import { META_TYPE } from './tokens'
 
 interface Props {
   value: string[]
@@ -47,7 +48,7 @@ export default function TagsInput({ value, onChange, placeholder }: Props) {
         // The one input in the entry editor with no `name` — specs address it here.
         data-testid="tags-input"
         placeholder={placeholder}
-        className="h-6 min-w-[110px] flex-1 border-b border-line2 bg-transparent font-mono text-xs text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line"
+        className={`h-6 min-w-[110px] flex-1 border-b border-line2 bg-transparent ${META_TYPE} text-text outline-none transition-colors placeholder:text-text3 focus:border-accent-line`}
         value={input}
         onChange={e => setInput(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/components/elements/fields/CustomFields/Row.tsx
+++ b/src/components/elements/fields/CustomFields/Row.tsx
@@ -5,7 +5,7 @@ import { cx } from '@/utils/cx'
 import { TrashGlyph } from '../../../Main/icons'
 import CopyButton from '../../CopyButton'
 import IconButton from '../../IconButton'
-import { HOVER_ONLY, MONO_LABEL, MONO_TYPE, ROW_HAIRLINE } from '../../tokens'
+import { HOVER_ONLY, LABEL, LABEL_TYPE, ROW_HAIRLINE, VALUE } from '../../tokens'
 
 interface Props {
   field: ExtraField
@@ -19,12 +19,12 @@ interface Props {
 }
 
 // The same value column in both modes, so switching does not move the row.
-const INK = 'block h-6 w-full min-w-0 truncate font-mono text-base leading-6 text-text'
+const INK = `${VALUE} w-full text-text`
 const BOX =
   'border-b border-line2 bg-transparent outline-none transition-colors placeholder:text-text3 focus:border-accent-line'
 
 // One label/value pair, in the detail row's geometry: the label takes the w-32
-// mono column the fixed rows use, the value the rest. Reading, the value gets a
+// label column the fixed rows use, the value the rest. Reading, the value gets a
 // copy button like any other; editing, the label is typed too — it is the user's
 // word for this field, not a translated one — and the row can be dropped.
 export default function CustomFieldRow({
@@ -59,12 +59,12 @@ export default function CustomFieldRow({
           autoComplete="off"
           spellCheck={false}
           onChange={event => onChange({ ...field, label: event.target.value })}
-          className={cx('w-32 flex-none text-text', MONO_TYPE, BOX)}
+          className={cx('w-32 flex-none text-text', LABEL_TYPE, BOX)}
         />
       ) : (
         <span
           data-testid={`entry-extra-label-${index}`}
-          className={cx('w-32 flex-none truncate', MONO_LABEL)}
+          className={cx('w-32 flex-none truncate', LABEL)}
         >
           {field.label}
         </span>

--- a/src/components/elements/fields/CustomFields/index.tsx
+++ b/src/components/elements/fields/CustomFields/index.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import type { ExtraField } from '@/lib/commands'
 import { PlusGlyph } from '../../../Main/icons'
 import Panel from '../../Panel'
-import { MONO_LABEL } from '../../tokens'
+import { LABEL } from '../../tokens'
 import { useFields } from '../context'
 import { isBlank, rowsOf } from './extras'
 import CustomFieldRow from './Row'
@@ -31,7 +31,7 @@ export default function CustomFields({ name = 'extra' }) {
 
   return (
     <div className="mt-4">
-      <span className={`mb-1.5 block ${MONO_LABEL}`}>{t('Custom fields')}</span>
+      <span className={`mb-1.5 block ${LABEL}`}>{t('Custom fields')}</span>
       {shown.length > 0 && (
         <Panel>
           {shown.map((field, index) => (

--- a/src/components/elements/fields/DateField.tsx
+++ b/src/components/elements/fields/DateField.tsx
@@ -3,6 +3,7 @@ import type { TKey } from '@/i18n'
 import { getFormat } from '@/defaults/dateFormat'
 import { cx } from '@/utils/cx'
 import { daysUntil, formatDate, relativeFuture, toIsoDate } from '@/utils/time'
+import { META_TYPE } from '../tokens'
 import { useField } from './context'
 import Field from './Field'
 
@@ -29,7 +30,7 @@ export default function DateField({
   const days = expiry && !editing ? daysUntil(value) : null
   const stamp =
     days === null ? undefined : (
-      <span className={cx('font-mono text-xs', days < 0 ? 'text-bad' : 'text-text3')}>
+      <span className={cx(META_TYPE, days < 0 ? 'text-bad' : 'text-text3')}>
         {days < 0 ? t('Expired') : t('Expires {{when}}', { when: relativeFuture(value) })}
       </span>
     )

--- a/src/components/elements/fields/Field.tsx
+++ b/src/components/elements/fields/Field.tsx
@@ -6,7 +6,7 @@ import type { TKey } from '@/i18n'
 import { EyeGlyph, EyeOffGlyph } from '../../Main/icons'
 import CopyButton from '../CopyButton'
 import IconButton from '../IconButton'
-import { HOVER_ONLY } from '../tokens'
+import { HOVER_ONLY, VALUE_LINE } from '../tokens'
 import { useField } from './context'
 import { requiredError } from './formats'
 import FieldRow from './Row'
@@ -54,7 +54,7 @@ const MASK = { WebkitTextSecurity: 'disc' } as CSSProperties
 const DOTS = '•'.repeat(12)
 
 // One field, both modes. Reading, it is the detail row it has always been:
-// mono value, reveal toggle, copy button, hidden when empty. Editing, the same
+// the value, reveal toggle, copy button, hidden when empty. Editing, the same
 // row with the value swapped for an underlined borderless input. Every
 // type-aware field in this folder is a thin wrapper around it.
 export default function Field({
@@ -95,10 +95,7 @@ export default function Field({
   const masked = secure && !show
   const mask = masked ? MASK : undefined
   // The headline treatment is for a secret being read, not for its mask.
-  const ink = cx(
-    'block h-6 min-w-0 truncate font-mono leading-6',
-    big && !masked ? 'text-xl tracking-secret' : 'text-base'
-  )
+  const ink = cx(VALUE_LINE, big && !masked ? 'text-xl tracking-secret' : 'text-base')
   // Nothing to gloss about a mask, and nothing to gloss while typing.
   const gloss = !editing && !masked ? suffix?.(value) : undefined
 
@@ -171,7 +168,7 @@ export default function Field({
               {masked ? DOTS : shown}
             </button>
             {gloss && (
-              <span className="min-w-0 flex-none truncate font-mono text-base leading-6 text-text3">
+              <span className="min-w-0 flex-none truncate text-base leading-6 text-text3">
                 · {gloss}
               </span>
             )}

--- a/src/components/elements/fields/Otp/Dial.tsx
+++ b/src/components/elements/fields/Otp/Dial.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { OTP_PERIOD } from '@/hooks/useOtp'
-import { MONO_META } from '../../tokens'
+import { META } from '../../tokens'
 
 const R = 48
 const CIRCUMFERENCE = 2 * Math.PI * R // ≈ 301
@@ -30,11 +30,11 @@ export default function Dial({ code, time }: { code: string; time: number }) {
             strokeDasharray={`${(time / OTP_PERIOD) * CIRCUMFERENCE} ${CIRCUMFERENCE}`}
           />
         </svg>
-        <div className="font-mono text-xl tracking-secret text-text">
+        <div className="text-xl tracking-secret tabular-nums text-text">
           {`${code.slice(0, 3)} ${code.slice(3)}`}
         </div>
       </div>
-      <div className={MONO_META}>
+      <div className={META}>
         {t('refreshes in {{n}}s', { n: time })}
       </div>
     </>

--- a/src/components/elements/fields/Otp/index.tsx
+++ b/src/components/elements/fields/Otp/index.tsx
@@ -3,7 +3,7 @@ import type { TKey } from '@/i18n'
 import { copy } from '@/services/copy'
 import { useOtp } from '@/hooks/useOtp'
 import Panel from '../../Panel'
-import { MONO_LABEL } from '../../tokens'
+import { LABEL } from '../../tokens'
 import { useField } from '../context'
 import Dial from './Dial'
 import { otpSecret } from './secret'
@@ -35,7 +35,7 @@ export default function OtpField({
 
   return (
     <Panel className="flex flex-col items-center p-3.5">
-      <div className={`self-stretch ${MONO_LABEL}`}>{t(label)}</div>
+      <div className={`self-stretch ${LABEL}`}>{t(label)}</div>
 
       {editing && (
         <input
@@ -53,7 +53,7 @@ export default function OtpField({
           // A pasted otpauth:// link collapses to the secret it carries, so the
           // vault only ever stores the thing the generator needs.
           onBlur={() => set(parsed || value.trim())}
-          className={`mt-2.5 h-6 w-full self-stretch truncate border-b bg-transparent text-center font-mono text-base text-text outline-none transition-colors placeholder:text-text3 ${
+          className={`mt-2.5 h-6 w-full self-stretch truncate border-b bg-transparent text-center text-base text-text outline-none transition-colors placeholder:text-text3 ${
             value && !parsed ? 'border-bad' : 'border-line2 focus:border-accent-line'
           }`}
         />

--- a/src/components/elements/fields/Passkeys/Row.tsx
+++ b/src/components/elements/fields/Passkeys/Row.tsx
@@ -4,7 +4,7 @@ import { cx } from '@/utils/cx'
 import { shortDate, toTime } from '@/utils/time'
 import { KeyGlyph, TrashGlyph } from '../../../Main/icons'
 import IconButton from '../../IconButton'
-import { MONO_META, ROW_HAIRLINE } from '../../tokens'
+import { META, ROW_HAIRLINE } from '../../tokens'
 
 interface Props {
   passkey: Passkey
@@ -34,7 +34,7 @@ export default function PasskeyRow({ passkey, onRemove }: Props) {
         <div className="truncate text-base text-text">
           {passkey.rpName || passkey.rpId}
         </div>
-        <div className={`mt-0.5 truncate ${MONO_META}`}>
+        <div className={`mt-0.5 truncate ${META}`}>
           {passkey.userName}
           {created !== null &&
             ` · ${t('Created {{time}}', { time: shortDate(created) })}`}

--- a/src/components/elements/fields/Passkeys/index.tsx
+++ b/src/components/elements/fields/Passkeys/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { Passkey } from '@/lib/commands'
 import Panel from '../../Panel'
-import { MONO_LABEL } from '../../tokens'
+import { LABEL } from '../../tokens'
 import { useFields } from '../context'
 import PasskeyRow from './Row'
 
@@ -30,7 +30,7 @@ export default function Passkeys({ name = 'passkeys' }) {
 
   return (
     <div className="mt-4">
-      <span className={`mb-1.5 block ${MONO_LABEL}`}>{t('Passkeys')}</span>
+      <span className={`mb-1.5 block ${LABEL}`}>{t('Passkeys')}</span>
       <Panel>
         {passkeys.map(passkey => (
           <PasskeyRow

--- a/src/components/elements/fields/PasswordField.tsx
+++ b/src/components/elements/fields/PasswordField.tsx
@@ -8,7 +8,7 @@ import IconButton from '../IconButton'
 import StrengthBar from '../StrengthBar'
 import Field from './Field'
 import { useField, useFields } from './context'
-import { MONO_META } from '../tokens'
+import { META } from '../tokens'
 
 // How long this password has been in place. `now` reads as "just now" rather
 // than "changed now ago", and past a week — where the duration runs out — the
@@ -62,7 +62,7 @@ export default function PasswordField({
           <>
             <StrengthBar password={value} />
             {/* A sentence about the password, not a label for one. */}
-            {stamp && <span className={MONO_META}>{stamp}</span>}
+            {stamp && <span className={META}>{stamp}</span>}
           </>
         )
       }

--- a/src/components/elements/fields/Row.tsx
+++ b/src/components/elements/fields/Row.tsx
@@ -2,7 +2,7 @@ import { useId, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cx } from '@/utils/cx'
 import type { TKey } from '@/i18n'
-import { MONO_LABEL, ROW_HAIRLINE } from '../tokens'
+import { LABEL, ROW_HAIRLINE } from '../tokens'
 import { useFields } from './context'
 
 interface Props {
@@ -47,7 +47,7 @@ const STACK_SIGIL = '@max-[420px]:hidden'
 const STACK_RAIL =
   '@max-[420px]:w-auto @max-[420px]:any-pointer-coarse:[&_button]:h-11 @max-[420px]:any-pointer-coarse:[&_button]:w-11'
 
-// THE detail-row geometry: a w-32 mono label column, the value, trailing
+// THE detail-row geometry: a w-32 micro-label column, the value, trailing
 // controls, then anything that belongs under the value. Read values and their
 // editors both render through it, so switching modes never moves a row.
 export default function FieldRow({ label, prefix, actions, below, error, children }: Props) {
@@ -69,7 +69,7 @@ export default function FieldRow({ label, prefix, actions, below, error, childre
                 catalog, rather than folded onto a second line. */}
             <label
               htmlFor={id}
-              className={`w-32 flex-none whitespace-nowrap ${MONO_LABEL} ${STACK_LABEL}`}
+              className={`w-32 flex-none whitespace-nowrap ${LABEL} ${STACK_LABEL}`}
             >
               {t(label)}
             </label>

--- a/src/components/elements/fields/chip.ts
+++ b/src/components/elements/fields/chip.ts
@@ -1,4 +1,5 @@
+import { META_TYPE } from '../tokens'
+
 // One tag chip, shared by the read row and the editor so a tag looks the same
 // before and after it is committed.
-export const TAG_CHIP =
-  'flex h-6 cursor-pointer items-center rounded-sm border border-line2 px-2.5 font-mono text-xs text-text2 transition-colors'
+export const TAG_CHIP = `flex h-6 cursor-pointer items-center rounded-sm border border-line2 px-2.5 ${META_TYPE} text-text2 transition-colors`

--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -18,13 +18,27 @@ export const HOVER_ONLY =
 export const TOAST =
   'animate-pop fixed z-[1000] max-w-[340px] rounded-xl border border-line bg-detail text-text shadow-float'
 
-// The mono micro-label face, without an ink. Take this when the label needs a
-// different colour (the accent "EDITING ·" eyebrow) and MONO_LABEL otherwise.
-export const MONO_TYPE = 'font-mono text-xs uppercase tracking-label'
+// The micro-label face, without an ink: 11px, uppercase, tracked, regular
+// weight — a label is the secondary line, and the value it captions carries the
+// weight. Take this when the label needs a different colour (the accent
+// "EDITING ·" eyebrow) and LABEL otherwise.
+export const LABEL_TYPE = 'text-xs uppercase tracking-label'
 
-export const MONO_LABEL = `${MONO_TYPE} text-text3`
+export const LABEL = `${LABEL_TYPE} text-text3`
 
-// The mono meta face: counts, timestamps, hints, shortcuts — the same 11px mono
-// as the label tier, muted, but set as ordinary text rather than a tracked
-// uppercase eyebrow.
-export const MONO_META = 'font-mono text-xs text-text3'
+// The meta face, without an ink: counts, timestamps, hints, shortcuts, chips —
+// the same 11px as the label tier, set as ordinary text rather than a tracked
+// uppercase eyebrow. Tabular figures, so a count or a countdown holds its width
+// as it changes instead of nudging what sits beside it. Take this when the ink
+// is the caller's (a count inheriting its chip's colour, an error in `text-bad`)
+// and META otherwise.
+export const META_TYPE = 'text-xs tabular-nums'
+
+export const META = `${META_TYPE} text-text3`
+
+// The detail row's value line: one line high, never wrapping, the ink the
+// caller's. VALUE_LINE leaves the size open for the one row that sets its own
+// (the headline secret, at text-xl); everything else takes VALUE.
+export const VALUE_LINE = 'block h-6 min-w-0 truncate leading-6'
+
+export const VALUE = `${VALUE_LINE} text-base`

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -96,9 +96,9 @@ export const i18nReady = resolveInitial().then(lng =>
 // document what language it is in. Registered once, rather than wrapping
 // `changeLanguage`, so a change from anywhere is picked up.
 //
-// `lang` is not decoration: the mono labels are uppercased by CSS
-// (`text-transform`, see MONO_TYPE), and casing is language-dependent. Under
-// `lang="en"` Turkish "i" uppercases to "I" instead of "İ", so every mono label
+// `lang` is not decoration: the micro labels are uppercased by CSS
+// (`text-transform`, see LABEL_TYPE), and casing is language-dependent. Under
+// `lang="en"` Turkish "i" uppercases to "I" instead of "İ", so every micro label
 // in the Turkish UI is misspelled. It also drives screen-reader pronunciation
 // and line breaking.
 i18n.on('languageChanged', locale => {

--- a/src/kinds/card/Fields/Value.tsx
+++ b/src/kinds/card/Fields/Value.tsx
@@ -8,6 +8,7 @@ type Mask = '•••' | '••••' | '••/••' | '•••• •�
 import { useCopied } from '@/hooks/useCopied'
 import { useFields } from '@/components/elements/fields'
 import { CheckGlyph, CopyGlyph } from '@/components/Main/icons'
+import { LABEL_TYPE, META_TYPE } from '@/components/elements/tokens'
 
 // Opaque version of the hover wash (white/10 composited over the card's
 // ground), so a click doesn't visibly shift the ground but the value is fully
@@ -88,7 +89,7 @@ export default function Value({
   const { copied, copy } = useCopied()
 
   const caption = label && (
-    <span className="block text-[11px] uppercase tracking-label opacity-50">{t(label)}</span>
+    <span className={`block ${LABEL_TYPE} opacity-50`}>{t(label)}</span>
   )
 
   if (set) {
@@ -116,7 +117,7 @@ export default function Value({
           )}
         />
         {invalid && (
-          <span className="mt-1 block text-[11px] text-[#FF8A8A]">{t('Required')}</span>
+          <span className={`mt-1 block ${META_TYPE} text-[#FF8A8A]`}>{t('Required')}</span>
         )}
       </label>
     )

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -57,7 +57,7 @@ export default function Fields() {
           gutters on a phone. A fixed height gave a squat 1.24:1 slab wherever
           the width was squeezed. The height is a floor, not a cap: with more
           rows than the face has room for, it grows rather than clipping. */}
-      <div className="relative flex aspect-[1.586] w-[460px] max-w-full flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 font-mono text-[#EDEEF0] shadow-[0_12px_28px_rgba(0,0,0,0.22)]">
+      <div className="relative flex aspect-[1.586] w-[460px] max-w-full flex-col overflow-hidden rounded-[16px] border border-line2 bg-[linear-gradient(150deg,#2A2D33,#14161A_62%)] p-6 text-[#EDEEF0] tabular-nums shadow-[0_12px_28px_rgba(0,0,0,0.22)]">
         <div className="absolute -right-10 -top-16 h-[240px] w-[240px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,.07),transparent_70%)]" />
 
         <div className="relative flex items-start justify-between gap-4">
@@ -70,7 +70,7 @@ export default function Fields() {
             testid="entry-value-name"
             placeholder="Cardholder"
             maxLength={40}
-            ink="text-[13px] uppercase tracking-label opacity-90"
+            ink="text-base uppercase tracking-label opacity-90"
             zone="top"
             className="-mx-1.5 flex-1"
           />
@@ -126,10 +126,10 @@ export default function Fields() {
             // and `isValid` wants both — so the box has to say so itself.
             invalid={attempted && !(month.value && year.value)}
             maxLength={5}
-            ink="text-[13px]"
+            ink="text-base"
             flag={
               expired && (
-                <span className="flex-none text-[10px] uppercase tracking-label text-[#FF8A8A]">
+                <span className="flex-none text-2xs uppercase tracking-label text-[#FF8A8A]">
                   {t('Expired')}
                 </span>
               )
@@ -147,7 +147,7 @@ export default function Fields() {
             placeholder="•••"
             required
             maxLength={4}
-            ink="text-[13px]"
+            ink="text-base"
           />
           <Value
             name="pin"
@@ -160,7 +160,7 @@ export default function Fields() {
             // Mask, not real catalog copy — falls through to itself.
             placeholder="••••"
             maxLength={6}
-            ink="text-[13px]"
+            ink="text-base"
           />
           {!editing && (
             <button

--- a/src/kinds/ssh/Fields/Fingerprint.tsx
+++ b/src/kinds/ssh/Fields/Fingerprint.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import CopyButton from '@/components/elements/CopyButton'
 import { FieldRow, useField } from '@/components/elements/fields'
+import { VALUE } from '@/components/elements/tokens'
 
 // Derived, never typed: the generator stamps it with the key, so the row reads
 // the same in both modes and a key pasted in by hand simply has none to show.
@@ -14,7 +15,7 @@ export default function Fingerprint() {
     <FieldRow label="Fingerprint" actions={<CopyButton value={value} title={t('Copy')} />}>
       {() => (
         <span
-          className="block h-6 min-w-0 truncate font-mono text-base leading-6 text-text"
+          className={`${VALUE} text-text`}
           data-testid="entry-value-fingerprint"
         >
           {value}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,8 +8,7 @@ import { applyTheme, getTheme } from './theme'
 import { i18nReady } from './i18n'
 import './shortcuts'
 // Design tokens + base (Tailwind v4). Sole stylesheet now the SASS is gone.
-// Type comes from the OS system stacks (see --font-sans/--font-mono) — no
-// bundled webfonts.
+// Type comes from the OS system stack (see --font-sans) — no bundled webfonts.
 import './styles/theme.css'
 
 applyPlatform()

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -268,8 +268,10 @@
   /*
    * Native system stacks — no bundled webfonts. On macOS (Tauri/WebKit) these
    * resolve to SF Pro and SF Mono; on Windows to Segoe UI and Consolas; on
-   * Linux to the desktop's configured fonts. The mono tier stays monospaced
-   * on purpose: labels, counts and revealed secrets rely on it.
+   * Linux to the desktop's configured fonts. The UI is set in the sans tier
+   * throughout — labels, counts and timestamps included, with tabular figures
+   * where a number has to hold its width. The mono tier is reserved for raw
+   * key material (an SSH key's body), which is code and wraps like it.
    */
   --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, sans-serif;
@@ -340,12 +342,12 @@
  * simply doesn't compile, which keeps the system honest.
  *
  *   Type      2xs 10px footer chrome (a tier below content)
- *             xs 11px mono micro (labels/meta/counts/kbd)
+ *             xs 11px micro (labels/meta/counts/kbd)
  *             base 13px everything readable — hierarchy via weight + ink
  *             md 15px the passphrase field and its mask
  *             lg 16 / xl 20 / 2xl 24 display tiers (2xl is also the phone
  *             shell's screen title) · 3xl 34 the vault score
- *   Tracking  label .12em (mono uppercase) · display −.02em (16px and up)
+ *   Tracking  label .12em (uppercase micro) · display −.02em (16px and up)
  *             secret .08em (revealed secrets, card numbers, TOTP)
  *   Radius    xs 4 chips & inlays · sm 8 controls · lg 12 tiles & cards
  *             xl 14 overlays · 2xl 28 sheets (a bottom sheet's top corners)

--- a/src/test/main.test.tsx
+++ b/src/test/main.test.tsx
@@ -125,7 +125,7 @@ describe('Main', () => {
     renderWithStore(<Main />, { store: seed() })
 
     const count = (testid: string) =>
-      screen.getByTestId(testid).querySelector('.font-mono')?.textContent
+      screen.getByTestId(`${testid}-count`).textContent
 
     expect(count('filter-all')).toBe('3')
     expect(count('filter-login')).toBe('1')

--- a/src/test/radioList.test.tsx
+++ b/src/test/radioList.test.tsx
@@ -11,7 +11,7 @@ const OPTIONS = [
 ]
 
 describe('RadioList', () => {
-  it('renders one radio per option with its mono meta', () => {
+  it('renders one radio per option with its meta', () => {
     render(<RadioList options={OPTIONS} value="60" onChange={vi.fn()} testidPrefix="lock" />)
 
     expect(screen.getAllByRole('radio')).toHaveLength(3)

--- a/src/test/settings.test.tsx
+++ b/src/test/settings.test.tsx
@@ -371,7 +371,7 @@ describe('Settings › language & region', () => {
     await waitFor(() => expect(i18n.resolvedLanguage).toBe('de-DE'))
   })
 
-  // The mono labels are uppercased by CSS, and `text-transform` follows the
+  // The micro labels are uppercased by CSS, and `text-transform` follows the
   // document language: under `lang="en"` Turkish "i" becomes "I" rather than
   // "İ", misspelling every label in the Turkish UI.
   it('tells the document what language it is in', async () => {


### PR DESCRIPTION
## Summary

Sets the whole UI in the sans system stack and folds the inline micro-type class strings into the shared tokens.

- **No more monospace in the UI.** Labels, meta text, counts, timestamps, chips, keyboard hints, field values, the OTP dial, the card face and the generator output all lose `font-mono`. Figures that change live (counts, countdowns, the segmented control) get `tabular-nums` so they hold their width. Mono remains only on raw SSH key material (the private key body and the generator's key blocks), which is code and wraps like it.
- **Tokens renamed to say what they are.** `MONO_TYPE` / `MONO_LABEL` / `MONO_META` become `LABEL_TYPE` / `LABEL` / `META`, plus a new ink-less `META_TYPE` and a `VALUE` / `VALUE_LINE` pair for the detail row's one-line value.
- **Deduplication.** Twenty call sites that spelled these classes out inline (chip counts, tag menu, audit counts, import hints, list flag, date stamp, form and SSH errors, entropy line, tag chip, tags input, button kbd, auth eyebrow, card captions, field values, custom fields, fingerprint) now use the tokens. The card face's arbitrary 13/11/10px sizes use the scale tokens they already equalled; the card number keeps its deliberately off-scale size.
- **Entry detail footer.** Keeps the label-over-value cells aligned with the tags cell. The timestamp value drops to the 11px meta tier, sits flush under its label, and uses muted ink with medium weight so the value leads its caption while the footer stays secondary to the rows above.
- **Settings footer.** Version line one ink up from the status line.

## Notes

- The vault score ring inherits sans and is set semibold for legibility at 9px.
- `Segmented` loses its `mono` prop; every segment uses tabular figures.
- One test selector changed: chip counts are found by their existing `-count` test id instead of the `.font-mono` class.

## Verification

`bun run typecheck`, `bun run lint`, and `bun run test` (51 files, 489 tests) all pass.