### PR TITLE
feat(env): ingest a .env file — editor drop zone, idle-window drop, Add-picker link

### DIFF
--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -1,0 +1,95 @@
+//! Reading a `.env` file off disk for the env kind. A dropped or picked path
+//! comes in; its text goes back out to become the draft's body. The file is
+//! never parsed here — the frontend owns the format — and never logged: the
+//! contents are the secret.
+
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+use tauri::AppHandle;
+use tauri_plugin_dialog::DialogExt;
+
+use crate::error::{Error, Result};
+
+// A real .env is a few kilobytes. Anything past this is not one, and reading
+// it whole into the webview would only ever be a mistake.
+const MAX_BYTES: u64 = 1024 * 1024;
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvFile {
+    pub file_name: String,
+    pub body: String,
+}
+
+// The command's body, split out so the two refusals can be tested without a
+// Tauri runtime around them.
+pub fn read_env_text(path: &Path) -> Result<EnvFile> {
+    let meta = fs::metadata(path)?;
+    if meta.len() > MAX_BYTES {
+        return Err(Error::Other("file is larger than 1 MiB".into()));
+    }
+    let body = String::from_utf8(fs::read(path)?)
+        .map_err(|_| Error::Other("file is not UTF-8 text".into()))?;
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    Ok(EnvFile { file_name, body })
+}
+
+#[tauri::command]
+pub fn read_env_file(path: String) -> Result<EnvFile> {
+    read_env_text(Path::new(&path))
+}
+
+// Same shape as `pick_import_file`: async + spawn_blocking keeps the blocking
+// picker off the main thread. No extension filter — a `.env` has no extension
+// for one to match, and `.env.production` is not `.production`.
+#[tauri::command]
+pub async fn pick_env_file(app: AppHandle) -> Result<Option<String>> {
+    let file =
+        tauri::async_runtime::spawn_blocking(move || app.dialog().file().blocking_pick_file())
+            .await
+            .map_err(|e| Error::Other(e.to_string()))?;
+    Ok(file
+        .and_then(|f| f.into_path().ok())
+        .map(|p| p.to_string_lossy().into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("swifty-env-{}-{name}", std::process::id()));
+        fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn reads_a_small_utf8_file_with_its_name() {
+        let path = scratch(".env.production", b"A=1\nB=two\n");
+        let file = read_env_text(&path).unwrap();
+        assert_eq!(file.body, "A=1\nB=two\n");
+        assert!(file.file_name.ends_with(".env.production"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn refuses_a_file_over_the_cap() {
+        let path = scratch("big.env", &vec![b'x'; (MAX_BYTES + 1) as usize]);
+        let err = read_env_text(&path).unwrap_err().to_string();
+        assert!(err.contains("1 MiB"), "{err}");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn refuses_bytes_that_are_not_utf8() {
+        let path = scratch("binary.env", &[0xff, 0xfe, b'A', b'=', b'1']);
+        let err = read_env_text(&path).unwrap_err().to_string();
+        assert!(err.contains("UTF-8"), "{err}");
+        let _ = fs::remove_file(path);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod clipboard;
 // the full gating rationale); the registration in lib.rs carries the same cfg.
 #[cfg(debug_assertions)]
 pub mod e2e;
+pub mod env;
 pub mod generator;
 pub mod import;
 pub mod save;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,8 @@ pub fn run() {
             commands::import::pick_import_file,
             commands::import::import_entries,
             commands::import::export_entries,
+            commands::env::read_env_file,
+            commands::env::pick_env_file,
             commands::generator::generate_password,
             commands::generator::generate_ssh_key,
             commands::generator::generate_otp,

--- a/src/components/Main/AddSecret/EnvAction.tsx
+++ b/src/components/Main/AddSecret/EnvAction.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next'
+import { useStore } from '@/store'
+import { isMobile } from '@/lib/platform'
+import { pickEnvFile } from '@/lib/commands'
+import { ingestEnvFile } from '@/kinds/env/ingest'
+import { openEnvDraft } from '../EnvDrop/open'
+import { EnvGlyph } from '../icons'
+
+/**
+ * The env file's way in that skips the tile: on the desktop a line of copy,
+ * because the whole window is already the target while the picker is up (see
+ * `Main/EnvDrop`); on a phone, where nothing is dropped, the file picker.
+ *
+ * Sits under the tiles with `ScanAction`, outside the grid the digits and
+ * arrows are bound to. The divider is shared: when the scan action draws its
+ * own this only needs a gap, and where the OS cannot scan this draws it.
+ */
+export default function EnvAction() {
+  const { t } = useTranslation()
+  const scan = useStore(state => state.ui.scan.supported)
+
+  // A cancelled dialog leaves the picker as it was; a chosen file hands the
+  // window over to the editor, which `openEnvDraft` closes the picker for.
+  const pick = () =>
+    pickEnvFile()
+      .then(async path => {
+        if (path) openEnvDraft(await ingestEnvFile(path))
+      })
+      .catch(() => {})
+
+  const row = 'flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-base text-text2'
+
+  return (
+    <div className={scan ? 'mt-1' : 'mt-5 border-t border-line pt-4'}>
+      {isMobile ? (
+        <button
+          type="button"
+          data-testid="add-env-file"
+          onClick={() => void pick()}
+          className={`${row} cursor-pointer transition-colors hover:bg-hover hover:text-text`}
+        >
+          <EnvGlyph size={16} className="flex-none text-text3" />
+          <span>{t('Choose a .env file')}</span>
+        </button>
+      ) : (
+        <div data-testid="add-env-file" className={row}>
+          <EnvGlyph size={16} className="flex-none text-text3" />
+          <span>{t('Drop a .env file')}</span>
+        </div>
+      )}
+      <p className="mt-1 pl-[30px] text-base text-text3">
+        {isMobile
+          ? t('Kept whole, read as a table of variables.')
+          : t('Anywhere on this window. Kept whole, read as a table of variables.')}
+      </p>
+    </div>
+  )
+}

--- a/src/components/Main/AddSecret/EnvAction.tsx
+++ b/src/components/Main/AddSecret/EnvAction.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useStore } from '@/store'
 import { isMobile } from '@/lib/platform'
-import { pickEnvFile } from '@/lib/commands'
-import { ingestEnvFile } from '@/kinds/env/ingest'
+import { useEnvIngest } from '@/kinds/env/useIngest'
 import { openEnvDraft } from '../EnvDrop/open'
 import { EnvGlyph } from '../icons'
 
@@ -18,15 +17,10 @@ import { EnvGlyph } from '../icons'
 export default function EnvAction() {
   const { t } = useTranslation()
   const scan = useStore(state => state.ui.scan.supported)
+  const { pick, error } = useEnvIngest(openEnvDraft)
 
   // A cancelled dialog leaves the picker as it was; a chosen file hands the
   // window over to the editor, which `openEnvDraft` closes the picker for.
-  const pick = () =>
-    pickEnvFile()
-      .then(async path => {
-        if (path) openEnvDraft(await ingestEnvFile(path))
-      })
-      .catch(() => {})
 
   const row = 'flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-base text-text2'
 
@@ -53,6 +47,11 @@ export default function EnvAction() {
           ? t('Kept whole, read as a table of variables.')
           : t('Anywhere on this window. Kept whole, read as a table of variables.')}
       </p>
+      {error && (
+        <p data-testid="add-env-error" className="mt-1 pl-[30px] text-base text-bad">
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/Main/AddSecret/index.tsx
+++ b/src/components/Main/AddSecret/index.tsx
@@ -6,6 +6,7 @@ import { KINDS } from '@/kinds'
 import Frame from '@/components/elements/Frame'
 import KindTile from './KindTile'
 import ScanAction from './ScanAction'
+import EnvAction from './EnvAction'
 
 const TITLE_ID = 'add-secret-title'
 
@@ -94,6 +95,7 @@ export default function AddSecret() {
           </div>
 
           <ScanAction />
+          <EnvAction />
         </div>
       </div>
     </Frame>

--- a/src/components/Main/EnvDrop/index.tsx
+++ b/src/components/Main/EnvDrop/index.tsx
@@ -1,0 +1,10 @@
+import { useFileDrop } from '@/hooks/useFileDrop'
+import { dropIdle } from './open'
+
+// Mounted once by `Main`, like `Scan`: the drop target is the unlocked app as
+// a whole. Desktop only by way of the hook — nothing is dropped on a phone.
+// What a drop does, and when it declines, is `open.ts`.
+export default function EnvDrop() {
+  useFileDrop(paths => void dropIdle(paths))
+  return null
+}

--- a/src/components/Main/EnvDrop/open.ts
+++ b/src/components/Main/EnvDrop/open.ts
@@ -1,0 +1,36 @@
+import { useStore, startEntry, closeAddPicker } from '@/store'
+import { dialogOpen } from '@/utils/dialogOpen'
+import { fileNameOf, ingestEnvFile, isEnvDrop, type IngestedEnv } from '@/kinds/env/ingest'
+import { isImagePath } from '../Scan/fields'
+
+/**
+ * Open the env editor as a new draft with the file already in it — the same
+ * `entries.prefill` road a scan takes, so `useDraft` seeds the body, the file
+ * name and the proposed title as the initial model rather than as typing.
+ */
+export const openEnvDraft = ({ body, fileName, title }: IngestedEnv) => {
+  closeAddPicker()
+  startEntry('env', { body, fileName, title })
+}
+
+/**
+ * A `.env` dropped onto the idle window opens a filled-in editor: one drop,
+ * one save. Idle means no editor is up — one that is has its own zone, and a
+ * drop there is that draft's business, never a second one. The Add picker is
+ * the exception among the dialogs: it is the moment the user is choosing what
+ * to add, so a drop answers it and closes it. Every other dialog (Settings ›
+ * Import has a zone of its own) keeps the drop.
+ *
+ * Images are the scanner's, so they are not even read. Anything else is read
+ * and kept only if it is named or reads like an env file — a file that is
+ * neither does nothing, as today.
+ */
+export const dropIdle = async (paths: string[]): Promise<void> => {
+  const { entries, ui } = useStore.getState()
+  if (entries.new || entries.edit) return
+  if (dialogOpen() && !ui.addPicker) return
+  const [path] = paths
+  if (!path || isImagePath(path)) return
+  const file = await ingestEnvFile(path).catch(() => null)
+  if (file && isEnvDrop(fileNameOf(path), file.body)) openEnvDraft(file)
+}

--- a/src/components/Main/EnvDrop/open.ts
+++ b/src/components/Main/EnvDrop/open.ts
@@ -1,7 +1,6 @@
 import { useStore, startEntry, closeAddPicker } from '@/store'
 import { dialogOpen } from '@/utils/dialogOpen'
-import { fileNameOf, ingestEnvFile, isEnvDrop, type IngestedEnv } from '@/kinds/env/ingest'
-import { isImagePath } from '../Scan/fields'
+import { ingestDroppedEnvFile, type IngestedEnv } from '@/kinds/env/ingest'
 
 /**
  * Open the env editor as a new draft with the file already in it — the same
@@ -11,6 +10,14 @@ import { isImagePath } from '../Scan/fields'
 export const openEnvDraft = ({ body, fileName, title }: IngestedEnv) => {
   closeAddPicker()
   startEntry('env', { body, fileName, title })
+}
+
+/** The exact idle surface that owned a drop, used as a lease across the read. */
+const idleDropContext = (): boolean | null => {
+  const { entries, ui } = useStore.getState()
+  if (entries.new || entries.edit) return null
+  if (dialogOpen() && !ui.addPicker) return null
+  return ui.addPicker
 }
 
 /**
@@ -26,11 +33,12 @@ export const openEnvDraft = ({ body, fileName, title }: IngestedEnv) => {
  * neither does nothing, as today.
  */
 export const dropIdle = async (paths: string[]): Promise<void> => {
-  const { entries, ui } = useStore.getState()
-  if (entries.new || entries.edit) return
-  if (dialogOpen() && !ui.addPicker) return
+  const context = idleDropContext()
+  if (context === null) return
   const [path] = paths
-  if (!path || isImagePath(path)) return
-  const file = await ingestEnvFile(path).catch(() => null)
-  if (file && isEnvDrop(fileNameOf(path), file.body)) openEnvDraft(file)
+  if (!path) return
+  const file = await ingestDroppedEnvFile(path).catch(() => null)
+  // Reading crosses an async boundary: only the same still-idle surface may
+  // consume its result. Opening/closing the picker also changes ownership.
+  if (file && idleDropContext() === context) openEnvDraft(file)
 }

--- a/src/components/Main/Scan/fields.ts
+++ b/src/components/Main/Scan/fields.ts
@@ -1,4 +1,7 @@
 import type { EntryDraft } from '@/defaults/entries'
+import { isImagePath } from '@/lib/fileTypes'
+
+export { IMAGE_EXTENSIONS, isImagePath } from '@/lib/fileTypes'
 
 /**
  * Turning what a scan read into what a draft holds.
@@ -9,27 +12,6 @@ import type { EntryDraft } from '@/defaults/entries'
  * they are printed. So there is no reformatting here: only which values are
  * worth carrying, and which of the draft's own values may be overwritten.
  */
-
-// What the OS recognizers can open, and what the file dialog filters to.
-// Anything else dropped on the window is somebody else's business — the Import
-// drop zone still wants its .csv.
-export const IMAGE_EXTENSIONS = [
-  'png',
-  'jpg',
-  'jpeg',
-  'heic',
-  'heif',
-  'webp',
-  'tiff',
-  'tif',
-  'bmp',
-  'gif'
-]
-
-export const isImagePath = (path: string): boolean => {
-  const extension = /\.([^.\\/]+)$/.exec(path)?.[1]
-  return !!extension && IMAGE_EXTENSIONS.includes(extension.toLowerCase())
-}
 
 /** The first image among dropped paths — a drop can carry more than one file. */
 export const firstImage = (paths: string[]): string | undefined =>

--- a/src/components/Main/Sidebar/Settings/Sections/Import/DropZone.tsx
+++ b/src/components/Main/Sidebar/Settings/Sections/Import/DropZone.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { isMobile } from '@/lib/platform'
 import { pickImportFile } from '@/lib/commands'
+import { useFileDrop } from '@/hooks/useFileDrop'
 import { DownloadGlyph } from '../../../../icons'
 import { META_TYPE } from '@/components/elements/tokens'
 
@@ -15,33 +15,9 @@ interface Props {
 // picker is `pick_import_file`, the very one the tiles above already use.
 export default function DropZone({ onDrop }: Props) {
   const { t } = useTranslation()
-  useEffect(() => {
-    if (isMobile) return
-    let alive = true
-    let unlisten: (() => void) | undefined
-
-    // Files dropped onto the window arrive as OS paths through the webview,
-    // not as a browser DataTransfer. The API is imported lazily so a non-Tauri
-    // host (the vitest jsdom run) simply never wires the listener up.
-    import('@tauri-apps/api/webview')
-      .then(({ getCurrentWebview }) =>
-        getCurrentWebview().onDragDropEvent(event => {
-          if (event.payload.type !== 'drop') return
-          const [path] = event.payload.paths
-          if (path) onDrop(path)
-        })
-      )
-      .then(stop => {
-        if (alive) unlisten = stop
-        else stop()
-      })
-      .catch(() => {})
-
-    return () => {
-      alive = false
-      unlisten?.()
-    }
-  }, [onDrop])
+  useFileDrop(([path]) => {
+    if (path) onDrop(path)
+  })
 
   const pick = () =>
     pickImportFile()

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -8,6 +8,7 @@ import Compact from './Compact'
 import Palette from './Palette'
 import AddSecret from './AddSecret'
 import Scan from './Scan'
+import EnvDrop from './EnvDrop'
 import { useShortcuts } from './useShortcuts'
 
 // Two shells, one set of overlays. `Wide` is the three-pane desktop/iPad layout
@@ -34,6 +35,7 @@ export function Main() {
         {!compact && <Palette />}
         <AddSecret />
         <Scan />
+        <EnvDrop />
       </FrameProvider>
       {/* `copied-notification` + `hidden` are toggled by services/copy.ts; the
           display flip is what replays `animate-pop`. App-level so copies from

--- a/src/hooks/useFileDrop.ts
+++ b/src/hooks/useFileDrop.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react'
+import { isMobile } from '@/lib/platform'
+
+/**
+ * Files dropped onto the window, as OS paths.
+ *
+ * They arrive through the webview's drag-drop event rather than as a browser
+ * DataTransfer, so every drop target in the app wires this same listener and
+ * minds its own file types (Import wants an export, the env editor a `.env`).
+ * The API is imported lazily so a non-Tauri host (the vitest jsdom run) simply
+ * never wires the listener up. Nothing drags a file onto a phone, so there this
+ * is a no-op and the target renders a picker button instead.
+ *
+ * `onPaths` is read through a ref: the listener is bound once for as long as
+ * `enabled` holds, and a caller may hand in a fresh closure every render.
+ */
+export function useFileDrop(onPaths: (paths: string[]) => void, enabled = true) {
+  const handler = useRef(onPaths)
+  useEffect(() => {
+    handler.current = onPaths
+  })
+
+  useEffect(() => {
+    if (!enabled || isMobile) return
+    let alive = true
+    let unlisten: (() => void) | undefined
+
+    import('@tauri-apps/api/webview')
+      .then(({ getCurrentWebview }) =>
+        getCurrentWebview().onDragDropEvent(event => {
+          if (event.payload.type !== 'drop') return
+          handler.current(event.payload.paths)
+        })
+      )
+      .then(stop => {
+        if (alive) unlisten = stop
+        else stop()
+      })
+      .catch(() => {})
+
+    return () => {
+      alive = false
+      unlisten?.()
+    }
+  }, [enabled])
+}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -404,5 +404,13 @@
   "A photo or screenshot, read on this device.": "A photo or screenshot, read on this device.",
   "Scan a photo…": "Scan a photo…",
   "A card or document from your photo library, read on this device.": "A card or document from your photo library, read on this device.",
-  "Images": "Images"
+  "Images": "Images",
+  "Drop a .env file here, or paste KEY=VALUE lines into any row": "Drop a .env file here, or paste KEY=VALUE lines into any row",
+  "Choose a .env file": "Choose a .env file",
+  "Drop a .env file": "Drop a .env file",
+  "Replace everything with {{name}}, or add only the keys not already here?": "Replace everything with {{name}}, or add only the keys not already here?",
+  "Replace": "Replace",
+  "Merge new keys": "Merge new keys",
+  "Kept whole, read as a table of variables.": "Kept whole, read as a table of variables.",
+  "Anywhere on this window. Kept whole, read as a table of variables.": "Anywhere on this window. Kept whole, read as a table of variables."
 }

--- a/src/kinds/env/Fields/DropTarget.tsx
+++ b/src/kinds/env/Fields/DropTarget.tsx
@@ -1,19 +1,72 @@
-import { useState, type KeyboardEvent } from 'react'
+import { useRef, useState, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cx } from '@/utils/cx'
 import { isMobile } from '@/lib/platform'
-import { pickEnvFile } from '@/lib/commands'
 import { useFileDrop } from '@/hooks/useFileDrop'
+import { useDialogFocus } from '@/hooks/useDialogFocus'
 import { dialogOpen } from '@/utils/dialogOpen'
 import Button from '@/components/elements/Button'
 import IconButton from '@/components/elements/IconButton'
 import { useFields } from '@/components/elements/fields'
 import { CloseGlyph, DownloadGlyph } from '@/components/Main/icons'
-import { ingestEnvFile, mergeNewKeys, type IngestedEnv } from '../ingest'
+import { mergeNewKeys, type IngestedEnv } from '../ingest'
+import { useEnvIngest } from '../useIngest'
 
 // The import zone's dress, so the two read as the same affordance.
 const ZONE =
   'mt-3 flex items-center gap-3.5 rounded-lg border border-dashed border-line2 px-4 py-5 text-text3'
+
+function PendingPrompt({
+  file,
+  apply,
+  close
+}: {
+  file: IngestedEnv
+  apply: (mode: 'replace' | 'merge') => void
+  close: () => void
+}) {
+  const { t } = useTranslation()
+  const prompt = useRef<HTMLDivElement>(null)
+  useDialogFocus(prompt, close)
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Escape') return
+    // The shared dialog hook closes at window level; keep the editor's document
+    // listener (and any other surface behind this prompt) from seeing the key.
+    event.stopPropagation()
+    event.preventDefault()
+    close()
+  }
+
+  return (
+    <div
+      ref={prompt}
+      role="dialog"
+      aria-labelledby="env-drop-question"
+      tabIndex={-1}
+      data-testid="env-drop-prompt"
+      onKeyDown={onKeyDown}
+      className={cx(ZONE, 'flex-wrap justify-between border-accent-line')}
+    >
+      <span id="env-drop-question" className="min-w-0 flex-1 text-base text-text2">
+        {t('Replace everything with {{name}}, or add only the keys not already here?', {
+          name: file.fileName
+        })}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button size="md" testid="env-drop-replace" onClick={() => apply('replace')}>
+          {t('Replace')}
+        </Button>
+        <Button size="md" variant="pale" testid="env-drop-merge" onClick={() => apply('merge')}>
+          {t('Merge new keys')}
+        </Button>
+        <IconButton title={t('Cancel')} testid="env-drop-cancel" onClick={close}>
+          <CloseGlyph />
+        </IconButton>
+      </div>
+    </div>
+  )
+}
 
 /**
  * The dashed target at the foot of the editor. A file dropped here becomes the
@@ -28,7 +81,6 @@ export default function DropTarget() {
   const { t } = useTranslation()
   const { entry, set } = useFields()
   const [pending, setPending] = useState<IngestedEnv | null>(null)
-  const [error, setError] = useState<string | null>(null)
   const body = typeof entry.body === 'string' ? entry.body : ''
   const title = typeof entry.title === 'string' ? entry.title : ''
 
@@ -39,68 +91,28 @@ export default function DropTarget() {
     setPending(null)
   }
 
-  const take = (path: string) =>
-    ingestEnvFile(path)
-      .then(file => {
-        setError(null)
-        // Nothing typed yet, so there is nothing to ask about.
-        if (!body.trim()) apply(file, 'replace')
-        else setPending(file)
-      })
-      .catch(e => setError(String(e)))
+  // `useEnvIngest` publishes to this callback's latest render. If typing happens
+  // while the file is read, this body — not the blank body at drop time — wins.
+  const ingest = useEnvIngest(file => {
+    if (!body.trim()) apply(file, 'replace')
+    else setPending(file)
+  })
 
   // Settings › Import is a dialog with a drop zone of its own; while it is up
   // a drop means an export, not an env file for the draft behind it.
   useFileDrop(([path]) => {
-    if (path && !dialogOpen()) void take(path)
+    if (path && !dialogOpen()) void ingest.drop(path)
   }, !!set)
-
-  const pick = () =>
-    pickEnvFile()
-      .then(path => {
-        if (path) return take(path)
-      })
-      .catch(() => {})
-
-  // Escape here answers the question, not the editor: `useDraft` hears Escape
-  // on the document as Cancel, so it must not travel past the zone.
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Escape') return
-    event.stopPropagation()
-    setPending(null)
-  }
 
   if (!set) return null
 
   if (pending) {
     return (
-      <div
-        data-testid="env-drop-prompt"
-        onKeyDown={onKeyDown}
-        className={cx(ZONE, 'flex-wrap justify-between border-accent-line')}
-      >
-        <span className="min-w-0 flex-1 text-base text-text2">
-          {t('Replace everything with {{name}}, or add only the keys not already here?', {
-            name: pending.fileName
-          })}
-        </span>
-        <div className="flex items-center gap-2">
-          <Button size="md" testid="env-drop-replace" onClick={() => apply(pending, 'replace')}>
-            {t('Replace')}
-          </Button>
-          <Button
-            size="md"
-            variant="pale"
-            testid="env-drop-merge"
-            onClick={() => apply(pending, 'merge')}
-          >
-            {t('Merge new keys')}
-          </Button>
-          <IconButton title={t('Cancel')} testid="env-drop-cancel" onClick={() => setPending(null)}>
-            <CloseGlyph />
-          </IconButton>
-        </div>
-      </div>
+      <PendingPrompt
+        file={pending}
+        apply={mode => apply(pending, mode)}
+        close={() => setPending(null)}
+      />
     )
   }
 
@@ -121,7 +133,7 @@ export default function DropTarget() {
         <button
           type="button"
           data-testid="env-dropzone"
-          onClick={() => void pick()}
+          onClick={() => void ingest.pick()}
           className={cx(ZONE, 'w-full cursor-pointer transition-colors hover:border-accent-line')}
         >
           {label}
@@ -131,9 +143,9 @@ export default function DropTarget() {
           {label}
         </div>
       )}
-      {error && (
+      {ingest.error && (
         <div data-testid="env-drop-error" className="mt-1.5 text-base text-bad">
-          {error}
+          {ingest.error}
         </div>
       )}
     </>

--- a/src/kinds/env/Fields/DropTarget.tsx
+++ b/src/kinds/env/Fields/DropTarget.tsx
@@ -1,0 +1,141 @@
+import { useState, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { cx } from '@/utils/cx'
+import { isMobile } from '@/lib/platform'
+import { pickEnvFile } from '@/lib/commands'
+import { useFileDrop } from '@/hooks/useFileDrop'
+import { dialogOpen } from '@/utils/dialogOpen'
+import Button from '@/components/elements/Button'
+import IconButton from '@/components/elements/IconButton'
+import { useFields } from '@/components/elements/fields'
+import { CloseGlyph, DownloadGlyph } from '@/components/Main/icons'
+import { ingestEnvFile, mergeNewKeys, type IngestedEnv } from '../ingest'
+
+// The import zone's dress, so the two read as the same affordance.
+const ZONE =
+  'mt-3 flex items-center gap-3.5 rounded-lg border border-dashed border-line2 px-4 py-5 text-text3'
+
+/**
+ * The dashed target at the foot of the editor. A file dropped here becomes the
+ * draft: onto an empty one it simply lands, name and proposed title included;
+ * onto one with variables already in it the zone turns into the question —
+ * replace the file, or add only the keys it does not have yet. On a phone the
+ * zone is a button that opens the file picker, as the import zone's is.
+ *
+ * Rendered in edit mode only: the `set` it writes through is the mode switch.
+ */
+export default function DropTarget() {
+  const { t } = useTranslation()
+  const { entry, set } = useFields()
+  const [pending, setPending] = useState<IngestedEnv | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const body = typeof entry.body === 'string' ? entry.body : ''
+  const title = typeof entry.title === 'string' ? entry.title : ''
+
+  const apply = (file: IngestedEnv, mode: 'replace' | 'merge') => {
+    set?.('body', mode === 'merge' ? mergeNewKeys(body, file.body) : file.body)
+    set?.('fileName', file.fileName)
+    if (!title.trim()) set?.('title', file.title)
+    setPending(null)
+  }
+
+  const take = (path: string) =>
+    ingestEnvFile(path)
+      .then(file => {
+        setError(null)
+        // Nothing typed yet, so there is nothing to ask about.
+        if (!body.trim()) apply(file, 'replace')
+        else setPending(file)
+      })
+      .catch(e => setError(String(e)))
+
+  // Settings › Import is a dialog with a drop zone of its own; while it is up
+  // a drop means an export, not an env file for the draft behind it.
+  useFileDrop(([path]) => {
+    if (path && !dialogOpen()) void take(path)
+  }, !!set)
+
+  const pick = () =>
+    pickEnvFile()
+      .then(path => {
+        if (path) return take(path)
+      })
+      .catch(() => {})
+
+  // Escape here answers the question, not the editor: `useDraft` hears Escape
+  // on the document as Cancel, so it must not travel past the zone.
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Escape') return
+    event.stopPropagation()
+    setPending(null)
+  }
+
+  if (!set) return null
+
+  if (pending) {
+    return (
+      <div
+        data-testid="env-drop-prompt"
+        onKeyDown={onKeyDown}
+        className={cx(ZONE, 'flex-wrap justify-between border-accent-line')}
+      >
+        <span className="min-w-0 flex-1 text-base text-text2">
+          {t('Replace everything with {{name}}, or add only the keys not already here?', {
+            name: pending.fileName
+          })}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button size="md" testid="env-drop-replace" onClick={() => apply(pending, 'replace')}>
+            {t('Replace')}
+          </Button>
+          <Button
+            size="md"
+            variant="pale"
+            testid="env-drop-merge"
+            onClick={() => apply(pending, 'merge')}
+          >
+            {t('Merge new keys')}
+          </Button>
+          <IconButton title={t('Cancel')} testid="env-drop-cancel" onClick={() => setPending(null)}>
+            <CloseGlyph />
+          </IconButton>
+        </div>
+      </div>
+    )
+  }
+
+  const label = (
+    <>
+      <DownloadGlyph size={16} />
+      <span className="min-w-0 text-left text-base text-text2">
+        {isMobile
+          ? t('Choose a .env file')
+          : t('Drop a .env file here, or paste KEY=VALUE lines into any row')}
+      </span>
+    </>
+  )
+
+  return (
+    <>
+      {isMobile ? (
+        <button
+          type="button"
+          data-testid="env-dropzone"
+          onClick={() => void pick()}
+          className={cx(ZONE, 'w-full cursor-pointer transition-colors hover:border-accent-line')}
+        >
+          {label}
+        </button>
+      ) : (
+        <div data-testid="env-dropzone" className={ZONE}>
+          {label}
+        </div>
+      )}
+      {error && (
+        <div data-testid="env-drop-error" className="mt-1.5 text-base text-bad">
+          {error}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/kinds/env/Fields/index.tsx
+++ b/src/kinds/env/Fields/index.tsx
@@ -7,6 +7,7 @@ import { NoteField, useField } from '@/components/elements/fields'
 import { META } from '@/components/elements/tokens'
 import { EyeGlyph, EyeOffGlyph } from '@/components/Main/icons'
 import { bandsOf, parseEnv, varsOf } from '../parse'
+import DropTarget from './DropTarget'
 import FileTab from './FileTab'
 import Table from './Table'
 
@@ -75,6 +76,9 @@ export default function Fields() {
           with it which rows are revealed — is mounted fresh on every mode
           switch, as every other kind's field set is. */}
       {variables ? <Table vars={vars} bands={bands} revealAll={showAll} /> : <FileTab />}
+
+      {/* Renders nothing outside edit mode; it writes the same `body`. */}
+      <DropTarget />
 
       {/* Reading, an empty note is no panel at all — like the card's aside. */}
       {(editing || note !== '') && (

--- a/src/kinds/env/ingest.test.ts
+++ b/src/kinds/env/ingest.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { fileNameOf, isEnvDrop, isEnvFileName, mergeNewKeys, proposeTitle } from './ingest'
+
+describe('fileNameOf', () => {
+  it('takes the last segment of either separator', () => {
+    expect(fileNameOf('/Users/me/code/api/.env')).toBe('.env')
+    expect(fileNameOf('C:\\code\\api\\.env.local')).toBe('.env.local')
+    expect(fileNameOf('.env')).toBe('.env')
+  })
+})
+
+describe('proposeTitle', () => {
+  it('names the project and the environment', () => {
+    expect(proposeTitle('/Users/me/code/api/.env.production')).toBe('api · production')
+    expect(proposeTitle('C:\\code\\api\\.env.local')).toBe('api · local')
+  })
+
+  it('is just the project for a bare .env', () => {
+    expect(proposeTitle('/Users/me/code/api/.env')).toBe('api')
+  })
+
+  it('reads a suffixed name as the environment', () => {
+    expect(proposeTitle('/Users/me/code/api/foo.env')).toBe('api · foo')
+  })
+
+  it('has only the environment when there is no folder', () => {
+    expect(proposeTitle('.env.staging')).toBe('staging')
+    expect(proposeTitle('.env')).toBe('')
+  })
+})
+
+describe('isEnvFileName / isEnvDrop', () => {
+  it('matches the dotfile family and the .env suffix', () => {
+    expect(isEnvFileName('.env')).toBe(true)
+    expect(isEnvFileName('.env.production')).toBe(true)
+    expect(isEnvFileName('local.env')).toBe(true)
+    expect(isEnvFileName('.envrc')).toBe(false)
+    expect(isEnvFileName('export.csv')).toBe(false)
+  })
+
+  it('falls back to the content when the name says nothing', () => {
+    expect(isEnvDrop('notes.txt', 'A=1\nB=2\n')).toBe(true)
+    expect(isEnvDrop('notes.txt', 'just a note\nanother line\n')).toBe(false)
+    expect(isEnvDrop('export.json', '{"a":1}\n')).toBe(false)
+    // The name carries it even when the body is one line.
+    expect(isEnvDrop('.env', 'A=1')).toBe(true)
+  })
+})
+
+describe('mergeNewKeys', () => {
+  const MINE = ['# Database', 'DATABASE_URL=postgres://mine', 'DB_POOL=10'].join('\n')
+
+  it('appends only the keys that are absent, in the incoming order', () => {
+    const theirs = ['DB_POOL=99', 'STRIPE_KEY=sk_live', 'DATABASE_URL=postgres://theirs', 'PORT=3000'].join(
+      '\n'
+    )
+    expect(mergeNewKeys(MINE + '\n', theirs)).toBe(MINE + '\nSTRIPE_KEY=sk_live\nPORT=3000\n')
+  })
+
+  it('keeps the existing body byte for byte, trailing newline or not', () => {
+    const merged = mergeNewKeys(MINE, 'PORT=3000')
+    expect(merged.startsWith(MINE)).toBe(true)
+    expect(merged).toBe(MINE + '\nPORT=3000\n')
+    expect(mergeNewKeys(MINE + '\n', 'DB_POOL=1')).toBe(MINE + '\n')
+  })
+
+  it('quotes what needs quoting and takes a repeated incoming key once', () => {
+    expect(mergeNewKeys('', 'MSG=hello world # yes\nMSG=again\nPATH=/a b')).toBe(
+      'MSG=hello world\nPATH=/a b\n'
+    )
+    expect(mergeNewKeys('', 'MSG="two\\nlines"')).toBe('MSG="two\\nlines"\n')
+  })
+})

--- a/src/kinds/env/ingest.ts
+++ b/src/kinds/env/ingest.ts
@@ -1,4 +1,5 @@
 import { readEnvFile, type EnvFile } from '@/lib/commands'
+import { isImagePath } from '@/lib/fileTypes'
 import { appendVars, looksLikeEnv, parseEnv, varsOf } from './parse'
 
 /**
@@ -60,4 +61,15 @@ export interface IngestedEnv extends EnvFile {
 export const ingestEnvFile = async (path: string): Promise<IngestedEnv> => {
   const file = await readEnvFile(path)
   return { ...file, title: proposeTitle(path) }
+}
+
+/**
+ * Claim a window drop only when it belongs to env ingestion. Images are rejected
+ * before the text reader so the scanner remains their sole owner; other files
+ * are read once and claimed only when either their name or contents are env-like.
+ */
+export const ingestDroppedEnvFile = async (path: string): Promise<IngestedEnv | null> => {
+  if (isImagePath(path)) return null
+  const file = await ingestEnvFile(path)
+  return isEnvDrop(fileNameOf(path), file.body) ? file : null
 }

--- a/src/kinds/env/ingest.ts
+++ b/src/kinds/env/ingest.ts
@@ -1,0 +1,63 @@
+import { readEnvFile, type EnvFile } from '@/lib/commands'
+import { appendVars, looksLikeEnv, parseEnv, varsOf } from './parse'
+
+/**
+ * Getting a `.env` off disk and into a draft: the name a dropped path suggests
+ * for the entry, and how a second file folds into a body that already has one.
+ * Pure over strings, apart from `ingestEnvFile`, which is the one call to the
+ * backend both the editor's drop zone and the idle-window drop make.
+ */
+
+export const fileNameOf = (path: string): string => path.replace(/^.*[\\/]/, '')
+
+/** `.env`, `.env.production`, `local.env` — what is named like an env file. */
+export const isEnvFileName = (name: string): boolean => /^\.env(\..+)?$/i.test(name) || /\.env$/i.test(name)
+
+/**
+ * The parent folder is what the file belongs to and the suffix is which of
+ * the project's environments it is: `~/code/api/.env.production` is the api's
+ * production env, so `api · production`. A bare `.env` is just `api`; a
+ * `local.env` names itself, `api · local`.
+ */
+export const proposeTitle = (path: string): string => {
+  const segments = path.split(/[\\/]+/).filter(Boolean)
+  const name = segments.pop() ?? ''
+  const parent = segments.pop() ?? ''
+  const env = name.startsWith('.env') ? name.slice(4).replace(/^\./, '') : name.replace(/\.env$/i, '')
+  return [parent, env].filter(Boolean).join(' · ')
+}
+
+/**
+ * Append the incoming vars whose key the existing body does not have, in the
+ * order they arrive. The existing text is a byte-identical prefix of the result,
+ * so a teammate's newer file tops yours up without touching a rotated value.
+ * A key the incoming file repeats is added once, with its first value.
+ */
+export const mergeNewKeys = (existing: string, incoming: string): string => {
+  const have = new Set(varsOf(parseEnv(existing)).map(v => v.key))
+  const fresh = varsOf(parseEnv(incoming)).filter(v => {
+    if (have.has(v.key)) return false
+    have.add(v.key)
+    return true
+  })
+  return appendVars(existing, fresh)
+}
+
+/**
+ * Whether a file dropped on the idle window is ours: named like an env file,
+ * or reading as one. Anything else belongs to whoever else is listening (the
+ * Import screen's zone, the scanner) or to nobody.
+ */
+export const isEnvDrop = (fileName: string, body: string): boolean =>
+  isEnvFileName(fileName) || looksLikeEnv(body)
+
+export interface IngestedEnv extends EnvFile {
+  /** Proposed from the path; the draft keeps it only where the title is blank. */
+  title: string
+}
+
+/** Read a dropped or picked path into what a draft needs. Rejects as the backend does. */
+export const ingestEnvFile = async (path: string): Promise<IngestedEnv> => {
+  const file = await readEnvFile(path)
+  return { ...file, title: proposeTitle(path) }
+}

--- a/src/kinds/env/useIngest.ts
+++ b/src/kinds/env/useIngest.ts
@@ -1,0 +1,54 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { pickEnvFile } from '@/lib/commands'
+import { ingestDroppedEnvFile, ingestEnvFile, type IngestedEnv } from './ingest'
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/**
+ * The lifecycle shared by every interactive env-file entry point.
+ *
+ * Only the newest request may publish a result, completion calls the latest
+ * consumer (rather than the render that began the read), and failures become
+ * visible state. Unmount invalidates the request so a departed surface cannot
+ * update itself later.
+ */
+export function useEnvIngest(onFile: (file: IngestedEnv) => void) {
+  const consumer = useRef(onFile)
+  const request = useRef(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Match the committed render before any in-flight read is allowed to publish.
+  // (Writing a ref during render is deliberately forbidden by this repo's hook
+  // lint rules; the same indirection is used by `useFileDrop`.)
+  useLayoutEffect(() => {
+    consumer.current = onFile
+  })
+
+  useEffect(
+    () => () => {
+      ++request.current
+    },
+    []
+  )
+
+  const run = async (load: () => Promise<IngestedEnv | null>) => {
+    const mine = ++request.current
+    setError(null)
+    try {
+      const file = await load()
+      if (mine === request.current && file) consumer.current(file)
+    } catch (cause) {
+      if (mine === request.current) setError(messageOf(cause))
+    }
+  }
+
+  const drop = (path: string) => run(() => ingestDroppedEnvFile(path))
+  const pick = () =>
+    run(async () => {
+      const path = await pickEnvFile()
+      return path ? ingestEnvFile(path) : null
+    })
+
+  return { drop, pick, error }
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -383,6 +383,20 @@ export interface ImportReport {
 export const pickImportFile = (): Promise<string | null> =>
   invoke('pick_import_file')
 
+// A `.env` file read whole as text, for the env kind's drop zone and picker.
+// The backend refuses anything over 1 MiB or not UTF-8; the body is the secret,
+// so it is handed straight to a draft and never logged.
+export interface EnvFile {
+  fileName: string
+  body: string
+}
+
+export const readEnvFile = (path: string): Promise<EnvFile> =>
+  invoke('read_env_file', { path })
+
+// No extension filter: a `.env` has none, and `.env.production` is not `.production`.
+export const pickEnvFile = (): Promise<string | null> => invoke('pick_env_file')
+
 export const importEntries = (
   path: string,
   format: ImportFormat,

--- a/src/lib/fileTypes.ts
+++ b/src/lib/fileTypes.ts
@@ -1,0 +1,20 @@
+/** File kinds that have a window-level drop owner. */
+
+// What the OS recognizers can open, and what the image picker filters to.
+export const IMAGE_EXTENSIONS = [
+  'png',
+  'jpg',
+  'jpeg',
+  'heic',
+  'heif',
+  'webp',
+  'tiff',
+  'tif',
+  'bmp',
+  'gif'
+]
+
+export const isImagePath = (path: string): boolean => {
+  const extension = /\.([^.\\/]+)$/.exec(path)?.[1]
+  return !!extension && IMAGE_EXTENSIONS.includes(extension.toLowerCase())
+}

--- a/src/test/envIngest.test.tsx
+++ b/src/test/envIngest.test.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FieldsProvider } from '@/components/elements/fields'
 import type { DraftValue, EntryDraft } from '@/defaults/entries'
-import { readEnvFile } from '@/lib/commands'
+import { pickEnvFile, readEnvFile } from '@/lib/commands'
 import Fields from '@/kinds/env/Fields'
+import { useEnvIngest } from '@/kinds/env/useIngest'
 import Main from '@/components/Main'
 import { makeStore, useStore, startEntry, openAddPicker } from '@/store'
 import { renderWithStore, withEntries, loginMeta } from './utils'
@@ -39,6 +40,14 @@ const MINE = ['# Database', 'DATABASE_URL=postgres://mine', 'DB_POOL=10', ''].jo
 const THEIRS = ['DB_POOL=99', 'STRIPE_KEY=sk_live_1', ''].join('\n')
 const FILE = { fileName: '.env.production', body: THEIRS }
 
+const deferred = <T,>() => {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
 const keyInputs = () =>
   Array.from(document.querySelectorAll<HTMLInputElement>('input[name^="env-key-"]')).map(
     el => el.value
@@ -63,6 +72,7 @@ function Editor({
   return (
     <FieldsProvider value={{ entry, set, attempted: false }}>
       <Fields />
+      <button data-testid="edit-env-body" onClick={() => set('body', 'LOCAL=mine\n')} />
     </FieldsProvider>
   )
 }
@@ -107,6 +117,23 @@ describe('the editor drop zone', () => {
 
     await waitFor(() => expect(onSet).toHaveBeenCalledWith('body', THEIRS))
     expect(onSet).not.toHaveBeenCalledWith('title', expect.anything())
+  })
+
+  it('rechecks the live draft after a pending read instead of replacing newer typing', async () => {
+    const reading = deferred<typeof FILE>()
+    vi.mocked(readEnvFile).mockReturnValue(reading.promise)
+    const onSet = vi.fn()
+    render(<Editor body="" onSet={onSet} />)
+
+    await drop('/Users/me/code/api/.env')
+    await userEvent.click(screen.getByTestId('edit-env-body'))
+    onSet.mockClear()
+
+    await act(async () => reading.resolve(FILE))
+
+    expect(await screen.findByTestId('env-drop-prompt')).toBeInTheDocument()
+    expect(onSet).not.toHaveBeenCalled()
+    expect(keyInputs()).toEqual(['LOCAL'])
   })
 
   it('asks before touching a draft that has variables, and replaces on request', async () => {
@@ -155,7 +182,7 @@ describe('the editor drop zone', () => {
     expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
 
     await drop('/Users/me/code/api/.env.production')
-    screen.getByTestId('env-drop-replace').focus()
+    expect(screen.getByTestId('env-drop-replace')).toHaveFocus()
     await userEvent.keyboard('{Escape}')
     expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
 
@@ -173,6 +200,60 @@ describe('the editor drop zone', () => {
 
     expect(await screen.findByTestId('env-drop-error')).toHaveTextContent('1 MiB')
     expect(onSet).not.toHaveBeenCalled()
+  })
+
+  it('declines image and unrelated-text drops so their owning surfaces can handle them', async () => {
+    vi.mocked(readEnvFile).mockResolvedValue({ fileName: 'notes.txt', body: 'hello\nworld\n' })
+    const onSet = vi.fn()
+    render(<Editor body={MINE} onSet={onSet} />)
+
+    await drop('/Users/me/notes.txt')
+    await waitFor(() => expect(readEnvFile).toHaveBeenCalledWith('/Users/me/notes.txt'))
+    await drop('/Users/me/card.png')
+
+    expect(readEnvFile).not.toHaveBeenCalledWith('/Users/me/card.png')
+    expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('env-drop-error')).not.toBeInTheDocument()
+    expect(onSet).not.toHaveBeenCalled()
+  })
+})
+
+describe('interactive env ingestion', () => {
+  it('surfaces picker failures through the shared request lifecycle', async () => {
+    vi.mocked(pickEnvFile).mockRejectedValue('file is larger than 1 MiB')
+    const consume = vi.fn()
+    const { result } = renderHook(() => useEnvIngest(consume))
+
+    await act(() => result.current.pick())
+
+    expect(result.current.error).toContain('1 MiB')
+    expect(consume).not.toHaveBeenCalled()
+  })
+
+  it('lets only the newest read publish a result', async () => {
+    const first = deferred<typeof FILE>()
+    const second = deferred<typeof FILE>()
+    vi.mocked(readEnvFile).mockImplementation(path =>
+      path.endsWith('first.env') ? first.promise : second.promise
+    )
+    const consume = vi.fn()
+    const { result } = renderHook(() => useEnvIngest(consume))
+
+    let firstRun: Promise<void>
+    let secondRun: Promise<void>
+    act(() => {
+      firstRun = result.current.drop('/tmp/first.env')
+      secondRun = result.current.drop('/tmp/second.env')
+    })
+    await act(async () => {
+      second.resolve({ fileName: 'second.env', body: 'SECOND=2\n' })
+      await secondRun
+      first.resolve({ fileName: 'first.env', body: 'FIRST=1\n' })
+      await firstRun
+    })
+
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(consume.mock.calls[0][0]).toMatchObject({ fileName: 'second.env', body: 'SECOND=2\n' })
   })
 })
 
@@ -225,6 +306,19 @@ describe('a .env dropped on the idle window', () => {
 
     expect(useStore.getState().entries.new).toBe('login')
     expect(readEnvFile).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an editor opened while the file is still being read', async () => {
+    const reading = deferred<typeof FILE>()
+    vi.mocked(readEnvFile).mockReturnValue(reading.promise)
+    const store = seed()
+    renderWithStore(<Main />, { store })
+
+    await drop('/Users/me/code/api/.env')
+    act(() => startEntry('login'))
+    await act(async () => reading.resolve(FILE))
+
+    expect(useStore.getState().entries.new).toBe('login')
   })
 
   it('answers the Add picker and closes it', async () => {

--- a/src/test/envIngest.test.tsx
+++ b/src/test/envIngest.test.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FieldsProvider } from '@/components/elements/fields'
+import type { DraftValue, EntryDraft } from '@/defaults/entries'
+import { readEnvFile } from '@/lib/commands'
+import Fields from '@/kinds/env/Fields'
+import Main from '@/components/Main'
+import { makeStore, useStore, startEntry, openAddPicker } from '@/store'
+import { renderWithStore, withEntries, loginMeta } from './utils'
+
+// The webview's drag-drop stream, replaced by a hand that can drop a file. The
+// hook subscribes after a lazy import, so a test waits for the listener before
+// it drops; `unlisten` takes it back out.
+type Handler = (event: { payload: { type: string; paths: string[] } }) => void
+let handlers: Handler[] = []
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: (handler: Handler) => {
+      handlers.push(handler)
+      return Promise.resolve(() => {
+        handlers = handlers.filter(h => h !== handler)
+      })
+    }
+  })
+}))
+
+const listening = () => waitFor(() => expect(handlers.length).toBeGreaterThan(0))
+
+const drop = async (path: string) => {
+  await listening()
+  await act(async () => {
+    for (const handler of [...handlers]) handler({ payload: { type: 'drop', paths: [path] } })
+  })
+}
+
+const MINE = ['# Database', 'DATABASE_URL=postgres://mine', 'DB_POOL=10', ''].join('\n')
+const THEIRS = ['DB_POOL=99', 'STRIPE_KEY=sk_live_1', ''].join('\n')
+const FILE = { fileName: '.env.production', body: THEIRS }
+
+const keyInputs = () =>
+  Array.from(document.querySelectorAll<HTMLInputElement>('input[name^="env-key-"]')).map(
+    el => el.value
+  )
+
+// Editing against a live draft, the way Show's editor holds one, with every
+// write reported so the test can see the keys the zone set.
+function Editor({
+  body,
+  title = '',
+  onSet
+}: {
+  body: string
+  title?: string
+  onSet: (name: string, value: DraftValue) => void
+}) {
+  const [entry, setEntry] = useState<EntryDraft>({ type: 'env', title, body, fileName: '', note: '' })
+  const set = (name: string, next: DraftValue) => {
+    onSet(name, next)
+    setEntry(prev => ({ ...prev, [name]: next }))
+  }
+  return (
+    <FieldsProvider value={{ entry, set, attempted: false }}>
+      <Fields />
+    </FieldsProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  handlers = []
+  vi.mocked(readEnvFile).mockResolvedValue(FILE)
+})
+
+describe('the editor drop zone', () => {
+  it('is only there while editing', () => {
+    render(
+      <FieldsProvider
+        value={{ entry: { type: 'env', title: 'x', body: MINE, note: '' }, set: null, attempted: false }}
+      >
+        <Fields />
+      </FieldsProvider>
+    )
+    expect(screen.queryByTestId('env-dropzone')).not.toBeInTheDocument()
+  })
+
+  it('fills an empty draft with the file, its name and a proposed title', async () => {
+    const onSet = vi.fn()
+    render(<Editor body="" onSet={onSet} />)
+    expect(screen.getByTestId('env-dropzone')).toHaveTextContent('Drop a .env file here')
+
+    await drop('/Users/me/code/api/.env.production')
+
+    await waitFor(() => expect(onSet).toHaveBeenCalledWith('body', THEIRS))
+    expect(onSet).toHaveBeenCalledWith('fileName', '.env.production')
+    expect(onSet).toHaveBeenCalledWith('title', 'api · production')
+    expect(readEnvFile).toHaveBeenCalledWith('/Users/me/code/api/.env.production')
+    expect(keyInputs()).toEqual(['DB_POOL', 'STRIPE_KEY'])
+  })
+
+  it('leaves a title that was already typed', async () => {
+    const onSet = vi.fn()
+    render(<Editor body="" title="Mine" onSet={onSet} />)
+
+    await drop('/Users/me/code/api/.env')
+
+    await waitFor(() => expect(onSet).toHaveBeenCalledWith('body', THEIRS))
+    expect(onSet).not.toHaveBeenCalledWith('title', expect.anything())
+  })
+
+  it('asks before touching a draft that has variables, and replaces on request', async () => {
+    const onSet = vi.fn()
+    render(<Editor body={MINE} onSet={onSet} />)
+
+    await drop('/Users/me/code/api/.env.production')
+
+    const prompt = await screen.findByTestId('env-drop-prompt')
+    expect(prompt).toHaveTextContent('.env.production')
+    expect(onSet).not.toHaveBeenCalled()
+    expect(keyInputs()).toEqual(['DATABASE_URL', 'DB_POOL'])
+
+    await userEvent.click(screen.getByTestId('env-drop-replace'))
+
+    expect(onSet).toHaveBeenCalledWith('body', THEIRS)
+    expect(onSet).toHaveBeenCalledWith('fileName', '.env.production')
+    expect(keyInputs()).toEqual(['DB_POOL', 'STRIPE_KEY'])
+    expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
+  })
+
+  it('merges only the new keys, leaving existing rows alone', async () => {
+    const onSet = vi.fn()
+    render(<Editor body={MINE} onSet={onSet} />)
+
+    await drop('/Users/me/code/api/.env.production')
+    await userEvent.click(await screen.findByTestId('env-drop-merge'))
+
+    expect(onSet).toHaveBeenCalledWith('body', MINE + 'STRIPE_KEY=sk_live_1\n')
+    expect(onSet).toHaveBeenCalledWith('fileName', '.env.production')
+    expect(keyInputs()).toEqual(['DATABASE_URL', 'DB_POOL', 'STRIPE_KEY'])
+    // The rotated value stays ours.
+    expect(document.querySelector<HTMLTextAreaElement>('textarea[name="env-value-2"]')).toHaveValue(
+      '10'
+    )
+  })
+
+  it('can be told no, with the × or with Escape — which the editor never hears', async () => {
+    const onSet = vi.fn()
+    const heard = vi.fn()
+    document.addEventListener('keydown', heard)
+    render(<Editor body={MINE} onSet={onSet} />)
+
+    await drop('/Users/me/code/api/.env.production')
+    await userEvent.click(await screen.findByTestId('env-drop-cancel'))
+    expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
+
+    await drop('/Users/me/code/api/.env.production')
+    screen.getByTestId('env-drop-replace').focus()
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByTestId('env-drop-prompt')).not.toBeInTheDocument()
+
+    expect(onSet).not.toHaveBeenCalled()
+    expect(heard).not.toHaveBeenCalled()
+    document.removeEventListener('keydown', heard)
+  })
+
+  it('shows why a file was refused', async () => {
+    vi.mocked(readEnvFile).mockRejectedValue('file is larger than 1 MiB')
+    const onSet = vi.fn()
+    render(<Editor body="" onSet={onSet} />)
+
+    await drop('/Users/me/huge.env')
+
+    expect(await screen.findByTestId('env-drop-error')).toHaveTextContent('1 MiB')
+    expect(onSet).not.toHaveBeenCalled()
+  })
+})
+
+describe('a .env dropped on the idle window', () => {
+  const seed = () => {
+    const store = makeStore()
+    withEntries([loginMeta({ id: 'l1', title: 'Google' })])
+    return store
+  }
+
+  it('opens a new env draft with the file already in it', async () => {
+    renderWithStore(<Main />, { store: seed() })
+
+    await drop('/Users/me/code/api/.env.production')
+
+    await waitFor(() => expect(useStore.getState().entries.new).toBe('env'))
+    await waitFor(() => expect(keyInputs()).toEqual(['DB_POOL', 'STRIPE_KEY']))
+    // Seeded through the same prefill a scan uses, and consumed the same way.
+    expect(useStore.getState().entries.prefill).toBeNull()
+    expect(document.querySelector('input[name="title"]')).toHaveValue('api · production')
+  })
+
+  it('takes a file that only reads like one', async () => {
+    vi.mocked(readEnvFile).mockResolvedValue({ fileName: 'keys.txt', body: 'A=1\nB=2\n' })
+    renderWithStore(<Main />, { store: seed() })
+
+    await drop('/Users/me/keys.txt')
+
+    await waitFor(() => expect(useStore.getState().entries.new).toBe('env'))
+  })
+
+  it('ignores anything that is neither named nor written like one', async () => {
+    vi.mocked(readEnvFile).mockResolvedValue({ fileName: 'notes.txt', body: 'hello\nworld\n' })
+    renderWithStore(<Main />, { store: seed() })
+
+    await drop('/Users/me/notes.txt')
+    await drop('/Users/me/card.png')
+
+    expect(useStore.getState().entries.new).toBeNull()
+    // The scanner's, so not even read.
+    expect(readEnvFile).not.toHaveBeenCalledWith('/Users/me/card.png')
+  })
+
+  it('leaves an open editor alone', async () => {
+    const store = seed()
+    startEntry('login')
+    renderWithStore(<Main />, { store })
+
+    await drop('/Users/me/code/api/.env')
+
+    expect(useStore.getState().entries.new).toBe('login')
+    expect(readEnvFile).not.toHaveBeenCalled()
+  })
+
+  it('answers the Add picker and closes it', async () => {
+    const store = seed()
+    renderWithStore(<Main />, { store })
+    act(() => openAddPicker())
+    expect(screen.getByTestId('add-env-file')).toHaveTextContent('Drop a .env file')
+
+    await drop('/Users/me/code/api/.env')
+
+    await waitFor(() => expect(useStore.getState().entries.new).toBe('env'))
+    expect(useStore.getState().ui.addPicker).toBe(false)
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -51,6 +51,8 @@ vi.mock('@/lib/commands', () => ({
   ),
   pickBackup: vi.fn().mockResolvedValue(null),
   pickImportFile: vi.fn().mockResolvedValue(null),
+  pickEnvFile: vi.fn().mockResolvedValue(null),
+  readEnvFile: vi.fn().mockRejectedValue('file is not UTF-8 text'),
   importEntries: vi
     .fn()
     .mockResolvedValue({ total: 0, imported: 0, skipped: 0, dryRun: true, errors: [] }),


### PR DESCRIPTION
Stacked on #425 (`feat/env-kind`). Slice 2 of the env kind: getting a `.env` file in with no ceremony. Design: `docs/env-kind-design.md` §5–6.

## What
- **Editor drop zone** (`src/kinds/env/Fields/DropTarget.tsx`): a dashed target at the foot of the env editor. On a blank draft it fills `body`, sets `fileName` and proposes a title from the path (`~/code/api/.env.production` → `api · production`). On a draft with content it asks **Replace** / **Merge new keys** (merge appends only keys not already present, leaving the existing body byte-for-byte). Escape / × cancel and do not reach the editor's own Cancel. On mobile the zone is a **Choose a .env file** button over the OS picker.
- **Idle-window drop** (`src/components/Main/EnvDrop`): with no editor open, dropping a file whose name matches `.env*` or whose content parses as env opens a prefilled env draft through the same path the scanner uses. Images stay the scanner's; other files are ignored. Works while the Add picker is open and closes it.
- **Add picker link** (`AddSecret/EnvAction.tsx`): *Drop a .env file* (desktop) / *Choose a .env file* (mobile) under the tiles.
- **`useFileDrop`** (`src/hooks/useFileDrop.ts`): the webview drag-drop listener extracted from the import `DropZone`, which now uses it too.
- **Rust** (`commands/env.rs`): `read_env_file` (1 MiB cap, UTF-8 only, contents never logged) and `pick_env_file`.
- **Pure helpers** (`src/kinds/env/ingest.ts`): `proposeTitle`, `fileNameOf`, `isEnvFileName`, `mergeNewKeys`, `isEnvDrop`, `ingestEnvFile`.

## Tests
`ingest.test.ts` (title proposal, merge), `envIngest.test.tsx` (12: zone branches, Escape containment, idle drop by name and by content, images ignored, open editor untouched, picker closed), Rust unit tests for the size/UTF-8 gate.

## Verification
`bun run typecheck`, `lint`, `test` (591 green); `cargo fmt --check`, `clippy -D warnings`, `cargo test` (293 green), after merging the review fixes from #425.