### PR TITLE
feat(identity): read ID documents as document faces

### DIFF
--- a/src/components/elements/tokens.ts
+++ b/src/components/elements/tokens.ts
@@ -2,6 +2,15 @@ export const CARD = 'overflow-hidden rounded-lg border border-line bg-card'
 
 export const ROW_HAIRLINE = 'inset-shadow-hairline last:inset-shadow-none'
 
+// A 460px face (a credit card, an ID document) with its note panel: stacked,
+// and side by side once the *pane* is wide enough for both — 460 plus a note
+// column worth reading. A container breakpoint rather than a viewport one:
+// the detail pane can be far narrower than the window (a split view, an iPad
+// half), and the faces themselves fold by container width, so the two must
+// agree on what "wide" means.
+export const FACE_ASIDE =
+  'grid grid-cols-1 items-start gap-3 @min-[720px]:grid-cols-[460px_minmax(0,1fr)]'
+
 // A trailing control that stays out of the way until the row is asked about —
 // hovered, or holding the keyboard. Pairs with a `group` on the row itself.
 // Opacity only: the control keeps its place in the layout and in the tab order.

--- a/src/kinds/card/Fields/index.tsx
+++ b/src/kinds/card/Fields/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { cardBrandOf, cardDigits, groupCardNumber, hasBrandMark } from '@/utils/cardBrand'
 import CardBrandMark from '@/components/elements/CardBrandMark'
 import Panel from '@/components/elements/Panel'
+import { FACE_ASIDE } from '@/components/elements/tokens'
 import { NoteField, useField, useFields } from '@/components/elements/fields'
 import { useTranslation } from 'react-i18next'
 import { EyeGlyph, EyeOffGlyph } from '@/components/Main/icons'
@@ -41,13 +42,7 @@ export default function Fields() {
   }
 
   return (
-    <div
-      // Compact has no room for the art and the rest of the fields side by
-      // side, so below 768px the pair stacks instead.
-      className={
-        aside ? 'grid grid-cols-1 items-start gap-3 md:grid-cols-[460px_minmax(0,1fr)]' : undefined
-      }
-    >
+    <div className={aside ? FACE_ASIDE : undefined}>
       {/* Card art: an always-dark plastic-card visual, deliberately off-system.
           Its gradient, hex inks, 16/4px radii, unleaded type sizes and the
           number's wide letter-spacing imitate a real card, so they are exempt

--- a/src/kinds/identity/Face/Card.tsx
+++ b/src/kinds/identity/Face/Card.tsx
@@ -1,0 +1,70 @@
+import type { CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LABEL_TYPE } from '@/components/elements/tokens'
+import { countryName } from '@/utils/countries'
+import { DOC_TYPE_LABELS } from '../templates'
+import { CARD_PALETTES, type CardType } from './palette'
+import DocCell, { type Doc } from './DocCell'
+import Frame from './Frame'
+import Portrait from './Portrait'
+import Reveal from './Reveal'
+import { FOOT, HOLDER } from './layout'
+
+interface Props {
+  docType: CardType
+  doc: Doc
+}
+
+/**
+ * An ID-1 card — the wallet-sized document: ID card, driving licence,
+ * residence permit, or whatever "other" is. Laid out the way they all are: a
+ * coloured band naming the document and its country, the portrait at the left,
+ * the holder beside it, the dates along the bottom.
+ */
+export default function Card({ docType, doc }: Props) {
+  const { t } = useTranslation()
+  const country = doc.value('country')
+  const place = countryName(country) ?? country
+
+  return (
+    <Frame palette={CARD_PALETTES[docType]} aspect="aspect-[1.586]" docType={docType} className="flex-col">
+      <header
+        className="flex items-center justify-between gap-3 bg-(--face-band) px-5 py-2 text-(--face-band-ink)"
+        style={{ '--face-hover': 'rgba(255, 255, 255, 0.12)' } as CSSProperties}
+      >
+        <span className={`truncate ${LABEL_TYPE}`}>
+          {t(DOC_TYPE_LABELS[docType])}
+          {place && ` · ${place}`}
+        </span>
+        <DocCell doc={doc} name="country" bare ink={`${LABEL_TYPE} font-medium`} className="flex-none" />
+      </header>
+
+      <div className="flex flex-1 gap-4 px-5 pt-4">
+        <Portrait />
+        <div className={HOLDER}>
+          <DocCell
+            doc={doc}
+            name="name"
+            ink="text-lg font-medium uppercase tracking-[0.03em]"
+            wrap
+            className="col-span-full"
+          />
+          <DocCell doc={doc} name="birth_date" />
+          <DocCell doc={doc} name="sex" />
+          <DocCell doc={doc} name="nationality" />
+          <div className="col-span-full flex items-end gap-2">
+            <DocCell doc={doc} name="number" ink="text-lg tracking-secret" wrap className="flex-1" />
+            <Reveal shown={doc.shown} onToggle={doc.toggle} className="mb-1" />
+          </div>
+        </div>
+      </div>
+
+      <div className={`${FOOT} px-5 pb-4 pt-3`}>
+        <DocCell doc={doc} name="issue_date" />
+        <DocCell doc={doc} name="expiry_date" />
+        <DocCell doc={doc} name="authority" />
+        <DocCell doc={doc} name="personal_number" />
+      </div>
+    </Frame>
+  )
+}

--- a/src/kinds/identity/Face/Cell.tsx
+++ b/src/kinds/identity/Face/Cell.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TKey } from '@/i18n'
+import { cx } from '@/utils/cx'
+import { useCopied } from '@/hooks/useCopied'
+import { CheckGlyph, CopyGlyph } from '@/components/Main/icons'
+
+// A face is a miniature, so its captions sit one step under the detail rows'
+// 11px label tier and are tracked a little tighter: "NATIONALITY" and
+// "PERSONAL NO." have to fit a third of the holder's column.
+export const CAPTION = 'text-2xs uppercase tracking-[0.1em]'
+
+interface Props {
+  /** The draft key — `entry-value-<name>` is the selector the e2e suite owns. */
+  name: string
+  /** Untranslated caption over the value. The name and the header code go bare. */
+  label?: TKey
+  /** What is stored, and what a click copies. */
+  value: string
+  /** What is shown, when that differs: a date in the user's pattern, a mask. */
+  display?: string
+  /** A small line under the value: how long a document has left. */
+  hint?: ReactNode
+  /** The value line's type. The name and the number are the big ones. */
+  ink?: string
+  /** Wrap rather than truncate: a document number is never worth clipping. */
+  wrap?: boolean
+  className?: string
+}
+
+// One printed value on a document face: a micro-label, the value, and a copy on
+// click — the same gesture the credit card face teaches, in the face's own ink.
+export default function Cell({
+  name,
+  label,
+  value,
+  display = value,
+  hint,
+  ink = 'text-base',
+  wrap,
+  className
+}: Props) {
+  const { t } = useTranslation()
+  const { copied, copy } = useCopied()
+
+  return (
+    <button
+      type="button"
+      onClick={() => copy(value)}
+      title={t('Copy')}
+      aria-label={label ? `${t(label)} · ${t('Copy')}` : t('Copy')}
+      className={cx(
+        'group relative -mx-1.5 min-w-0 cursor-pointer rounded-sm px-1.5 py-1 text-left transition-colors hover:bg-(--face-hover)',
+        className
+      )}
+    >
+      {label && (
+        <span className={`block truncate ${CAPTION} text-(--face-ink2)`}>{t(label)}</span>
+      )}
+      <span
+        className={cx('block min-w-0 leading-6', wrap ? 'break-all' : 'truncate', label && 'mt-0.5', ink)}
+        data-testid={`entry-value-${name}`}
+      >
+        {display}
+      </span>
+      {hint}
+      <span className="pointer-events-none absolute right-1 top-1 opacity-0 transition-opacity group-hover:opacity-50">
+        <CopyGlyph size={12} />
+      </span>
+      {copied && (
+        <span className="absolute inset-0 grid place-items-center rounded-sm bg-(--face-ink) text-white">
+          <CheckGlyph size={12} />
+        </span>
+      )}
+    </button>
+  )
+}

--- a/src/kinds/identity/Face/DocCell.tsx
+++ b/src/kinds/identity/Face/DocCell.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next'
+import { cx } from '@/utils/cx'
+import { META_TYPE } from '@/components/elements/tokens'
+import { daysUntil, formatDate, relativeFuture } from '@/utils/time'
+import { specOf, type IdentityKey } from '../templates'
+import Cell from './Cell'
+
+/** What a face reads from: the document's values, and whether its secrets show. */
+export interface Doc {
+  /** A stored value, '' unless this document's template has a row for it. */
+  value: (key: IdentityKey) => string
+  shown: boolean
+  toggle: () => void
+}
+
+interface Props {
+  doc: Doc
+  name: IdentityKey
+  /** Drop the caption: the header prints the country code on its own. */
+  bare?: boolean
+  ink?: string
+  wrap?: boolean
+  className?: string
+}
+
+const DOTS = '•'.repeat(10)
+
+// One row of the template, printed on the face. The template's spec says what
+// the value is — a date, a secret, a date the document dies on — and this turns
+// that into how it shows, the same way the form's rows do for the editor.
+export default function DocCell({ doc, name, bare, ink, wrap, className }: Props) {
+  const { t } = useTranslation()
+  const spec = specOf(name)
+  const value = doc.value(name)
+  if (!value) return null
+
+  const masked = spec.secret && !doc.shown
+  const days = spec.expiry ? daysUntil(value) : null
+  const hint =
+    days === null ? undefined : (
+      <span
+        className={cx(
+          'mt-0.5 block',
+          META_TYPE,
+          days < 0 ? 'text-[#B3261E]' : 'text-(--face-ink2)'
+        )}
+      >
+        {days < 0 ? t('Expired') : relativeFuture(value)}
+      </span>
+    )
+
+  return (
+    <Cell
+      name={name}
+      label={bare ? undefined : spec.label}
+      value={value}
+      display={masked ? DOTS : spec.date ? formatDate(value) : value}
+      hint={hint}
+      ink={cx(ink ?? 'text-base', masked && 'text-(--face-ink2)')}
+      wrap={wrap && !masked}
+      className={className}
+    />
+  )
+}

--- a/src/kinds/identity/Face/Frame.tsx
+++ b/src/kinds/identity/Face/Frame.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { cx } from '@/utils/cx'
+import type { Palette } from './palette'
+
+interface Props {
+  palette: Palette
+  /** The document's proportions: ID-1 for a card, ID-3 for a passport page. */
+  aspect: string
+  /** Which document this is, for the e2e suite and for anyone styling one. */
+  docType: string
+  /** Layout of the printed area: a card stacks, a passport is spine + page. */
+  className?: string
+  children: ReactNode
+}
+
+// The paper every face is printed on. The palette goes down as CSS variables,
+// so the cells and the header band colour themselves without being told; the
+// guilloche is a fan of hairline rings from one corner, faded out before it
+// reaches the text — security paper, not wallpaper. Sized like the credit card
+// (460 wide, shrinking with the pane) and cast in its shadow, so the two read
+// as objects from one wallet.
+//
+// The proportions are a floor, not a cage. The rings layer is the one that
+// carries the aspect ratio, and it shares its grid cell with the printed area,
+// so the face is as tall as the real document — or as tall as its rows need
+// when a phone-narrow pane folds them, rather than clipping its footer.
+export default function Frame({ palette, aspect, docType, className, children }: Props) {
+  const rings = `repeating-radial-gradient(circle at 92% 6%, ${palette.guilloche} 0 1px, transparent 1px 11px)`
+  const fade = 'radial-gradient(circle at 92% 6%, black 0, transparent 64%)'
+
+  return (
+    <div
+      data-testid="identity-face"
+      data-doc-type={docType}
+      style={
+        {
+          background: palette.paper,
+          '--face-ink': palette.ink,
+          '--face-ink2': palette.ink2,
+          '--face-band': palette.band,
+          '--face-band-ink': palette.bandInk,
+          '--face-hover': 'rgba(0, 0, 0, 0.06)'
+        } as CSSProperties
+      }
+      className="grid w-[460px] max-w-full overflow-hidden rounded-[16px] border border-black/10 text-(--face-ink) tabular-nums shadow-[0_12px_28px_rgba(0,0,0,0.22)]"
+    >
+      <div
+        aria-hidden
+        className={cx('pointer-events-none col-start-1 row-start-1 w-full self-start', aspect)}
+        style={{ backgroundImage: rings, maskImage: fade, WebkitMaskImage: fade }}
+      />
+      <div className={cx('col-start-1 row-start-1 flex min-w-0', className)}>{children}</div>
+    </div>
+  )
+}

--- a/src/kinds/identity/Face/Passport.tsx
+++ b/src/kinds/identity/Face/Passport.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next'
+import { LABEL_TYPE } from '@/components/elements/tokens'
+import { countryName } from '@/utils/countries'
+import { DOC_TYPE_LABELS } from '../templates'
+import { passportPalette } from './palette'
+import DocCell, { type Doc } from './DocCell'
+import Frame from './Frame'
+import Portrait from './Portrait'
+import Reveal from './Reveal'
+import { FOOT, HOLDER } from './layout'
+
+interface Props {
+  doc: Doc
+}
+
+/**
+ * A passport, open at the data page: ID-3 proportions, a strip of the cover
+ * showing along the binding — in the colour the issuing country binds in, with
+ * the word in gold — and the page itself laid out as they all are: the holder
+ * beside the portrait, the document's own dates below.
+ */
+export default function Passport({ doc }: Props) {
+  const { t } = useTranslation()
+  const country = doc.value('country')
+  const place = countryName(country) ?? country
+  const label = t(DOC_TYPE_LABELS.passport)
+
+  return (
+    <Frame palette={passportPalette(country)} aspect="aspect-[1.42]" docType="passport">
+      <aside className="flex w-11 flex-none flex-col items-center justify-between bg-(--face-band) py-4 text-(--face-band-ink)">
+        {/* Bottom to top, the way a spine reads when the book lies face up. */}
+        <span className={`rotate-180 [writing-mode:vertical-rl] ${LABEL_TYPE} tracking-[0.3em]`}>
+          {label}
+        </span>
+        <span aria-hidden className="h-5 w-5 rounded-full border-[1.5px] border-current opacity-80" />
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col px-5 py-3">
+        <header className="flex items-center justify-between gap-3 text-(--face-ink2)">
+          <span className={`truncate ${LABEL_TYPE}`}>
+            {label}
+            {place && ` · ${place}`}
+          </span>
+          <DocCell
+            doc={doc}
+            name="country"
+            bare
+            ink={`${LABEL_TYPE} font-medium text-(--face-ink)`}
+            className="flex-none"
+          />
+        </header>
+
+        <div className="mt-3 flex flex-1 gap-4">
+          <Portrait />
+          <div className={HOLDER}>
+            <DocCell
+              doc={doc}
+              name="name"
+              ink="text-lg font-medium uppercase tracking-[0.03em]"
+              wrap
+              className="col-span-full"
+            />
+            <DocCell doc={doc} name="nationality" />
+            <DocCell doc={doc} name="birth_date" />
+            <DocCell doc={doc} name="sex" />
+            <div className="col-span-full flex items-end gap-2">
+              <DocCell doc={doc} name="number" ink="text-lg tracking-secret" wrap className="flex-1" />
+              <Reveal shown={doc.shown} onToggle={doc.toggle} className="mb-1" />
+            </div>
+          </div>
+        </div>
+
+        <div className={`${FOOT} mt-3`}>
+          <DocCell doc={doc} name="issue_date" />
+          <DocCell doc={doc} name="expiry_date" />
+          <DocCell doc={doc} name="authority" />
+          <DocCell doc={doc} name="personal_number" />
+        </div>
+      </div>
+    </Frame>
+  )
+}

--- a/src/kinds/identity/Face/Portrait.tsx
+++ b/src/kinds/identity/Face/Portrait.tsx
@@ -1,0 +1,17 @@
+// Where the photograph goes. The vault holds no photo, so the frame holds the
+// silhouette every blank form prints there — shoulders cut by the frame's edge,
+// as a passport photo is. It is what makes a face read as an ID at a glance
+// rather than as a table of fields.
+export default function Portrait() {
+  return (
+    <div
+      aria-hidden
+      className="flex aspect-[3/4] w-[84px] flex-none items-end justify-center overflow-hidden rounded-[6px] bg-black/6 text-(--face-ink) @max-[420px]:w-[64px]"
+    >
+      <svg viewBox="0 0 64 60" className="h-[72%] w-auto opacity-20" fill="currentColor">
+        <circle cx="32" cy="17" r="14" />
+        <path d="M4 60c0-15 12-26 28-26s28 11 28 26Z" />
+      </svg>
+    </div>
+  )
+}

--- a/src/kinds/identity/Face/Reveal.tsx
+++ b/src/kinds/identity/Face/Reveal.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+import { cx } from '@/utils/cx'
+import { EyeGlyph, EyeOffGlyph } from '@/components/Main/icons'
+
+interface Props {
+  shown: boolean
+  onToggle: () => void
+  className?: string
+}
+
+// The one eye on a face: it lifts every mask at once, as the credit card's does.
+// `reveal-number` is the selector the e2e suite presses, and its label is what
+// it reads to know which way the toggle is.
+export default function Reveal({ shown, onToggle, className }: Props) {
+  const { t } = useTranslation()
+  const label = shown ? t('Hide') : t('Reveal')
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      title={label}
+      aria-label={label}
+      data-testid="reveal-number"
+      className={cx(
+        'grid h-7 w-7 flex-none cursor-pointer place-items-center rounded-sm text-(--face-ink2) transition-colors hover:bg-(--face-hover) hover:text-(--face-ink)',
+        className
+      )}
+    >
+      {shown ? <EyeOffGlyph /> : <EyeGlyph />}
+    </button>
+  )
+}

--- a/src/kinds/identity/Face/index.tsx
+++ b/src/kinds/identity/Face/index.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { useFields } from '@/components/elements/fields'
+import { docTypeOf, TEMPLATES, type IdentityKey } from '../templates'
+import type { Doc } from './DocCell'
+import Card from './Card'
+import Passport from './Passport'
+
+/**
+ * The document as an object — the read view of an identity.
+ *
+ * A passport is a booklet and everything else is a card, so there are two
+ * faces; both print only the rows the document's template has, so a value left
+ * over from another type (an import, an older vault) never shows on a face
+ * that has no place for it. Reading only: the editor keeps its labelled rows,
+ * where a type switch can reshape the form and a date can explain its pattern.
+ */
+export default function Face() {
+  const { entry } = useFields()
+  const [shown, setShown] = useState(false)
+  const docType = docTypeOf(entry)
+  const keys = new Set<IdentityKey>(TEMPLATES[docType].map(row => row.key))
+
+  const doc: Doc = {
+    value: key => {
+      const raw = keys.has(key) ? entry[key] : ''
+      return typeof raw === 'string' ? raw.trim() : ''
+    },
+    shown,
+    toggle: () => setShown(!shown)
+  }
+
+  return docType === 'passport' ? <Passport doc={doc} /> : <Card docType={docType} doc={doc} />
+}

--- a/src/kinds/identity/Face/layout.ts
+++ b/src/kinds/identity/Face/layout.ts
@@ -1,0 +1,12 @@
+// The two grids both faces are printed on.
+
+// The holder's details, beside the portrait: three across on the desktop, two
+// once the pane is phone-narrow so no caption has to be cut.
+export const HOLDER =
+  'grid min-w-0 flex-1 grid-cols-3 content-start gap-x-3 gap-y-1.5 @max-[420px]:grid-cols-2'
+
+// The row along the bottom edge — issued, expires, authority, personal number,
+// whichever the document has. Each cell hugs its value and the row spreads them
+// to the edges, the way a card prints its dates; phone-narrow, two per row.
+export const FOOT =
+  'grid grid-flow-col auto-cols-[minmax(0,auto)] justify-between gap-x-4 gap-y-1.5 @max-[420px]:grid-flow-row @max-[420px]:grid-cols-2 @max-[420px]:justify-normal'

--- a/src/kinds/identity/Face/palette.test.ts
+++ b/src/kinds/identity/Face/palette.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { DOC_TYPES } from '../templates'
+import { CARD_PALETTES, coverOf, passportPalette } from './palette'
+
+describe('CARD_PALETTES', () => {
+  it('prints every card-shaped document', () => {
+    for (const type of DOC_TYPES) {
+      if (type === 'passport') continue
+      expect(CARD_PALETTES[type]).toBeDefined()
+    }
+  })
+})
+
+describe('coverOf', () => {
+  it('binds a passport in its country’s cover', () => {
+    expect(coverOf('GBR')).toBe(coverOf('USA'))
+    expect(coverOf('SAU')).not.toBe(coverOf('GBR'))
+    expect(coverOf('NZL')).not.toBe(coverOf('GBR'))
+  })
+
+  // The country is free text: what someone typed, in whatever case.
+  it('reads the code however it was typed', () => {
+    expect(coverOf(' gbr ')).toBe(coverOf('GBR'))
+  })
+
+  // Burgundy is the EU's and the most common, so a country the table does not
+  // name — and no country at all — gets that rather than nothing.
+  it('falls back to burgundy', () => {
+    expect(coverOf('DEU')).toBe(coverOf(''))
+    expect(coverOf('Narnia')).toBe(coverOf('DEU'))
+  })
+})
+
+describe('passportPalette', () => {
+  it('changes only the cover with the country', () => {
+    const { band: gb, ...gbPage } = passportPalette('GBR')
+    const { band: de, ...dePage } = passportPalette('DEU')
+    expect(gb).not.toBe(de)
+    expect(gbPage).toEqual(dePage)
+  })
+})

--- a/src/kinds/identity/Face/palette.ts
+++ b/src/kinds/identity/Face/palette.ts
@@ -1,0 +1,98 @@
+import type { DocType } from '../templates'
+
+/**
+ * The colours one document face is printed in.
+ *
+ * Fixed hex, never theme tokens: a face stands for a physical object, so it
+ * keeps its own paper and ink in both themes — the same reason the credit card
+ * face is graphite in light mode too.
+ */
+export interface Palette {
+  /** The paper: a two-stop gradient, light like the real thing. */
+  paper: string
+  /** Body ink, and the quieter ink the labels and glosses take. */
+  ink: string
+  ink2: string
+  /** The header band (a card) or the cover (a passport), and its print. */
+  band: string
+  bandInk: string
+  /** The guilloche rings, drawn at low alpha over the paper. */
+  guilloche: string
+}
+
+/** Every document that is a card in the wallet rather than a booklet. */
+export type CardType = Exclude<DocType, 'passport'>
+
+// Each card takes the paper its real counterpart is most often printed on: an
+// EU licence is pink, a polycarbonate ID card cool white, a permit greenish.
+export const CARD_PALETTES: Record<CardType, Palette> = {
+  id_card: {
+    paper: 'linear-gradient(150deg, #F3F6FA, #DBE3ED 62%)',
+    ink: '#18243A',
+    ink2: '#5D6C82',
+    band: '#1F3A5F',
+    bandInk: '#E9EFF7',
+    guilloche: 'rgba(31, 58, 95, 0.10)'
+  },
+  driver_license: {
+    paper: 'linear-gradient(150deg, #FBF0F2, #EDD6DB 62%)',
+    ink: '#3A1E27',
+    ink2: '#7C5C66',
+    band: '#8C2F45',
+    bandInk: '#FBF0F2',
+    guilloche: 'rgba(140, 47, 69, 0.10)'
+  },
+  residence_permit: {
+    paper: 'linear-gradient(150deg, #EFF5F1, #D7E3DA 62%)',
+    ink: '#1C2E27',
+    ink2: '#5F746B',
+    band: '#2E5E4E',
+    bandInk: '#EEF5F0',
+    guilloche: 'rgba(46, 94, 78, 0.10)'
+  },
+  other: {
+    paper: 'linear-gradient(150deg, #F4F3F0, #E0DED8 62%)',
+    ink: '#23262B',
+    ink2: '#6C717A',
+    band: '#3B3F46',
+    bandInk: '#F1F1EE',
+    guilloche: 'rgba(59, 63, 70, 0.10)'
+  }
+}
+
+/**
+ * Passport covers come in four colours the world over, and gold is printed on
+ * all of them. Burgundy is the default: it is the EU's, and the most common.
+ */
+const COVERS = {
+  burgundy: '#5B1F2D',
+  navy: '#1B2A4A',
+  green: '#1F4D3A',
+  black: '#17181C'
+} as const
+
+type Cover = keyof typeof COVERS
+
+const COVER_OF: Record<string, Cover> = Object.fromEntries([
+  ...'USA CAN AUS GBR IND UKR ISR ARG BRA URY ARE KAZ'.split(' ').map(code => [code, 'navy']),
+  ...'SAU PAK MAR NGA IDN BGD EGY IRN DZA MEX'.split(' ').map(code => [code, 'green']),
+  ['NZL', 'black']
+])
+
+/** The cover colour the issuing country binds its passports in. */
+export const coverOf = (country: string): string =>
+  COVERS[COVER_OF[country.trim().toUpperCase()] ?? 'burgundy']
+
+const PASSPORT_PAGE = {
+  paper: 'linear-gradient(150deg, #F6F2E9, #E8E1D2 62%)',
+  ink: '#241E17',
+  ink2: '#77705F',
+  bandInk: '#D9BC66',
+  guilloche: 'rgba(184, 150, 62, 0.14)'
+}
+
+/** A passport's data page, bound in the cover its country uses. */
+export const passportPalette = (country: string): Palette => ({
+  ...PASSPORT_PAGE,
+  band: coverOf(country)
+})

--- a/src/kinds/identity/Fields/index.tsx
+++ b/src/kinds/identity/Fields/index.tsx
@@ -7,6 +7,7 @@ import {
   NoteField,
   useFields
 } from '@/components/elements/fields'
+import { filled } from '@/components/elements/fields/formats'
 import { countryName } from '@/utils/countries'
 import {
   docTypeOf,
@@ -16,6 +17,7 @@ import {
   type DocType,
   type Row
 } from '../templates'
+import Face from '../Face'
 import DocTypeRow from './DocType'
 
 // The template's rows cut into bands wherever the group changes — holder,
@@ -46,11 +48,32 @@ export default function Fields() {
     for (const key of droppedKeys(docType, next)) set(key, '')
   }
 
-  // Reading, an empty field renders nothing at all — so a band with nothing in
-  // it must not leave its gutter and an empty block behind.
-  const rows = editing
-    ? TEMPLATES[docType]
-    : TEMPLATES[docType].filter(({ key }) => (entry[key] ?? '') !== '')
+  // Reading, the document is an object (see `Face`); the note it carries and
+  // any custom fields keep their rows beside and below it, as on a credit card.
+  if (!editing) {
+    const aside = filled(entry.note)
+    return (
+      <>
+        <div
+          className={
+            aside
+              ? 'grid grid-cols-1 items-start gap-3 md:grid-cols-[460px_minmax(0,1fr)]'
+              : undefined
+          }
+        >
+          <Face />
+          {aside && (
+            <Panel>
+              <NoteField label="Note" />
+            </Panel>
+          )}
+        </div>
+        <CustomFieldsField />
+      </>
+    )
+  }
+
+  const rows = TEMPLATES[docType]
 
   const row = ({ key, required }: Row) => {
     const spec = specOf(key)
@@ -83,13 +106,9 @@ export default function Fields() {
 
   return (
     <>
-      {/* Reading, the type is in the eyebrow (see Show/Read) — a line of its
-          own here would only say it twice. */}
-      {editing && (
-        <div className="mb-3">
-          <DocTypeRow value={docType} onChange={switchTo} />
-        </div>
-      )}
+      <div className="mb-3">
+        <DocTypeRow value={docType} onChange={switchTo} />
+      </div>
       <Panel>
         {bands(rows).map((band, index) => (
           <Fragment key={specOf(band[0].key).group}>

--- a/src/kinds/identity/Fields/index.tsx
+++ b/src/kinds/identity/Fields/index.tsx
@@ -8,6 +8,7 @@ import {
   useFields
 } from '@/components/elements/fields'
 import { filled } from '@/components/elements/fields/formats'
+import { FACE_ASIDE } from '@/components/elements/tokens'
 import { countryName } from '@/utils/countries'
 import {
   docTypeOf,
@@ -54,13 +55,7 @@ export default function Fields() {
     const aside = filled(entry.note)
     return (
       <>
-        <div
-          className={
-            aside
-              ? 'grid grid-cols-1 items-start gap-3 md:grid-cols-[460px_minmax(0,1fr)]'
-              : undefined
-          }
-        >
+        <div className={aside ? FACE_ASIDE : undefined}>
           <Face />
           {aside && (
             <Panel>

--- a/src/test/fields.test.tsx
+++ b/src/test/fields.test.tsx
@@ -618,11 +618,13 @@ describe('Identity read view', () => {
     expect(await screen.findByTestId('entry-value-doc_type')).toHaveTextContent('Passport')
   })
 
+  // The face captions the date "Expires", so the time left stands on its own
+  // line under it rather than repeating the word.
   it('says how long the document has left', async () => {
     vi.mocked(revealEntry).mockResolvedValue(document_(away(400)))
     renderWithStore(<Show entry={identityMeta()} />)
 
-    expect(await screen.findByText(/Expires in 1 year/)).toBeInTheDocument()
+    expect(await screen.findByText('in 1 year')).toBeInTheDocument()
   })
 
   it('says so once it has run out', async () => {
@@ -632,13 +634,13 @@ describe('Identity read view', () => {
     expect(await screen.findByText('Expired')).toBeInTheDocument()
   })
 
-  // The code is what the document prints and what the copy button hands over;
-  // the name beside it is decoration.
+  // The code is what the document prints and what a click copies; the face's
+  // header names the country in full beside the document's type.
   it('names the country beside its alpha-3 code', async () => {
     vi.mocked(revealEntry).mockResolvedValue(identityEntry())
     renderWithStore(<Show entry={identityMeta()} />)
 
     expect(await screen.findByTestId('entry-value-country')).toHaveTextContent('GBR')
-    expect(screen.getByText('· United Kingdom')).toBeInTheDocument()
+    expect(screen.getByText(/Passport · United Kingdom/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Reading an identity now shows the document as an object, the way a credit card entry shows its face.

- **Two canonical faces** in `src/kinds/identity/Face/`. ID cards, driving licences, residence permits and "other" share one landscape ID‑1 card: a coloured header band naming the document and its country, the alpha‑3 code at the right, a portrait silhouette, the holder's details beside it, dates spread along the bottom edge. Passports get an ID‑3 data page with a strip of the cover along the binding and "Passport" printed vertically in gold.
- **Physical palettes, fixed in both themes**, like the credit card's graphite. Licences are rose, ID cards cool polycarbonate blue, permits sage, other neutral. The passport cover follows the issuing country (navy, green, black, burgundy by default). Faint guilloche rings fan out from one corner.
- **Same interactions as the card face.** Click a value to copy, one eye lifts every mask (`reveal-number`), expiry shows "in 8 years" beneath the date or a red "Expired", dates render in the user's pattern.
- **Reading only.** Editing keeps the existing labelled rows, since the type switch reshapes the form and a passport has ten fields. Note and custom fields sit beside and below the face, as on a credit card.
- **Responsive.** Below 420px of pane the holder grid drops to two columns and the face grows past its ideal ratio instead of clipping.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run test` all pass (496 tests), including a new test for the cover palette.
- Rendered in headless Chrome at 860px and 360px, light and dark, for every document type.
- Two assertions in the identity read‑view component test were updated to the new layout: the time left reads "in 1 year" under an "Expires" caption, and the country name appears in the header beside the document type.
- The e2e identity spec's selectors (`entry-value-*`, `reveal-number`, `entry-value-doc_type`) are preserved. The wdio suite was not run here since it needs a Tauri build.

No new translation keys; every caption reuses the template labels.