### PR TITLE
ci(release): fix the failures blocking the desktop Release workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Local config for `scripts/release-local.sh` and for local dev builds that
+# need the Google Drive sync client (read at compile time via option_env! in
+# src-tauri/src/sync/auth.rs). Copy to `.env` and fill in. NEVER commit the
+# real `.env` (it is gitignored). In CI these same values come from GitHub
+# repository secrets (see docs/releasing.md).
+#
+# For a plain `bun run tauri dev` with these values, load the file first:
+#   set -a; source .env; set +a; bun run tauri dev
+
+# --- Google Drive sync OAuth client (baked into the binary at compile time).
+#     Desktop-app OAuth client from Google Cloud Console → APIs & Services →
+#     Credentials. Leave empty to build without Drive sync configured. ---
+GOOGLE_OAUTH_CLIENT_ID=""
+GOOGLE_OAUTH_CLIENT_SECRET=""
+
+# --- macOS code signing + notarization (Apple Developer ID) ---
+# The full identity string from `security find-identity -v -p codesigning`.
+# Must be the "Developer ID Application" certificate: "Apple Development" and
+# "Apple Distribution" certificates cannot be notarized for direct download.
+APPLE_SIGNING_IDENTITY="Developer ID Application: Oleksandr Chaplinsky (UFBL3F444A)"
+# Apple ID email used for notarization.
+APPLE_ID=""
+# App-specific password (https://appleid.apple.com → Sign-In and Security →
+# App-Specific Passwords), NOT your Apple account password.
+APPLE_PASSWORD=""
+# Apple Developer Team ID.
+APPLE_TEAM_ID="UFBL3F444A"
+
+# --- Updater artifact signing (Tauri minisign keypair) ---
+# Contents of the private key generated via `bun run tauri signer generate`.
+# Its public half is `plugins.updater.pubkey` in src-tauri/tauri.conf.json.
+# Stored locally outside the repo (e.g. ~/.tauri/swifty.key); load it inline:
+TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/swifty.key)"
+# Password for the key above. Empty if the key was generated without one.
+TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
       - javascript
     groups:
       # Batch the Tauri JS plugins so they bump together with the Rust side.
+      # Dependabot cannot group across ecosystems, so the npm and cargo Tauri
+      # PRs still arrive separately; `tauri build` requires each npm package
+      # and its crate to share a major.minor, and CI's supply-chain job
+      # (scripts/check-tauri-versions.mjs) fails when they drift. Merge the
+      # two Tauri PRs together, or bump the lagging side in the same PR.
       tauri-js:
         patterns:
           - '@tauri-apps/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
               - 'src-tauri/Cargo.toml'
               - 'src-tauri/Cargo.lock'
               - 'src-tauri/deny.toml'
+              - 'scripts/check-tauri-versions.mjs'
 
   frontend:
     name: Frontend (build + lint)
@@ -247,6 +248,14 @@ jobs:
         with:
           bun-version: 1.3.3
       - run: bun install --frozen-lockfile
+
+      # `tauri build` refuses to compile when a Tauri npm package and its Rust
+      # crate are on different major.minor releases. Dependabot bumps the two
+      # sides in separate PRs (npm vs cargo), so catch the drift here rather
+      # than in the release workflow.
+      - name: Tauri npm/crate versions agree
+        run: bun scripts/check-tauri-versions.mjs
+
       - name: bun audit (production deps — blocking)
         run: bun audit --audit-level=high --production
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,14 +124,21 @@ jobs:
 
       # Replace the placeholder release body with GitHub's auto-generated
       # release notes (the same "What's Changed" list the UI button produces),
-      # built from PRs/commits since the previous release. Runs once, on Linux;
-      # the draft can still be edited by hand before publishing.
+      # built from PRs/commits since the previous release. Runs once, on Linux,
+      # and only while the body is still the placeholder above: a re-run
+      # against an existing draft leaves hand-edited notes alone.
       - name: Generate release notes
         if: matrix.platform == 'ubuntu-latest'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLACEHOLDER: See the assets below to download and install this version.
         run: |
           TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
+          CURRENT=$(gh release view "$TAG" --json body --jq .body)
+          if [ "$CURRENT" != "$PLACEHOLDER" ]; then
+            echo "Release body already customised; leaving it untouched."
+            exit 0
+          fi
           NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
             -f tag_name="$TAG" --jq .body)
           if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,28 @@
 # tauri-plugin-updater reads from `releases/latest/download/latest.json`.
 # Publishing the draft is what makes a version visible to installed apps.
 #
-# One-time secret setup and the per-release procedure: docs/RELEASING.md.
+# One-time secret setup and the per-release procedure: docs/releasing.md.
+# The same build can be run locally with scripts/release-local.sh (macOS only).
 #
 # Repository secrets used. The Apple/Google names are the ones already set on
 # the repo (from the Electron-era release workflows); the Tauri bundler expects
 # different env names, so they are mapped below.
-#   CERTIFICATES_P12 / CERTIFICATES_P12_PASSWORD        base64 .p12 Developer ID cert + password (macOS signing)
+#   CERTIFICATES_P12 / CERTIFICATES_P12_PASSWORD        base64 .p12 export of the "Developer ID Application"
+#                                                       cert + its export password (macOS signing). It must
+#                                                       be that certificate: the bundler compares the .p12
+#                                                       against APPLE_SIGNING_IDENTITY and aborts on a
+#                                                       mismatch (an "Apple Development" cert here failed
+#                                                       a previous run).
 #   APPLE_ID / APPLE_ID_PASSWORD / APPLE_TEAM_ID        Apple ID, app-specific password, team id (notarization)
 #   TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)                minisign key for updater artifact signatures
 #   GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET Desktop OAuth client, baked in at compile time
 #                                                       (src-tauri/src/sync/auth.rs)
 # Windows installers are not code-signed (no certificate). macOS is signed and notarized.
+#
+# Before the build starts, the Tauri CLI checks that every @tauri-apps/* npm
+# package and its Rust crate share a major.minor; a mismatch fails all three
+# platforms. CI's supply-chain job runs the same check on every PR
+# (scripts/check-tauri-versions.mjs) so it is caught before release day.
 
 name: Release
 
@@ -42,8 +53,13 @@ jobs:
           - platform: ubuntu-latest
             args: ''
             bundlePath: src-tauri/target/release/bundle
+          # NSIS only. The MSI (WiX) bundler rejects a pre-release identifier
+          # that is not purely numeric ("1.0.0-alpha.1" -> "optional pre-release
+          # identifier in app version must be numeric-only"), and the updater
+          # is happy with the NSIS -setup.exe. Drop the flag to ship an .msi as
+          # well once versions are plain x.y.z.
           - platform: windows-latest
-            args: ''
+            args: '--bundles nsis'
             bundlePath: src-tauri/target/release/bundle
     runs-on: ${{ matrix.platform }}
     steps:
@@ -105,6 +121,22 @@ jobs:
           uploadUpdaterJson: true
           tauriScript: bun run tauri
           args: ${{ matrix.args }}
+
+      # Replace the placeholder release body with GitHub's auto-generated
+      # release notes (the same "What's Changed" list the UI button produces),
+      # built from PRs/commits since the previous release. Runs once, on Linux;
+      # the draft can still be edited by hand before publishing.
+      - name: Generate release notes
+        if: matrix.platform == 'ubuntu-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
+          NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body)
+          if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+            gh release edit "$TAG" --notes "$NOTES"
+          fi
 
       # --- SLSA build provenance (T-CI-4) ---------------------------------
       # Attest the installers this platform produced. Each pattern that matches

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-process": "^2.3.1",
-        "@tauri-apps/plugin-updater": "^2.10.1",
+        "@tauri-apps/plugin-updater": "^2.11.0",
         "@zxcvbn-ts/core": "^4.2.0",
         "@zxcvbn-ts/language-common": "^4.1.3",
         "@zxcvbn-ts/language-en": "^4.1.1",
@@ -478,7 +478,7 @@
 
     "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 
-    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.11.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-AE36XkOoSna24G40jZMY15nzAnkXEPL/73tGoseGrtGOHuI/cZwWzHpZFLjKXDPgzYZ435z1gHu28LgrsBwIxQ=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,145 @@
+# Releasing Swifty (desktop)
+
+Swifty ships for macOS (signed + notarized universal build), Windows (NSIS
+installer) and Linux (.deb, .rpm, AppImage) through GitHub Releases, with a
+silent in-app auto-updater. This doc covers the one-time setup and the
+per-release procedure. iOS is a separate workflow: see
+[releasing-ios.md](releasing-ios.md).
+
+## Overview
+
+```
+bump version → push a v* tag (or run Release manually) → CI builds all three platforms
+            → DRAFT GitHub release (installers + .app.tar.gz + .sig + latest.json)
+            → you review and publish the draft → installed apps update on next launch
+```
+
+- **Workflow:** `.github/workflows/release.yml`, one matrix job per platform.
+- **macOS:** `universal-apple-darwin` (one binary for Apple Silicon + Intel),
+  signed with the Developer ID Application cert (team `UFBL3F444A`), notarized
+  and stapled by `tauri-apps/tauri-action`.
+- **Windows:** NSIS `-setup.exe` only, not code-signed (no certificate). The
+  MSI bundler is skipped while versions carry a pre-release suffix such as
+  `1.0.0-alpha.1`; WiX only accepts numeric pre-release identifiers.
+- **Linux:** `.deb`, `.rpm` and `.AppImage`, unsigned.
+- **Update artifacts:** `createUpdaterArtifacts: true` in `tauri.conf.json`
+  emits the platform-specific updater bundle plus a `.sig` made with the Swifty
+  minisign key. `tauri-action` merges them into one `latest.json`, which the app
+  fetches from `releases/latest/download/latest.json`.
+- **Provenance + SBOM:** every installer gets a SLSA build-provenance
+  attestation, and the Linux job attaches CycloneDX SBOMs to the release.
+
+## One-time setup
+
+### 1. Updater signing keypair
+
+A minisign keypair signs every update artifact; the app verifies it with the
+public key embedded in `src-tauri/tauri.conf.json` (`plugins.updater.pubkey`).
+The public key is committed. The private key lives outside the repo, for
+example at `~/.tauri/swifty.key`. To regenerate:
+
+```sh
+bun run tauri signer generate -w ~/.tauri/swifty.key
+```
+
+Then put the new `~/.tauri/swifty.key.pub` contents into
+`plugins.updater.pubkey`. **If you lose the private key, existing installs can
+no longer auto-update** and need a fresh manual install.
+
+### 2. GitHub repository secrets
+
+Set these under **Settings → Secrets and variables → Actions**. The Apple and
+Google names predate the Tauri port and are kept as-is; `release.yml` maps them
+onto the env names the Tauri bundler expects.
+
+| Secret | How to produce it |
+| --- | --- |
+| `CERTIFICATES_P12` | Export the **"Developer ID Application: Oleksandr Chaplinsky (UFBL3F444A)"** certificate *with its private key* from Keychain Access as a `.p12`, then `base64 -i cert.p12 \| pbcopy`. It must be this certificate: the bundler compares the `.p12` against the hard-coded `APPLE_SIGNING_IDENTITY` and aborts on a mismatch. An "Apple Development" or "Apple Distribution" cert cannot be notarized for direct download. |
+| `CERTIFICATES_P12_PASSWORD` | The password you set when exporting the `.p12`. |
+| `APPLE_ID` | Apple ID email of the developer account. |
+| `APPLE_ID_PASSWORD` | An **app-specific password** (appleid.apple.com → Sign-In and Security → App-Specific Passwords). Not your account password. |
+| `APPLE_TEAM_ID` | `UFBL3F444A`. |
+| `TAURI_SIGNING_PRIVATE_KEY` | Contents of `~/.tauri/swifty.key`. |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for that key (empty if generated without one). |
+| `GOOGLE_OAUTH_CLIENT_ID` | Desktop-app OAuth client id from Google Cloud Console, baked in at compile time for Google Drive sync (`src-tauri/src/sync/auth.rs`). Unset → Drive sync reports "not configured". |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | The matching client secret. |
+
+`APPLE_SIGNING_IDENTITY` is not a secret (it is the certificate's display
+name) and is written directly in `release.yml`. If the certificate is ever
+reissued under a different name, update it there and in `.env.example`.
+
+### 3. Update endpoint
+
+The repo is public, so the updater reads straight from GitHub Releases:
+
+```json
+"endpoints": ["https://github.com/swiftyapp/swifty/releases/latest/download/latest.json"]
+```
+
+`/releases/latest` only ever points at a **published, non-draft, non-prerelease**
+release, so the updater sees a version only once you publish it. Integrity is
+enforced by the minisign signature the app verifies against the embedded
+pubkey.
+
+## Per-release procedure
+
+1. **Bump the version** in all three files (keep them identical):
+   - `src-tauri/tauri.conf.json` → `version` (this is what the release tag and
+     name are derived from, via `v__VERSION__`)
+   - `package.json` → `version`
+   - `src-tauri/Cargo.toml` → `version` (then `cargo update -p swifty
+     --manifest-path src-tauri/Cargo.toml` so `Cargo.lock` follows)
+2. Merge that to `main`. CI's supply-chain job must be green: it fails when a
+   `@tauri-apps/*` npm package and its Rust crate are on different major.minor
+   releases, which is exactly the check `tauri build` would otherwise fail on
+   release day (`scripts/check-tauri-versions.mjs`).
+3. Trigger the build, either way:
+   - push a tag: `git tag v<version> && git push origin v<version>`
+     (this also triggers the iOS release), or
+   - GitHub → Actions → *Release* → *Run workflow* (only offered for the
+     default branch).
+4. Wait for all three platform jobs. They create one **draft** release
+   `Swifty v<version>` with the installers, the updater artifacts, their
+   `.sig` files, `latest.json` and the SBOMs. The Linux job replaces the
+   placeholder body with GitHub's auto-generated release notes.
+5. Review the draft and **Publish** it. Once published, installed apps pick it
+   up on next launch.
+
+## Local signed build (macOS)
+
+To produce a signed + notarized universal build on your Mac without CI:
+
+```sh
+cp .env.example .env   # then fill in the values
+./scripts/release-local.sh
+```
+
+Artifacts land in `src-tauri/target/universal-apple-darwin/release/bundle/`.
+The Developer ID certificate must be in your login keychain; the script signs
+with `APPLE_SIGNING_IDENTITY` from `.env` and does not need the `.p12`.
+
+For an unsigned smoke build of just the app bundle (no DMG, no notarization),
+any minisign key satisfies the updater-artifact step:
+
+```sh
+bun run tauri signer generate -w /tmp/test.key --ci
+TAURI_SIGNING_PRIVATE_KEY="$(cat /tmp/test.key)" bun run tauri build --bundles app
+```
+
+## How the in-app updater behaves
+
+`src/services/autoUpdate.ts` runs once at launch. It is a no-op in dev builds,
+calls `check()`, and on an available update downloads, installs and relaunches.
+Failures (offline, endpoint down) are logged and swallowed so they never block
+startup. Required capabilities live in `src-tauri/capabilities/desktop.json`
+(`updater:default`, `process:default`).
+
+## Known limitations
+
+- Windows installers are unsigned; SmartScreen will warn on first launch.
+- `src-tauri/Entitlements.plist` requests `keychain-access-groups` with an
+  `$(AppIdentifierPrefix)` placeholder. Tauri passes the file to `codesign`
+  verbatim and does not expand Xcode-style variables, so the signed app may
+  carry the literal string. The secure-store code falls back to the
+  verify-then-read gate when the entitlement is not honoured; verify Touch ID
+  enrolment on the first notarized build.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
-    "@tauri-apps/plugin-updater": "^2.10.1",
+    "@tauri-apps/plugin-updater": "^2.11.0",
     "@zxcvbn-ts/core": "^4.2.0",
     "@zxcvbn-ts/language-common": "^4.1.3",
     "@zxcvbn-ts/language-en": "^4.1.1",

--- a/scripts/check-tauri-versions.mjs
+++ b/scripts/check-tauri-versions.mjs
@@ -1,0 +1,64 @@
+// Fails when a Tauri npm package and its Rust crate are on different
+// major.minor releases — the same check `tauri build` runs before compiling
+// ("Found version mismatched Tauri packages"). Dependabot bumps the npm and
+// cargo sides in separate PRs, so the two lockfiles drift; this catches it in
+// CI instead of in the release build.
+//
+// Pairs, as the Tauri CLI defines them:
+//   @tauri-apps/api       <-> tauri
+//   @tauri-apps/plugin-X  <-> tauri-plugin-X
+// Only pairs present on both sides are compared (Rust-only plugins are skipped).
+//
+// Usage: bun scripts/check-tauri-versions.mjs
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const bunLock = readFileSync(join(root, 'bun.lock'), 'utf8')
+const cargoLock = readFileSync(join(root, 'src-tauri', 'Cargo.lock'), 'utf8')
+
+// bun.lock resolutions look like "@tauri-apps/plugin-updater@2.10.1".
+const npm = new Map()
+for (const [, name, version] of bunLock.matchAll(
+  /"@tauri-apps\/(api|plugin-[a-z-]+)@(\d+\.\d+\.\d+)[^"]*"/g,
+)) {
+  npm.set(name, version)
+}
+
+// Cargo.lock packages are `name = "tauri-plugin-updater"` / `version = "2.11.0"`.
+const crates = new Map()
+for (const [, name, version] of cargoLock.matchAll(
+  /name = "(tauri|tauri-plugin-[a-z-]+)"\nversion = "([^"]+)"/g,
+)) {
+  if (!crates.has(name)) crates.set(name, [])
+  crates.get(name).push(version)
+}
+
+const majorMinor = (v) => v.split('.').slice(0, 2).join('.')
+
+const mismatched = []
+for (const [npmName, npmVersion] of npm) {
+  const crateName = npmName === 'api' ? 'tauri' : `tauri-${npmName}`
+  const crateVersions = crates.get(crateName)
+  if (!crateVersions) continue
+  if (!crateVersions.some((v) => majorMinor(v) === majorMinor(npmVersion))) {
+    mismatched.push(
+      `${crateName} (v${crateVersions.join(', v')}) : @tauri-apps/${npmName} (v${npmVersion})`,
+    )
+  }
+}
+
+if (mismatched.length > 0) {
+  console.error(
+    'Found version mismatched Tauri packages. The npm package and Rust crate must be on the same major/minor release:',
+  )
+  for (const line of mismatched) console.error(`  ${line}`)
+  console.error(
+    '\nBump the lagging side (package.json + `bun install`, or src-tauri/Cargo.toml + `cargo update -p <crate>`) so both agree.',
+  )
+  process.exit(1)
+}
+
+console.log(`Tauri npm/crate versions agree (${npm.size} packages checked).`)

--- a/scripts/check-tauri-versions.mjs
+++ b/scripts/check-tauri-versions.mjs
@@ -36,19 +36,35 @@ for (const [, name, version] of cargoLock.matchAll(
   crates.get(name).push(version)
 }
 
+// Fail closed: every Tauri app has `@tauri-apps/api` and the `tauri` crate, so
+// if either is missing the lockfile format has changed and the regexes above
+// no longer see anything. Do not let that pass as "0 packages agree".
+const fail = (msg) => {
+  console.error(msg)
+  process.exit(1)
+}
+if (!npm.has('api')) fail('check-tauri-versions: no @tauri-apps/api entry found in bun.lock (format changed?)')
+if (!crates.has('tauri')) fail('check-tauri-versions: no `tauri` package found in src-tauri/Cargo.lock (format changed?)')
+
 const majorMinor = (v) => v.split('.').slice(0, 2).join('.')
 
 const mismatched = []
+let compared = 0
 for (const [npmName, npmVersion] of npm) {
   const crateName = npmName === 'api' ? 'tauri' : `tauri-${npmName}`
   const crateVersions = crates.get(crateName)
+  // The CLI only compares pairs installed on both sides; an npm plugin with
+  // no crate is a project-shape question, not a version mismatch.
   if (!crateVersions) continue
+  compared++
   if (!crateVersions.some((v) => majorMinor(v) === majorMinor(npmVersion))) {
     mismatched.push(
       `${crateName} (v${crateVersions.join(', v')}) : @tauri-apps/${npmName} (v${npmVersion})`,
     )
   }
 }
+
+if (compared === 0) fail('check-tauri-versions: no npm/crate pairs were compared')
 
 if (mismatched.length > 0) {
   console.error(
@@ -61,4 +77,4 @@ if (mismatched.length > 0) {
   process.exit(1)
 }
 
-console.log(`Tauri npm/crate versions agree (${npm.size} packages checked).`)
+console.log(`Tauri npm/crate versions agree (${compared} npm/crate pairs checked).`)

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Build a signed + notarized universal macOS release locally.
+#
+# Reads signing/notarization config from .env (copy .env.example → .env first).
+# Produces a signed .dmg and the updater artifacts (.app.tar.gz + .sig) under
+# src-tauri/target/universal-apple-darwin/release/bundle/.
+#
+# This mirrors the macOS leg of the Release GitHub Actions workflow
+# (.github/workflows/release.yml) for local builds. See docs/releasing.md.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -f .env ]]; then
+  echo "error: .env not found. Copy .env.example to .env and fill it in." >&2
+  exit 1
+fi
+
+# Load .env (allows command substitution like TAURI_SIGNING_PRIVATE_KEY="$(cat ...)").
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+# Same npm/crate agreement check the release build enforces, but fails fast.
+bun scripts/check-tauri-versions.mjs
+
+# Ensure both arch targets exist for the universal lipo.
+rustup target add aarch64-apple-darwin x86_64-apple-darwin >/dev/null 2>&1 || true
+
+echo "Building signed + notarized universal macOS app…"
+bun run tauri build --target universal-apple-darwin
+
+echo
+echo "Done. Artifacts:"
+echo "  src-tauri/target/universal-apple-darwin/release/bundle/"


### PR DESCRIPTION
## Why

The desktop **Release** workflow has failed on both of its runs. The logs show three distinct causes, two of which live in the repo:

1. **All platforms, latest run** — the Tauri CLI aborts before compiling: `tauri-plugin-updater` (crate) was on 2.11 while `@tauri-apps/plugin-updater` (npm) was on 2.10. Dependabot bumps npm and cargo in separate PRs, so the lockfiles drift.
2. **Windows, earlier run** — the MSI/WiX bundler rejects `1.0.0-alpha.1` (“pre-release identifier must be numeric-only”).
3. **macOS, earlier run** — the `CERTIFICATES_P12` secret holds an *Apple Development* cert, but the bundler expects the *Developer ID Application* identity and aborts on the mismatch. This is a secret-side fix (see below), documented here.

## What

- Bump `@tauri-apps/plugin-updater` to `^2.11.0` (lockfile refreshed; typecheck + auto-update tests pass).
- New `scripts/check-tauri-versions.mjs` mirrors the CLI's major.minor check; CI's **supply-chain** job runs it so drift fails on the Dependabot PR instead of on release day. `dependabot.yml` notes the cross-ecosystem coupling.
- `release.yml`: Windows builds **NSIS only** while versions carry a pre-release suffix; header documents the certificate requirement; the Linux job replaces the placeholder body with GitHub's auto-generated release notes (as in quorum).
- Mirror quorum's local tooling: `scripts/release-local.sh`, `.env.example`, `docs/releasing.md` (the workflow header pointed at a doc that did not exist).

## Verification

- Local `bun run tauri build --bundles app` on macOS passes the version check, compiles, and produces `Swifty.app`, the updater tarball and its `.sig`. Signing/notarization not exercised locally.
- `actionlint` and YAML parsing pass for both workflows.

## Follow-up outside this PR (repo secrets)

- Re-export **“Developer ID Application: Oleksandr Chaplinsky (UFBL3F444A)”** with its private key as a `.p12`, `base64` it into `CERTIFICATES_P12`, and put the export password in `CERTIFICATES_P12_PASSWORD`.
- Confirm `APPLE_ID_PASSWORD` is an app-specific password.

Known risk noted in `docs/releasing.md`: `Entitlements.plist` uses an Xcode-style `$(AppIdentifierPrefix)` placeholder that codesign will not expand; the secure-store code falls back gracefully, but Touch ID enrolment should be checked on the first notarized build.