### PR TITLE
feat(splash): mascot wake-up splash before the lock screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,10 @@
       themed instead of a white flash (matters on reload and on the startup
       fallback path in window.rs). Values mirror `--c-app` in styles/theme.css;
       they have to be literal here because this paints before any CSS loads.
-      Keyed off the OS rather than the stored preference — reading localStorage
-      would need an inline script, which the CSP rightly forbids.
+      Keyed off the OS until the bundle runs — reading localStorage would need
+      an inline script, which the CSP rightly forbids — then off `data-theme`,
+      which main.tsx sets synchronously before anything else (the app defaults
+      to light, not to the OS, so the two can disagree).
     -->
     <style>
       html {
@@ -33,10 +35,247 @@
           background: #0f1011;
         }
       }
+      html[data-theme='light'] {
+        background: #e7e8ea;
+      }
+      html[data-theme='dark'] {
+        background: #0f1011;
+      }
+    </style>
+    <!--
+      Startup splash: the mascot waking up, in the spot the lock screen then
+      draws it. Static markup inside #root, so it is on screen from the first
+      frame and React's first commit replaces it (createRoot clears the
+      container) — no teardown code. Everything here is a literal copy of what
+      the app computes: the body is AsteriskBody (asteriskGeometry.ts — spike
+      path, hub, soften filter), the face is Mascot.tsx (eye ellipses, blink),
+      the ground glow and the column are AuthShell + Auth / LockScreen. Change
+      those, mirror here.
+
+      The choreography is paused until main.tsx adds `splash-live` to <html>,
+      so it starts when the window is revealed rather than while it is still
+      hidden loading the bundle; main.tsx also holds the first React frame
+      until the last animation ends (see lib/splash.ts), so the lock screen
+      takes over from the resting pose, not mid-motion. Base styles are the
+      resting pose, which is what reduced-motion shows straight away.
+    -->
+    <style>
+      .splash {
+        /* Brand ink / eye paper / ground glow — `--c-brand`, `--c-brand-eye`,
+           `--topglow` in theme.css. Same OS-then-data-theme keying as above. */
+        --ink: #34373e;
+        --eye: #ffffff;
+        --glow: rgba(255, 255, 255, 0.7);
+        --ease-swift: cubic-bezier(0.2, 0.8, 0.2, 1);
+        --ease-spring: cubic-bezier(0.34, 1.45, 0.64, 1);
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        overflow: hidden;
+        pointer-events: none;
+      }
+      @media (prefers-color-scheme: dark) {
+        .splash {
+          --ink: #d6d8dc;
+          --eye: #15161a;
+          --glow: rgba(255, 255, 255, 0.06);
+        }
+      }
+      html[data-theme='light'] .splash {
+        --ink: #34373e;
+        --eye: #ffffff;
+        --glow: rgba(255, 255, 255, 0.7);
+      }
+      html[data-theme='dark'] .splash {
+        --ink: #d6d8dc;
+        --eye: #15161a;
+        --glow: rgba(255, 255, 255, 0.06);
+      }
+      /* The compact (phone) shell — the same 767px cut as useLayout / the md:
+         breakpoint — pads past the notch and reserves the bottom chrome
+         (AuthShell), which moves where the column centers; mirror it exactly
+         so the mascot lands where LockScreen draws it. */
+      @media (max-width: 767px) {
+        .splash {
+          padding: env(safe-area-inset-top) 1.25rem calc(env(safe-area-inset-bottom) + 7rem);
+        }
+      }
+
+      /* AuthShell's soft radial glow behind the column. */
+      .splash-glow {
+        position: absolute;
+        left: 50%;
+        top: 44%;
+        width: 1200px;
+        height: 700px;
+        transform: translate(-50%, -50%);
+        background: radial-gradient(closest-side, var(--glow), transparent 70%);
+        animation: splash-glow 900ms ease-out both;
+      }
+
+      /* The lock screen's centered column (`my-auto`), with the mascot at its
+         top: 96 mascot + 28 gap + 15 eyebrow (11px × 1.35) + 32 gap + 48
+         field. Sizes from Auth.tsx / Eyebrow / Masterpass (lock variant). The
+         phone's LockScreen has the same first frame: it renders the card until
+         the biometric probe answers, which is after React mounts. */
+      .splash-col {
+        position: relative;
+        display: flex;
+        justify-content: center;
+        height: 219px;
+        width: 560px;
+        max-width: 100%;
+        margin: auto 0;
+      }
+      .splash-mascot {
+        display: block;
+        width: 96px;
+        height: 96px;
+      }
+
+      /* The whole body winds into place like a key turning: over-rotated and
+         small, springing back to rest while the spikes grow out of the hub. */
+      .splash-body {
+        transform-origin: 32px 32px;
+        animation: splash-wind 760ms var(--ease-spring) both;
+      }
+      .splash-ink {
+        fill: var(--ink);
+      }
+      .splash-hub {
+        transform-origin: 32px 32px;
+        animation: splash-hub 460ms var(--ease-spring) both;
+      }
+      /* Each spike extends from the hub along its own axis; the wrapping <g>
+         carries the rotation, so scaleY here is always "outward". Staggered
+         clockwise from the top, so the growth sweeps around the hub. */
+      .splash-spike path {
+        transform-origin: 32px 32px;
+        animation: splash-spike 400ms var(--ease-spring) both;
+      }
+      .splash-spike:nth-of-type(1) path { animation-delay: 100ms; }
+      .splash-spike:nth-of-type(2) path { animation-delay: 140ms; }
+      .splash-spike:nth-of-type(3) path { animation-delay: 180ms; }
+      .splash-spike:nth-of-type(4) path { animation-delay: 220ms; }
+      .splash-spike:nth-of-type(5) path { animation-delay: 260ms; }
+      .splash-spike:nth-of-type(6) path { animation-delay: 300ms; }
+
+      /* The face, last: eyes open once the body has settled, glance around
+         the room, and come to rest looking straight ahead — the lock screen's
+         idle pose (gaze 0, ry 5, blink every 6.8s). Mascot.tsx nests them the
+         same way: gaze translate → blink scale → eyes. */
+      .splash-gaze {
+        animation: splash-glance 480ms var(--ease-swift) 900ms both;
+      }
+      .splash-blink {
+        transform-origin: 32px 27px;
+        animation: blink 6.8s ease-in-out infinite;
+      }
+      .splash-eyes {
+        fill: var(--eye);
+        transform-origin: 32px 27px;
+        animation: splash-wake 240ms var(--ease-spring) 660ms both;
+      }
+
+      /* Held at the first frame until the bundle is live (see the note above). */
+      .splash * {
+        animation-play-state: paused;
+      }
+      html.splash-live .splash * {
+        animation-play-state: running;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .splash * {
+          animation: none !important;
+        }
+      }
+
+      @keyframes splash-glow {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      @keyframes splash-wind {
+        from { transform: rotate(-60deg) scale(0.72); }
+        to { transform: rotate(0deg) scale(1); }
+      }
+      @keyframes splash-hub {
+        from { transform: scale(0); }
+        to { transform: scale(1); }
+      }
+      @keyframes splash-spike {
+        from { transform: scaleY(0); }
+        to { transform: scaleY(1); }
+      }
+      @keyframes splash-wake {
+        from { transform: scaleY(0); }
+        to { transform: scaleY(1); }
+      }
+      @keyframes splash-glance {
+        0% { transform: translateX(0); }
+        30% { transform: translateX(3px); }
+        70% { transform: translateX(-3px); }
+        100% { transform: translateX(0); }
+      }
+      /* Verbatim from theme.css, so the idle blink is the same blink. */
+      @keyframes blink {
+        0%, 93%, 100% { transform: scaleY(1); }
+        96%, 97.5% { transform: scaleY(0.06); }
+      }
     </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="splash" aria-hidden="true">
+        <div class="splash-glow"></div>
+        <div class="splash-col">
+          <svg class="splash-mascot" viewBox="0 0 64 64">
+            <defs>
+              <filter id="splash-soften" x="-15%" y="-15%" width="130%" height="130%">
+                <feGaussianBlur in="SourceGraphic" stdDeviation="1.8" result="b" />
+                <feColorMatrix
+                  in="b"
+                  type="matrix"
+                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -13"
+                />
+              </filter>
+            </defs>
+            <g class="splash-body">
+              <g class="splash-ink" filter="url(#splash-soften)">
+                <g class="splash-spike" transform="rotate(0 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <g class="splash-spike" transform="rotate(60 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <g class="splash-spike" transform="rotate(120 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <g class="splash-spike" transform="rotate(180 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <g class="splash-spike" transform="rotate(240 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <g class="splash-spike" transform="rotate(300 32 32)">
+                  <path d="M26 24 L24 7 Q23.5 3 27.5 3 L36.5 3 Q40.5 3 40 7 L38 24 Z" />
+                </g>
+                <circle class="splash-hub" cx="32" cy="32" r="14" />
+              </g>
+              <g class="splash-gaze" data-splash-last>
+                <g class="splash-blink">
+                  <g class="splash-eyes">
+                    <ellipse cx="27.6" cy="27.4" rx="3.5" ry="5" />
+                    <ellipse cx="37.2" cy="26.8" rx="3.5" ry="5" />
+                  </g>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -52,12 +52,15 @@
       the ground glow and the column are AuthShell + Auth / LockScreen. Change
       those, mirror here.
 
-      The choreography is paused until main.tsx adds `splash-live` to <html>,
-      so it starts when the window is revealed rather than while it is still
-      hidden loading the bundle; main.tsx also holds the first React frame
-      until the last animation ends (see lib/splash.ts), so the lock screen
-      takes over from the resting pose, not mid-motion. Base styles are the
-      resting pose, which is what reduced-motion shows straight away.
+      The base styles are the resting pose, complete; the choreography only
+      applies once main.tsx adds `splash-live` to <html>. So it starts when
+      the bundle is live — which is also when window.rs reveals the window —
+      rather than playing unseen behind a hidden one, and main.tsx holds the
+      first React frame until the last animation ends (see lib/splash.ts), so
+      the lock screen takes over from the resting pose, not mid-motion. If the
+      bundle never runs (dev server down, a throwing script) window.rs's
+      fallback timer reveals this resting frame, a whole mascot rather than a
+      blank window; reduced-motion users get the same frame straight away.
     -->
     <style>
       .splash {
@@ -112,7 +115,6 @@
         height: 700px;
         transform: translate(-50%, -50%);
         background: radial-gradient(closest-side, var(--glow), transparent 70%);
-        animation: splash-glow 900ms ease-out both;
       }
 
       /* The lock screen's centered column (`my-auto`), with the mascot at its
@@ -135,57 +137,64 @@
         height: 96px;
       }
 
-      /* The whole body winds into place like a key turning: over-rotated and
-         small, springing back to rest while the spikes grow out of the hub. */
-      .splash-body {
+      /* Resting pose. Transform origins are set here, once, for the moves
+         below; the idle blink is part of the pose (the lock screen's mascot
+         blinks the same way), so it runs regardless. */
+      .splash-body,
+      .splash-hub,
+      .splash-spike path {
         transform-origin: 32px 32px;
-        animation: splash-wind 760ms var(--ease-spring) both;
       }
       .splash-ink {
         fill: var(--ink);
       }
-      .splash-hub {
-        transform-origin: 32px 32px;
+      .splash-blink,
+      .splash-eyes {
+        transform-origin: 32px 27px;
+      }
+      .splash-blink {
+        animation: blink 6.8s ease-in-out infinite;
+      }
+      .splash-eyes {
+        fill: var(--eye);
+      }
+
+      /* The choreography, live only once the bundle is (see the note above). */
+      html.splash-live .splash-glow {
+        animation: splash-glow 900ms ease-out both;
+      }
+      /* The whole body winds into place like a key turning: over-rotated and
+         small, springing back to rest while the spikes grow out of the hub. */
+      html.splash-live .splash-body {
+        animation: splash-wind 760ms var(--ease-spring) both;
+      }
+      html.splash-live .splash-hub {
         animation: splash-hub 460ms var(--ease-spring) both;
       }
       /* Each spike extends from the hub along its own axis; the wrapping <g>
          carries the rotation, so scaleY here is always "outward". Staggered
          clockwise from the top, so the growth sweeps around the hub. */
-      .splash-spike path {
-        transform-origin: 32px 32px;
+      html.splash-live .splash-spike path {
         animation: splash-spike 400ms var(--ease-spring) both;
       }
-      .splash-spike:nth-of-type(1) path { animation-delay: 100ms; }
-      .splash-spike:nth-of-type(2) path { animation-delay: 140ms; }
-      .splash-spike:nth-of-type(3) path { animation-delay: 180ms; }
-      .splash-spike:nth-of-type(4) path { animation-delay: 220ms; }
-      .splash-spike:nth-of-type(5) path { animation-delay: 260ms; }
-      .splash-spike:nth-of-type(6) path { animation-delay: 300ms; }
+      html.splash-live .splash-spike:nth-of-type(1) path { animation-delay: 100ms; }
+      html.splash-live .splash-spike:nth-of-type(2) path { animation-delay: 140ms; }
+      html.splash-live .splash-spike:nth-of-type(3) path { animation-delay: 180ms; }
+      html.splash-live .splash-spike:nth-of-type(4) path { animation-delay: 220ms; }
+      html.splash-live .splash-spike:nth-of-type(5) path { animation-delay: 260ms; }
+      html.splash-live .splash-spike:nth-of-type(6) path { animation-delay: 300ms; }
 
       /* The face, last: eyes open once the body has settled, glance around
          the room, and come to rest looking straight ahead — the lock screen's
          idle pose (gaze 0, ry 5, blink every 6.8s). Mascot.tsx nests them the
          same way: gaze translate → blink scale → eyes. */
-      .splash-gaze {
+      html.splash-live .splash-gaze {
         animation: splash-glance 480ms var(--ease-swift) 900ms both;
       }
-      .splash-blink {
-        transform-origin: 32px 27px;
-        animation: blink 6.8s ease-in-out infinite;
-      }
-      .splash-eyes {
-        fill: var(--eye);
-        transform-origin: 32px 27px;
+      html.splash-live .splash-eyes {
         animation: splash-wake 240ms var(--ease-spring) 660ms both;
       }
 
-      /* Held at the first frame until the bundle is live (see the note above). */
-      .splash * {
-        animation-play-state: paused;
-      }
-      html.splash-live .splash * {
-        animation-play-state: running;
-      }
       @media (prefers-reduced-motion: reduce) {
         .splash * {
           animation: none !important;

--- a/src/lib/splash.ts
+++ b/src/lib/splash.ts
@@ -1,0 +1,41 @@
+// The startup splash lives as static markup in index.html (the mascot waking
+// up where the lock screen will draw it). Its animations are authored paused
+// so they start when the bundle is live — which is also when window.rs reveals
+// the window — instead of running unseen behind a hidden window. This starts
+// them and reports when the last one has ended, so the first React frame can
+// take over from the resting pose rather than mid-motion.
+
+const LAST = '[data-splash-last]'
+// The choreography ends around 1.4s; past this the app renders regardless, so
+// a missed `animationend` can never hold the UI hostage.
+const CAP_MS = 1600
+
+const reducedMotion = (): boolean => {
+  try {
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Start the splash and resolve once it has settled. Resolves at once when
+ * there is no splash to wait for (tests, a reduced-motion user who sees the
+ * resting pose immediately).
+ */
+export const runSplash = (): Promise<void> => {
+  document.documentElement.classList.add('splash-live')
+  const last = document.querySelector(LAST)
+  if (!last || reducedMotion()) return Promise.resolve()
+
+  return new Promise(resolve => {
+    const timer = setTimeout(resolve, CAP_MS)
+    // `animationend` bubbles, so the descendants' animations would arrive here
+    // too; only the marked element's own end counts.
+    last.addEventListener('animationend', event => {
+      if (event.target !== last) return
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}

--- a/src/lib/splash.ts
+++ b/src/lib/splash.ts
@@ -1,9 +1,12 @@
-// The startup splash lives as static markup in index.html (the mascot waking
-// up where the lock screen will draw it). Its animations are authored paused
-// so they start when the bundle is live — which is also when window.rs reveals
-// the window — instead of running unseen behind a hidden window. This starts
-// them and reports when the last one has ended, so the first React frame can
-// take over from the resting pose rather than mid-motion.
+// The startup splash lives as static markup in index.html: the mascot at rest
+// where the lock screen will draw it, with a wake-up choreography that only
+// applies once `splash-live` is on <html>. Gating it on the bundle means it
+// starts when the bundle is live — which is also when window.rs reveals the
+// window — instead of running unseen behind a hidden one, and that a bundle
+// which never runs leaves a whole mascot for window.rs's fallback reveal, not
+// a blank frame. This flips the gate and reports when the last animation has
+// ended, so the first React frame can take over from the resting pose rather
+// than mid-motion.
 
 const LAST = '[data-splash-last]'
 // The choreography ends around 1.4s; past this the app renders regardless, so

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,17 +6,23 @@ import { runStartupUpdateCheck } from './services/autoUpdate'
 import { applyPlatform } from './utils/platform'
 import { applyTheme, getTheme } from './theme'
 import { i18nReady } from './i18n'
+import { runSplash } from './lib/splash'
 import './shortcuts'
 // Design tokens + base (Tailwind v4). Sole stylesheet now the SASS is gone.
 // Type comes from the OS system stack (see --font-sans) — no bundled webfonts.
 import './styles/theme.css'
 
 applyPlatform()
+// Theme first: the splash in index.html recolors off `data-theme` the moment
+// it is set, before its animation starts.
 applyTheme(getTheme())
+const splashSettled = runSplash()
 
 // Awaiting the catalog before the first paint means no flash of English on a
 // non-default language, and no Suspense boundary threaded through the tree.
-void i18nReady.then(() =>
+// Awaiting the splash means the lock screen takes over from the mascot at rest
+// (same pixels), so the swap reads as one continuous scene.
+void Promise.all([i18nReady, splashSettled]).then(() =>
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <App />

--- a/tests/e2e/helpers/app.ts
+++ b/tests/e2e/helpers/app.ts
@@ -7,3 +7,40 @@ export async function waitFor(testid: string, timeout = 15_000): Promise<void> {
 export async function waitForAppReady(timeout = 15_000): Promise<void> {
   await waitFor("main-view", timeout);
 }
+
+type Tagged = { __e2eOutgoing?: boolean };
+
+/**
+ * Reload the page and wait for the NEW document to answer.
+ *
+ * The in-app WebDriver server's `refresh` returns as soon as the reload is
+ * requested, before the navigation commits, so a lookup right after it can
+ * still resolve against the outgoing document — and a click there is lost
+ * when that document is torn down a few milliseconds later (seen on CI: the
+ * setup spec clicked "start setup" on the old page and then waited forever
+ * for a form the new page never opened). Tagging the outgoing document and
+ * waiting for one without the tag turns the reload into a real barrier.
+ */
+export async function reload(): Promise<void> {
+  await browser.execute(() => {
+    (window as unknown as Tagged).__e2eOutgoing = true;
+  });
+  await browser.refresh();
+  await browser.waitUntil(
+    async () => {
+      try {
+        return await browser.execute(
+          () => !(window as unknown as Tagged).__e2eOutgoing,
+        );
+      } catch {
+        // Mid-navigation: no document to run in yet.
+        return false;
+      }
+    },
+    {
+      timeout: 30_000,
+      interval: 50,
+      timeoutMsg: "[e2e] the page never reloaded into a fresh document",
+    },
+  );
+}

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -1,4 +1,4 @@
-export { waitFor, waitForAppReady } from "./app";
+export { waitFor, waitForAppReady, reload } from "./app";
 export { chord, pressEnter, pressArrowDown } from "./keys";
 export { setRange } from "./inputs";
 export { resetPristine, resetEmpty } from "./reset";

--- a/tests/e2e/helpers/reset.ts
+++ b/tests/e2e/helpers/reset.ts
@@ -1,4 +1,4 @@
-import { waitFor } from "./app";
+import { reload, waitFor } from "./app";
 
 /**
  * Per-spec state isolation.
@@ -82,7 +82,7 @@ async function reset(mode: ResetMode, password?: string): Promise<void> {
     localStorage.setItem("locale", "en-US");
   });
 
-  await browser.refresh();
+  await reload();
 }
 
 /** No vault on disk: the app lands on the first-run setup choice screen. */

--- a/tests/e2e/specs/setup.spec.ts
+++ b/tests/e2e/specs/setup.spec.ts
@@ -1,4 +1,10 @@
-import { entryItems, resetPristine, waitFor, waitForAppReady } from "../helpers";
+import {
+  entryItems,
+  reload,
+  resetPristine,
+  waitFor,
+  waitForAppReady,
+} from "../helpers";
 
 // First-run setup: the two gates that stand between a fresh install and a
 // vault (strength, confirmation) plus the back/forward navigation around them.
@@ -62,7 +68,7 @@ describe("first-run setup", () => {
 
     // Nothing was written: a reload re-runs `is_initialized` against disk, and
     // the app offers first-run setup again rather than an unlock screen.
-    await browser.refresh();
+    await reload();
     await waitFor("start-setup-button");
     await expect($('[data-testid="unlock-password-input"]')).not.toBeDisplayed();
   });

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -23,6 +23,8 @@ const APP_BINARY =
   process.env.SWIFTY_APP_BINARY ??
   path.join(ROOT, "src-tauri", "target", "debug", "swifty");
 
+const VITE_PORT = process.env.E2E_VITE_PORT ?? "1420";
+
 const TEST_DB_DIR = path.join(os.tmpdir(), `swifty-e2e-${Date.now()}`);
 
 const SPECS_DIR = path.join(__dirname, "specs");
@@ -90,15 +92,19 @@ async function waitForPort(
     if (exitCode !== null) {
       throw new Error(`[e2e] ${label} process exited with code ${exitCode} before port ${port} opened`);
     }
-    const open = await new Promise<boolean>((resolve) => {
-      const s = net.connect(port, "127.0.0.1");
-      s.once("connect", () => { s.destroy(); resolve(true); });
-      s.once("error", () => { s.destroy(); resolve(false); });
-    });
-    if (open) return;
+    if (await portOpen(port)) return;
     await new Promise<void>((r) => setTimeout(r, 250));
   }
   throw new Error(`[e2e] ${label} did not open port ${port} within ${timeoutMs}ms`);
+}
+
+/** One TCP connect attempt: is something listening on `port` right now? */
+function portOpen(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const s = net.connect(port, "127.0.0.1");
+    s.once("connect", () => { s.destroy(); resolve(true); });
+    s.once("error", () => { s.destroy(); resolve(false); });
+  });
 }
 
 export const config: WebdriverIO.Config = {
@@ -138,12 +144,15 @@ export const config: WebdriverIO.Config = {
     fs.mkdirSync(TEST_DB_DIR, { recursive: true });
 
     // Start the Vite dev server — the debug binary loads the frontend from
-    // http://localhost:1420 (baked in at compile time by tauri-build).
+    // http://localhost:1420 (baked in at compile time by tauri-build; a binary
+    // built with another `build.devUrl` needs E2E_VITE_PORT to match). Strict:
+    // if the port is taken, fail here rather than let Vite drift to the next
+    // one while the app, and this readiness probe, talk to whatever holds it.
     console.log("[e2e] Starting Vite dev server...");
     // Invoke the vite binary directly — avoids relying on `bun` being in PATH
     // when wdio is running under Node.js.
     const viteBin = path.join(ROOT, "node_modules", ".bin", "vite");
-    viteProcess = spawn(viteBin, ["--port", "1420"], {
+    viteProcess = spawn(viteBin, ["--port", VITE_PORT, "--strictPort"], {
       cwd: ROOT,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env },
@@ -160,11 +169,20 @@ export const config: WebdriverIO.Config = {
       }
     });
     // Use HTTP polling — avoids IPv4/IPv6 mismatch that TCP connect can hit
-    await waitForHttp("http://localhost:1420", 30_000, "Vite");
-    console.log("[e2e] Vite ready on :1420");
+    await waitForHttp(`http://localhost:${VITE_PORT}`, 30_000, "Vite");
+    console.log(`[e2e] Vite ready on :${VITE_PORT}`);
 
     // Start the app binary — it loads the frontend from Vite and starts
-    // the WebDriver server on :4445.
+    // the WebDriver server on :4445. That port must be ours to open: another
+    // debug Swifty already running (a second checkout's dev app, say) holds
+    // it, the single-instance plugin quietly exits the binary we spawn, and
+    // the whole suite then drives the wrong app. Seen locally; every reset
+    // was refused by the SWIFTY_E2E gate, but nothing else would have been.
+    if (await portOpen(4445)) {
+      throw new Error(
+        "[e2e] port 4445 is already in use — is another Swifty instance running? Quit it first.",
+      );
+    }
     console.log(`[e2e] Starting app (${APP_BINARY})`);
     appProcess = spawn(APP_BINARY, [], {
       cwd: ROOT,


### PR DESCRIPTION
## Summary

Fills the blank window at startup with a static splash: the mascot waking up in the exact spot the lock screen then draws it, so the first React frame reads as a continuation of the same scene.

- **`index.html`** — the mascot (a literal copy of the AsteriskBody geometry, soften filter and Mascot face) as static markup inside `#root`, styled by an inline `<style>` block (CSP permits inline styles; no inline script is needed). The hub pops in, the six spikes grow out of it clockwise while the body winds into place, then the eyes open, glance around and settle into the idle pose with the same 6.8s blink. React's first commit replaces the container, so there is no teardown code.
- **`src/lib/splash.ts`** (new) — the animations are authored paused; this starts them by adding `splash-live` to `<html>` when the bundle runs (which is also when `window.rs` reveals the window) and resolves when the last animation ends, capped at 1.6s. Resolves immediately for reduced-motion users, who see the resting pose straight away.
- **`src/main.tsx`** — waits for both `i18nReady` and the splash before mounting, so the lock screen takes over from the resting pose rather than mid-motion.

Colours key off the OS colour scheme until `data-theme` is set (synchronously, before the animation starts), then off the app's actual theme. The compact shell's padding (safe-area insets, gutters, reserved bottom chrome) is mirrored under the same 767px cut as `useLayout`, so the mascot lands where `LockScreen` draws it on phones too.

## Verification

- `tsc --noEmit` and eslint pass; the full vitest suite passes (57 files, 612 tests).
- In headless Chromium, the splash mascot's bounding box was compared against the mounted lock-screen mascot at phone portrait (390×844), phone landscape (844×390), small tablet (768×1024) and desktop (1040×700), in both themes. All match to within 0.08px (the eyebrow's fractional line height).
- Frames captured at fixed points on the timeline confirm each phase renders as intended.

## Notes

- Geometry, colours and layout numbers are literal copies of what the app computes; each is commented with its source. Changing the mascot or the auth layout means mirroring the change here.
- The real iOS build was not run; the safe-area insets come from the same `env()` values the shell uses.
- On a fresh install the app switches to the setup flow right after mounting, so the mascot shows briefly and then the setup screen replaces it.