### PR TITLE
feat(share): one-time credential sharing over the sender's own Drive (backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@
 GOOGLE_OAUTH_CLIENT_ID=""
 GOOGLE_OAUTH_CLIENT_SECRET=""
 
+# --- Google API key for receiving shared secrets (baked in at compile time,
+#     src-tauri/src/share/remote.rs). A public identifier, not a secret: it only
+#     lets the app download "anyone with the link" share files without a Google
+#     login. Create one in Google Cloud Console → APIs & Services → Credentials
+#     and restrict it to the Google Drive API. Leave empty to build with
+#     receiving disabled. ---
+GOOGLE_API_KEY=""
+
 # --- macOS code signing + notarization (Apple Developer ID) ---
 # The full identity string from `security find-identity -v -p codesigning`.
 # Must be the "Developer ID Application" certificate: "Apple Development" and

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -24,6 +24,9 @@
 #                               (src-tauri/src/sync/auth.rs). iOS OAuth clients have no
 #                               client secret, so GOOGLE_OAUTH_CLIENT_SECRET is
 #                               deliberately not set here.
+#   GOOGLE_API_KEY              Public Drive API key for receiving shared secrets
+#                               without a login, baked in at compile time
+#                               (src-tauri/src/share/remote.rs). Same key as desktop.
 #
 # Signing is fully automatic: the App Store Connect API key lets Xcode create
 # and download the Apple Distribution certificate and the App Store provisioning
@@ -131,6 +134,7 @@ jobs:
           # Google Drive sync OAuth client, read via option_env! at compile time.
           # iOS clients are public: there is no client secret to set.
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_IOS_CLIENT_ID }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           bun run tauri ios build --ci \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@
 #   TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)                minisign key for updater artifact signatures
 #   GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET Desktop OAuth client, baked in at compile time
 #                                                       (src-tauri/src/sync/auth.rs)
+#   GOOGLE_API_KEY                                      Drive API key for receiving shared secrets, baked
+#                                                       in at compile time (src-tauri/src/share/remote.rs)
 # Windows installers are not code-signed (no certificate). macOS is signed and notarized.
 #
 # Before the build starts, the Tauri CLI checks that every @tauri-apps/* npm
@@ -112,6 +114,8 @@ jobs:
           # Google Drive sync OAuth client, read via option_env! at compile time.
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          # Public Drive API key for receiving shared secrets without a login.
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
           tagName: v__VERSION__
           releaseName: Swifty v__VERSION__

--- a/docs/share-design.md
+++ b/docs/share-design.md
@@ -1,0 +1,113 @@
+# Sharing a secret — one-time, over the sender's own Drive
+
+Status: v1. Backend module `src-tauri/src/share`, frontend `src/components/Main/Share`.
+
+Swifty has no server, and sharing does not add one. A share is a sealed copy of
+one entry that lives for a day in the sender's own Google Drive. The recipient
+opens it with a link, and the link is the only secret.
+
+## 1. What the user is trying to do
+
+- Hand a colleague the Wi-Fi password, a shared inbox login or an API key
+  without pasting it into a chat where it stays forever.
+- Do it from a phone as easily as from a laptop.
+- Receive one without signing up for anything.
+
+Two flows follow: **send**, which produces a link, and **receive**, which turns
+a link into a new entry in the recipient's vault. There is no live link between
+the two copies: once received, the entry is the recipient's, and later edits on
+either side stay where they were made.
+
+## 2. Trust model in one paragraph
+
+The sender's app generates a fresh random 256-bit key, seals the entry with
+AES-256-GCM under it, uploads the ciphertext to a `Swifty/Shares` folder in the
+sender's Drive, and marks that one file readable by anyone who knows its id.
+The link carries the file id and the key. Google holds ciphertext and sees that
+a share was made, but never the key. The recipient's app downloads the file with
+a public API key (no login) and unseals it locally. Whoever gets the link before
+it expires gets the credential, so the link must travel over a channel the
+sender already trusts, and it stops working after 24 hours or when revoked.
+
+## 3. Formats
+
+Link, one pasteable token:
+
+```
+swifty://share#v1.<driveFileId>.<key>
+```
+
+`key` is the 32 key bytes, base64url without padding. Nothing fetches this URL;
+the scheme exists so the token is unambiguous and could register as a deep link
+later.
+
+Envelope (plaintext before sealing):
+
+```json
+{ "v": 1, "entry": { ...sanitized Entry... } }
+```
+
+Sealed with the same AES-256-GCM helper the vault uses for entry payloads
+(`crypto::seal_aead`): a random 16-byte nonce is prepended to the ciphertext.
+
+Sanitizing strips what must not travel: the entry id (the recipient assigns a
+fresh one), the timestamps, the favorite flag, and any passkeys — a copied
+passkey is a second authenticator nobody registered. Tags and custom fields are
+kept.
+
+## 4. Drive layout
+
+```
+Swifty/                 the existing sync folder
+  vault.swsync          the vault pack, untouched by sharing
+  Shares/
+    <random>.swshare    one share, appProperties: entryId, kind, expiresAt
+```
+
+`appProperties` is the only metadata written. `entryId` is the sender's local
+id, an opaque UUID that lets the sender's own UI show a title for an active
+share without revealing it to Drive. `kind` is the entry type. `expiresAt` is
+unix milliseconds.
+
+## 5. Lifetime and control
+
+- Fixed 24-hour lifetime in v1.
+- **Revoke** deletes the file. From the send dialog right after creating the
+  link, or later from Settings › Sync › Shared links.
+- **Sweep** lists `Shares/` and deletes anything past `expiresAt`. It runs at
+  the end of every successful sync and whenever the active shares list is
+  opened. Because the truth lives in Drive rather than a local ledger, any of the
+  sender's devices can revoke or clean up, and nothing new is stored locally.
+- The recipient's app treats a missing file as "expired or revoked" and says so.
+
+True one-time delivery cannot be enforced without a server. Expiry plus revoke
+is the honest approximation.
+
+## 6. What each side needs
+
+| | Google account | Network | Env |
+|---|---|---|---|
+| Send | Drive connected (existing sync OAuth, `drive.file` scope) | yes | `GOOGLE_OAUTH_CLIENT_ID` |
+| Receive | none | yes | `GOOGLE_API_KEY` |
+
+The API key is a public identifier restricted to the Drive API, baked in at
+compile time like the OAuth client id. A build without it can send but not
+receive, and the receive dialog says which key is missing.
+
+## 7. Backend API
+
+`share::create(app, cryptor, entry_id) -> Created { link, file_id, expires_at }`
+`share::open(link) -> Entry` (sanitized, empty id)
+`share::revoke(app, cryptor, file_id)`
+`share::list(app, cryptor) -> Vec<ActiveShare>` (also sweeps)
+`share::sweep(app, cryptor) -> usize`
+
+Exposed to the frontend as `share_create`, `share_open`, `share_revoke`,
+`share_list`. All Drive calls run off the async runtime via `spawn_blocking`,
+the way sync does.
+
+## 8. Out of scope for v1
+
+Live one-way and two-way shares (a separately keyed pack with Drive per-user
+permissions, syncing through the existing engine), configurable expiry, QR
+codes, deep-link opening of the token, and any recipient-side burn-on-read.

--- a/docs/share-design.md
+++ b/docs/share-design.md
@@ -1,10 +1,16 @@
-# Sharing a secret — one-time, over the sender's own Drive
+# Sharing a secret — by link, over the sender's own Drive
 
 Status: v1. Backend module `src-tauri/src/share`, frontend `src/components/Main/Share`.
 
 Swifty has no server, and sharing does not add one. A share is a sealed copy of
 one entry that lives for a day in the sender's own Google Drive. The recipient
 opens it with a link, and the link is the only secret.
+
+What this is, precisely: a bearer-link transfer of a snapshot. It does not
+authenticate a named recipient, does not propagate later changes, and is not
+burn-after-reading. Whoever holds the link can open the share until it expires
+or is revoked; revoking stops future downloads but cannot retract a credential
+already imported. The UI is written to promise exactly that and no more.
 
 ## 1. What the user is trying to do
 
@@ -44,16 +50,24 @@ later.
 Envelope (plaintext before sealing):
 
 ```json
-{ "v": 1, "entry": { ...sanitized Entry... } }
+{ "v": 1, "expiresAt": 1700086400000, "entry": { ...sanitized Entry... } }
 ```
 
 Sealed with the same AES-256-GCM helper the vault uses for entry payloads
 (`crypto::seal_aead`): a random 16-byte nonce is prepended to the ciphertext.
+The expiry sits inside the ciphertext, so it is authenticated by the same tag
+as the entry: nobody holding the file, Drive included, can extend it.
 
 Sanitizing strips what must not travel: the entry id (the recipient assigns a
 fresh one), the timestamps, the favorite flag, and any passkeys — a copied
 passkey is a second authenticator nobody registered. Tags and custom fields are
-kept.
+kept. It runs on **both** ends. On send, so nothing leaves that should not. On
+receipt, because the plaintext is whatever the link's author sealed: a crafted
+envelope naming an existing row's id must not be able to replace that row.
+Receipt also refuses an unknown entry kind and anything past its expiry.
+
+A login whose only secret is a passkey is refused at share time with a plain
+message, rather than arriving as a username and nothing else.
 
 ## 4. Drive layout
 
@@ -61,27 +75,40 @@ kept.
 Swifty/                 the existing sync folder
   vault.swsync          the vault pack, untouched by sharing
   Shares/
-    <random>.swshare    one share, appProperties: entryId, kind, expiresAt
+    <random>.swshare    one share, appProperties: swiftyShare, entryId, kind, expiresAt
 ```
 
-`appProperties` is the only metadata written. `entryId` is the sender's local
-id, an opaque UUID that lets the sender's own UI show a title for an active
-share without revealing it to Drive. `kind` is the entry type. `expiresAt` is
-unix milliseconds.
+`appProperties` is the only metadata written. `swiftyShare=1` is the marker
+every share carries, and the only thing listing selects on: shares are found by
+it wherever they sit, so two devices racing to create `Shares/` and uploading
+into their own copies hide nothing from the sweep or the revoke list. The
+folder is only created by an upload, never by a listing, so accounts that never
+share never gain one. `entryId` is the sender's local id, an opaque UUID that
+lets the sender's own UI show a title without revealing it to Drive. `kind` is
+the entry type. `expiresAt` is unix milliseconds, a duplicate of the
+authenticated copy inside the envelope, there so the sweep can date a file
+without its key. Listings follow `nextPageToken` to the end.
 
 ## 5. Lifetime and control
 
-- Fixed 24-hour lifetime in v1.
+- Fixed 24-hour lifetime in v1, enforced where it can be: the recipient's app
+  refuses an envelope whose authenticated `expiresAt` has passed, whether or
+  not the file is still there. Deletion is the cleanup, not the enforcement.
 - **Revoke** deletes the file. From the send dialog right after creating the
   link, or later from Settings › Sync › Shared links.
-- **Sweep** lists `Shares/` and deletes anything past `expiresAt`. It runs at
-  the end of every successful sync and whenever the active shares list is
-  opened. Because the truth lives in Drive rather than a local ledger, any of the
-  sender's devices can revoke or clean up, and nothing new is stored locally.
+- **Sweep** lists every marked share and deletes anything past `expiresAt`. It
+  runs at the end of every successful sync and whenever the active shares list
+  is opened. Because the truth lives in Drive rather than a local ledger, any
+  of the sender's devices can revoke or clean up, and nothing new is stored
+  locally. A share with no readable expiry is never treated as expired.
 - The recipient's app treats a missing file as "expired or revoked" and says so.
+- The recipient downloads at most 2 MiB, checked against the declared length
+  and again while streaming, with a 30-second deadline: the id in a pasted link
+  can name any public file on Drive.
 
-True one-time delivery cannot be enforced without a server. Expiry plus revoke
-is the honest approximation.
+Burn-after-reading cannot be enforced without a server. Expiry plus revoke is
+the honest approximation, and the UI says "expires" and "revoke", not "one
+time".
 
 ## 6. What each side needs
 
@@ -96,11 +123,14 @@ receive, and the receive dialog says which key is missing.
 
 ## 7. Backend API
 
-`share::create(app, cryptor, entry_id) -> Created { link, file_id, expires_at }`
-`share::open(link) -> Entry` (sanitized, empty id)
-`share::revoke(app, cryptor, file_id)`
-`share::list(app, cryptor) -> Vec<ActiveShare>` (also sweeps)
-`share::sweep(app, cryptor) -> usize`
+`share::create(remote, entry, now_ms) -> Created { link, file_id, expires_at }`
+`share::open(fetch, link, now_ms) -> Entry` (sanitized, empty id, unexpired)
+`share::revoke(remote, file_id)`
+`share::list(remote, now_ms) -> Vec<ActiveShare>` (also sweeps)
+`share::sweep(remote, now_ms) -> usize`
+
+Generic over `ShareRemote` and `PublicFetch`, so the whole lifecycle is tested
+against an in-memory fake.
 
 Exposed to the frontend as `share_create`, `share_open`, `share_revoke`,
 `share_list`. All Drive calls run off the async runtime via `spawn_blocking`,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -203,6 +203,26 @@ convert it into the encrypted database.)
   user consents to restart (or the next time they quit and reopen). This replaces
   the earlier silent-on-launch install.
 
+## Sharing a secret
+
+A share (see `docs/share-design.md`) is one entry, sanitized, sealed under a
+fresh random 256-bit AES-GCM key and uploaded to the sender's own Drive as an
+"anyone with the link" file. The link carries the file id and the key.
+
+- **Google** holds ciphertext, the file's creation time, the entry kind and the
+  sender's opaque local entry id. It never holds the key and cannot read the
+  entry. Neither the vault key nor the master passphrase is involved.
+- **The link is the secret.** Anyone who obtains it before it expires or is
+  revoked can open the share. Swifty cannot defend the channel the sender chose
+  to send it over; it limits the exposure to 24 hours and lets the sender revoke
+  earlier.
+- **Integrity.** AES-GCM authentication means a modified or substituted file
+  fails to open rather than yielding a tampered entry.
+- **The public API key** used to download shares is an identifier, not a
+  credential: it grants no access to anything not already public.
+- **One-time is approximate.** Without a server nothing can count reads. A
+  share stays openable until it expires or is revoked.
+
 ## What Swifty explicitly does NOT defend against
 
 - **A compromised operating system.** Code running as the user — malware, a

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -217,11 +217,22 @@ fresh random 256-bit AES-GCM key and uploaded to the sender's own Drive as an
   to send it over; it limits the exposure to 24 hours and lets the sender revoke
   earlier.
 - **Integrity.** AES-GCM authentication means a modified or substituted file
-  fails to open rather than yielding a tampered entry.
+  fails to open rather than yielding a tampered entry. The expiry is inside the
+  ciphertext, so it is authenticated too, and the recipient enforces it even
+  when the sender's device never got to delete the file.
+- **Sender-controlled content is not trusted.** Encryption proves the sender
+  held the key, not that the entry is well-formed. On receipt the entry is
+  sanitized again (id, timestamps, favorite, passkeys stripped), its kind is
+  checked, and it is always saved as a fresh row, so a crafted envelope cannot
+  overwrite an existing entry. Downloads are capped at 2 MiB and time-limited,
+  because a pasted link can name any public Drive file.
 - **The public API key** used to download shares is an identifier, not a
   credential: it grants no access to anything not already public.
-- **One-time is approximate.** Without a server nothing can count reads. A
-  share stays openable until it expires or is revoked.
+- **This is a bearer-link snapshot, not delivery to a person.** Nothing
+  authenticates the recipient, nothing propagates later edits, and without a
+  server nothing can count reads. A share stays openable until it expires or
+  is revoked; revoking stops future downloads but cannot retract a credential
+  already imported or erase a downloaded copy.
 
 ## What Swifty explicitly does NOT defend against
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod env;
 pub mod generator;
 pub mod import;
 pub mod save;
+pub mod share;
 pub mod sync;
 pub mod vault;
 

--- a/src-tauri/src/commands/share.rs
+++ b/src-tauri/src/commands/share.rs
@@ -47,7 +47,7 @@ pub async fn share_create(
 /// recipient may not even have a vault yet.
 #[tauri::command]
 pub async fn share_open(link: String) -> Result<Entry> {
-    blocking(move || share::open(&DrivePublicFetch, &link)).await
+    blocking(move || share::open(&DrivePublicFetch, &link, share::now_ms())).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/share.rs
+++ b/src-tauri/src/commands/share.rs
@@ -1,0 +1,98 @@
+//! Commands for one-time sharing. The logic is in [`crate::share`]; this is the
+//! boundary that turns a session into the credentials a Drive call needs.
+//!
+//! Two rules shape every command here. The session lock is taken, read and
+//! released before anything touches the network — a mutex held across an await
+//! would stall every other command for a round trip. And the Drive work runs on
+//! `spawn_blocking`, because the transport drives async calls with `block_on`,
+//! which deadlocks on a runtime worker (see `commands::sync::start_run`).
+
+use tauri::{AppHandle, State};
+
+use crate::crypto::Cryptor;
+use crate::error::{Error, Result};
+use crate::models::Entry;
+use crate::share::{self, remote::DrivePublicFetch, ActiveShare, Created};
+use crate::state::AppState;
+use crate::store::VaultStore;
+
+use super::store_err;
+
+/// Seal one of this vault's entries and publish it; returns the link.
+#[tauri::command]
+pub async fn share_create(
+    entry_id: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Created> {
+    let (entry, cryptor) = {
+        let session = state.session.lock().unwrap();
+        sendable(&session)?;
+        let record = session
+            .store()?
+            .get(&entry_id)
+            .map_err(store_err)?
+            .ok_or(Error::NotFound)?;
+        (
+            session.payload_cipher()?.unseal(&record.payload)?,
+            session.cryptor()?,
+        )
+    };
+
+    blocking(move || share::create(&share::drive_remote(&app, cryptor), &entry, share::now_ms()))
+        .await
+}
+
+/// Open a link someone sent. Needs no account and no unlocked vault — the
+/// recipient may not even have a vault yet.
+#[tauri::command]
+pub async fn share_open(link: String) -> Result<Entry> {
+    blocking(move || share::open(&DrivePublicFetch, &link)).await
+}
+
+#[tauri::command]
+pub async fn share_revoke(
+    file_id: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<()> {
+    let cryptor = sender_cryptor(&state)?;
+    blocking(move || share::revoke(&share::drive_remote(&app, cryptor), &file_id)).await
+}
+
+/// The sender's outstanding shares, expired ones swept first.
+#[tauri::command]
+pub async fn share_list(app: AppHandle, state: State<'_, AppState>) -> Result<Vec<ActiveShare>> {
+    let cryptor = sender_cryptor(&state)?;
+    blocking(move || share::list(&share::drive_remote(&app, cryptor), share::now_ms())).await
+}
+
+/// What the sending side requires. Checked in this order because a locked
+/// session also reports `sync_configured == false`, and telling someone to
+/// connect Drive when they merely need to unlock is a dead end.
+fn sendable(session: &crate::state::Session) -> Result<()> {
+    if !session.is_unlocked() {
+        return Err(Error::Locked);
+    }
+    if !session.sync_configured {
+        return Err(Error::SyncNotConfigured);
+    }
+    Ok(())
+}
+
+fn sender_cryptor(state: &State<'_, AppState>) -> Result<Cryptor> {
+    let session = state.session.lock().unwrap();
+    sendable(&session)?;
+    session.cryptor()
+}
+
+// A join error means the blocking thread panicked or was cancelled; there is no
+// inner result to report, so surface the join failure itself (as `sync_import`
+// does).
+async fn blocking<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    tauri::async_runtime::spawn_blocking(work)
+        .await
+        .map_err(|e| Error::Other(e.to_string()))?
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod passkey;
 // can drive the OCR backend without the app around it.
 pub mod scan;
 mod secure_store;
+mod share;
 mod state;
 mod storage;
 pub mod store;
@@ -153,6 +154,10 @@ pub fn run() {
             commands::sync::sync_now,
             commands::sync::sync_import,
             commands::sync::sync_status,
+            commands::share::share_create,
+            commands::share::share_open,
+            commands::share::share_revoke,
+            commands::share::share_list,
             // E2E-only vault reset. `generate_handler!` honours per-command
             // attributes, so in a release build the match arm — and with it the
             // only reference to the (also cfg'd-out) module — simply is not

--- a/src-tauri/src/share/envelope.rs
+++ b/src-tauri/src/share/envelope.rs
@@ -22,6 +22,15 @@ pub fn expires_at(now_ms: i64) -> i64 {
     now_ms + SHARE_TTL_MS
 }
 
+/// Shown to a recipient who opens a link past its expiry. Deleting the file is
+/// best effort (the sender may be offline), so this check is what actually
+/// enforces the 24 hours on the receiving side.
+pub const SHARE_EXPIRED: &str = "this share has expired";
+
+/// Every kind this build can store. A share carrying anything else is refused
+/// on receipt rather than saved as a row no view knows how to render.
+const KINDS: [&str; 6] = ["login", "note", "card", "identity", "ssh", "env"];
+
 const KEY_LEN: usize = 32;
 const VERSION: u8 = 1;
 const PREFIX: &str = "swifty://share#";
@@ -53,12 +62,32 @@ impl std::fmt::Debug for ShareKey {
     }
 }
 
+/// Refuse what sanitizing would silently hollow out. A login whose only secret
+/// is a passkey would arrive as a username and nothing else, and the sender
+/// would not know why; better to say so before a link exists.
+pub fn check_shareable(entry: &Entry) -> Result<()> {
+    let has_passkey = entry.passkeys.as_ref().is_some_and(|p| !p.is_empty());
+    let has_secret = [&entry.password, &entry.otp]
+        .iter()
+        .any(|v| v.as_deref().is_some_and(|s| !s.is_empty()));
+    if entry.kind == "login" && has_passkey && !has_secret {
+        return Err(Error::Other(
+            "this login holds only a passkey, and passkeys cannot be shared".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Strip everything the recipient's vault must decide for itself.
 ///
 /// The id is theirs to assign, the timestamps describe the sender's copy, the
 /// star is the sender's opinion, and a copied passkey would be a second
 /// authenticator the site never registered. Everything else — tags, extra
 /// fields, the secret itself — is the point of the share and travels intact.
+///
+/// Applied on both ends. Sending, so nothing leaves that should not; receiving,
+/// because the plaintext is whatever the link's author sealed, and a crafted
+/// envelope must not be able to name an existing row's id and replace it.
 pub fn sanitize(entry: &Entry) -> Entry {
     Entry {
         id: String::new(),
@@ -74,21 +103,30 @@ pub fn sanitize(entry: &Entry) -> Entry {
 /// The sealed plaintext. `entry` is generic so the reader can check the version
 /// before parsing it: a future format may shape the entry differently, and that
 /// has to read as "newer version", not as a parse failure.
+///
+/// The expiry rides inside the ciphertext, so it is authenticated by the same
+/// tag as the entry: nobody holding the file — Drive included — can extend it.
 #[derive(Serialize, Deserialize)]
 struct Envelope<E> {
     v: u8,
+    #[serde(rename = "expiresAt")]
+    expires_at: i64,
     entry: E,
 }
 
-pub fn seal(key: &ShareKey, entry: &Entry) -> Result<Vec<u8>> {
+pub fn seal(key: &ShareKey, entry: &Entry, expires_ms: i64) -> Result<Vec<u8>> {
     let plaintext = serde_json::to_vec(&Envelope {
         v: VERSION,
+        expires_at: expires_ms,
         entry: &sanitize(entry),
     })?;
     crate::crypto::seal_aead(key.as_ref(), &plaintext)
 }
 
-pub fn unseal(key: &ShareKey, blob: &[u8]) -> Result<Entry> {
+/// Open a share as of `now_ms`. What comes back is safe to save as a new row:
+/// expired, unknown-kind and sender-supplied identity are all refused or
+/// stripped here, before the frontend ever sees it.
+pub fn unseal(key: &ShareKey, blob: &[u8], now_ms: i64) -> Result<Entry> {
     // A wrong key and a tampered file are the same event to the user: the link
     // they have does not open this share. The AEAD error underneath says
     // nothing they can act on.
@@ -101,7 +139,17 @@ pub fn unseal(key: &ShareKey, blob: &[u8]) -> Result<Entry> {
             "this share was made by a newer version of Swifty".into(),
         ));
     }
-    Ok(serde_json::from_value(envelope.entry)?)
+    if envelope.expires_at <= now_ms {
+        return Err(Error::Other(SHARE_EXPIRED.into()));
+    }
+
+    let entry: Entry = serde_json::from_value(envelope.entry)?;
+    if !KINDS.contains(&entry.kind.as_str()) {
+        return Err(Error::Other(
+            "this share holds a kind of entry this version of Swifty does not know".into(),
+        ));
+    }
+    Ok(sanitize(&entry))
 }
 
 /// A whole share in one pasteable token: `swifty://share#v1.<fileId>.<key>`.
@@ -215,13 +263,19 @@ mod tests {
         .unwrap()
     }
 
+    const NOW: i64 = 1_700_000_000_000;
+
+    fn sealed(key: &ShareKey) -> Vec<u8> {
+        seal(key, &entry(), expires_at(NOW)).unwrap()
+    }
+
     #[test]
     fn seal_round_trips_the_entry_without_the_sender_s_copy() {
         let key = ShareKey::generate();
-        let blob = seal(&key, &entry()).unwrap();
+        let blob = sealed(&key);
         assert!(!blob.windows(6).any(|w| w == b"s3cret"));
 
-        let back = unseal(&key, &blob).unwrap();
+        let back = unseal(&key, &blob, NOW).unwrap();
         assert_eq!(back.title, "Site");
         assert_eq!(back.password.as_deref(), Some("s3cret"));
         assert_eq!(back.otp.as_deref(), Some("SEED"));
@@ -243,31 +297,101 @@ mod tests {
     #[test]
     fn tampered_ciphertext_does_not_open() {
         let key = ShareKey::generate();
-        let mut blob = seal(&key, &entry()).unwrap();
+        let mut blob = sealed(&key);
         let last = blob.len() - 1;
         blob[last] ^= 1;
         assert_eq!(
-            unseal(&key, &blob).unwrap_err().to_string(),
+            unseal(&key, &blob, NOW).unwrap_err().to_string(),
             "this link does not open the share"
         );
     }
 
     #[test]
     fn wrong_key_does_not_open() {
-        let blob = seal(&ShareKey::generate(), &entry()).unwrap();
-        assert!(unseal(&ShareKey::generate(), &blob).is_err());
+        let blob = sealed(&ShareKey::generate());
+        assert!(unseal(&ShareKey::generate(), &blob, NOW).is_err());
     }
 
     #[test]
     fn a_newer_envelope_version_is_refused() {
         let key = ShareKey::generate();
-        let plaintext =
-            serde_json::to_vec(&json!({"v": 2, "entry": {"shape": "unknown"}})).unwrap();
+        let plaintext = serde_json::to_vec(
+            &json!({"v": 2, "expiresAt": i64::MAX, "entry": {"shape": "unknown"}}),
+        )
+        .unwrap();
         let blob = crate::crypto::seal_aead(key.as_ref(), &plaintext).unwrap();
         assert_eq!(
-            unseal(&key, &blob).unwrap_err().to_string(),
+            unseal(&key, &blob, NOW).unwrap_err().to_string(),
             "this share was made by a newer version of Swifty"
         );
+    }
+
+    // The sender's device may never get to delete the file; the recipient's
+    // clock is what turns the link off.
+    #[test]
+    fn an_expired_envelope_is_refused_even_though_the_file_still_opens() {
+        let key = ShareKey::generate();
+        let blob = sealed(&key);
+        assert!(unseal(&key, &blob, NOW + SHARE_TTL_MS - 1).is_ok());
+        assert_eq!(
+            unseal(&key, &blob, NOW + SHARE_TTL_MS)
+                .unwrap_err()
+                .to_string(),
+            SHARE_EXPIRED
+        );
+    }
+
+    // Sealed by hand, the way an attacker would: the plaintext names an
+    // existing id and carries everything sanitizing normally strips.
+    fn crafted(key: &ShareKey, entry: serde_json::Value) -> Vec<u8> {
+        let plaintext =
+            serde_json::to_vec(&json!({"v": 1, "expiresAt": i64::MAX, "entry": entry})).unwrap();
+        crate::crypto::seal_aead(key.as_ref(), &plaintext).unwrap()
+    }
+
+    #[test]
+    fn a_crafted_envelope_cannot_smuggle_identity_or_passkeys_in() {
+        let key = ShareKey::generate();
+        let mut smuggled = serde_json::to_value(entry()).unwrap();
+        smuggled["id"] = json!("victim-row");
+        let back = unseal(&key, &crafted(&key, smuggled), NOW).unwrap();
+
+        assert_eq!(back.id, "");
+        assert!(back.created_at.is_none());
+        assert!(back.updated_at.is_none());
+        assert!(!back.favorite);
+        assert!(back.passkeys.is_none());
+        assert_eq!(back.password.as_deref(), Some("s3cret"));
+    }
+
+    #[test]
+    fn an_unknown_kind_is_refused_on_receipt() {
+        let key = ShareKey::generate();
+        let blob = crafted(&key, json!({"id": "", "type": "wallet", "title": "x"}));
+        assert_eq!(
+            unseal(&key, &blob, NOW).unwrap_err().to_string(),
+            "this share holds a kind of entry this version of Swifty does not know"
+        );
+    }
+
+    #[test]
+    fn a_passkey_only_login_cannot_be_shared_but_one_with_a_password_can() {
+        let with_password = entry();
+        assert!(check_shareable(&with_password).is_ok());
+
+        let mut passkey_only = entry();
+        passkey_only.password = None;
+        passkey_only.otp = Some(String::new());
+        assert_eq!(
+            check_shareable(&passkey_only).unwrap_err().to_string(),
+            "this login holds only a passkey, and passkeys cannot be shared"
+        );
+
+        let mut plain = entry();
+        plain.password = None;
+        plain.otp = None;
+        plain.passkeys = None;
+        assert!(check_shareable(&plain).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/share/envelope.rs
+++ b/src-tauri/src/share/envelope.rs
@@ -1,0 +1,346 @@
+//! The pure half of sharing: the one-time key, the sealed envelope, and the
+//! link that carries both halves of what a recipient needs.
+//!
+//! Nothing here touches the network, the vault or Tauri. The key is generated
+//! here and never leaves the sender's machine except inside the link, so Drive
+//! only ever holds bytes it cannot read.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use crate::error::{Error, Result};
+use crate::models::Entry;
+
+/// How long a share lives. Fixed rather than chosen: a share is meant to be
+/// opened now, and a dial the sender has to think about is one more way to
+/// leave a credential lying in someone else's Drive.
+pub const SHARE_TTL_MS: i64 = 24 * 60 * 60 * 1000;
+
+pub fn expires_at(now_ms: i64) -> i64 {
+    now_ms + SHARE_TTL_MS
+}
+
+const KEY_LEN: usize = 32;
+const VERSION: u8 = 1;
+const PREFIX: &str = "swifty://share#";
+const VERSION_TAG: &str = "v1";
+
+/// The AES-256 key a single share is sealed under. Fresh per share, never
+/// derived from the vault: losing it costs the recipient the share and nothing
+/// else.
+pub struct ShareKey(Zeroizing<[u8; KEY_LEN]>);
+
+impl ShareKey {
+    pub fn generate() -> Self {
+        let mut key = Zeroizing::new([0u8; KEY_LEN]);
+        rand::thread_rng().fill_bytes(&mut *key);
+        Self(key)
+    }
+}
+
+impl AsRef<[u8]> for ShareKey {
+    fn as_ref(&self) -> &[u8] {
+        &*self.0
+    }
+}
+
+// The key is the whole secret of a share, and links get logged.
+impl std::fmt::Debug for ShareKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ShareKey(redacted)")
+    }
+}
+
+/// Strip everything the recipient's vault must decide for itself.
+///
+/// The id is theirs to assign, the timestamps describe the sender's copy, the
+/// star is the sender's opinion, and a copied passkey would be a second
+/// authenticator the site never registered. Everything else — tags, extra
+/// fields, the secret itself — is the point of the share and travels intact.
+pub fn sanitize(entry: &Entry) -> Entry {
+    Entry {
+        id: String::new(),
+        created_at: None,
+        updated_at: None,
+        password_updated_at: None,
+        favorite: false,
+        passkeys: None,
+        ..entry.clone()
+    }
+}
+
+/// The sealed plaintext. `entry` is generic so the reader can check the version
+/// before parsing it: a future format may shape the entry differently, and that
+/// has to read as "newer version", not as a parse failure.
+#[derive(Serialize, Deserialize)]
+struct Envelope<E> {
+    v: u8,
+    entry: E,
+}
+
+pub fn seal(key: &ShareKey, entry: &Entry) -> Result<Vec<u8>> {
+    let plaintext = serde_json::to_vec(&Envelope {
+        v: VERSION,
+        entry: &sanitize(entry),
+    })?;
+    crate::crypto::seal_aead(key.as_ref(), &plaintext)
+}
+
+pub fn unseal(key: &ShareKey, blob: &[u8]) -> Result<Entry> {
+    // A wrong key and a tampered file are the same event to the user: the link
+    // they have does not open this share. The AEAD error underneath says
+    // nothing they can act on.
+    let plaintext = crate::crypto::unseal_aead(key.as_ref(), blob)
+        .map_err(|_| Error::Other("this link does not open the share".into()))?;
+
+    let envelope: Envelope<serde_json::Value> = serde_json::from_slice(&plaintext)?;
+    if envelope.v != VERSION {
+        return Err(Error::Other(
+            "this share was made by a newer version of Swifty".into(),
+        ));
+    }
+    Ok(serde_json::from_value(envelope.entry)?)
+}
+
+/// A whole share in one pasteable token: `swifty://share#v1.<fileId>.<key>`.
+///
+/// One token rather than a URL with query parameters, because both halves have
+/// to survive being pasted into a chat window by hand, and because a fragment
+/// keeps the key out of anything that would forward the link to a server.
+#[derive(Debug)]
+pub struct Link {
+    pub file_id: String,
+    pub key: ShareKey,
+}
+
+impl Link {
+    pub fn format(&self) -> String {
+        format!(
+            "{PREFIX}{VERSION_TAG}.{}.{}",
+            self.file_id,
+            URL_SAFE_NO_PAD.encode(self.key.as_ref())
+        )
+    }
+
+    pub fn parse(s: &str) -> Result<Link> {
+        let rest = s.trim().strip_prefix(PREFIX).ok_or_else(not_a_link)?;
+        let mut parts = rest.split('.');
+
+        let version = parts.next().unwrap_or_default();
+        if version != VERSION_TAG {
+            // A tag whose shape we recognize but whose number we don't can only
+            // come from a build that speaks a format this one doesn't.
+            return Err(if is_version_tag(version) {
+                newer_version()
+            } else {
+                not_a_link()
+            });
+        }
+
+        let file_id = parts.next().unwrap_or_default();
+        let key = parts.next().ok_or_else(incomplete)?;
+        if parts.next().is_some() {
+            return Err(not_a_link());
+        }
+
+        if file_id.is_empty() {
+            return Err(incomplete());
+        }
+        if !file_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        {
+            return Err(not_a_link());
+        }
+
+        // Held zeroized on the way in: this is the key, in the clear, for as
+        // long as the decode's buffer lives.
+        let decoded = Zeroizing::new(URL_SAFE_NO_PAD.decode(key).map_err(|_| incomplete())?);
+        if decoded.len() != KEY_LEN {
+            return Err(incomplete());
+        }
+        let mut bytes = Zeroizing::new([0u8; KEY_LEN]);
+        bytes.copy_from_slice(&decoded);
+
+        Ok(Link {
+            file_id: file_id.to_string(),
+            key: ShareKey(bytes),
+        })
+    }
+}
+
+fn is_version_tag(s: &str) -> bool {
+    matches!(s.strip_prefix('v'), Some(rest) if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+}
+
+// These reach the user verbatim, so they say what to do about it rather than
+// what failed.
+fn not_a_link() -> Error {
+    Error::Other("this is not a Swifty share link".into())
+}
+
+fn incomplete() -> Error {
+    Error::Other("this link is incomplete".into())
+}
+
+fn newer_version() -> Error {
+    Error::Other("this link was made by a newer version of Swifty".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry() -> Entry {
+        serde_json::from_value(json!({
+            "id": "entry-1", "type": "login", "title": "Site",
+            "website": "https://ex.com/login", "username": "alice",
+            "password": "s3cret", "otp": "SEED",
+            "tags": ["work", "eu"],
+            "extra": [{"label": "PIN", "value": "1234"}],
+            "favorite": true,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-02-01T00:00:00Z",
+            "password_updated_at": "2024-02-01T00:00:00Z",
+            "passkeys": [{
+                "credentialId": "Y3JlZA", "rpId": "ex.com",
+                "userHandle": "dXNlcg", "userName": "alice",
+                "userDisplayName": "Alice", "privateKey": "cHJpdmF0ZUtleQ",
+                "counter": 0
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn seal_round_trips_the_entry_without_the_sender_s_copy() {
+        let key = ShareKey::generate();
+        let blob = seal(&key, &entry()).unwrap();
+        assert!(!blob.windows(6).any(|w| w == b"s3cret"));
+
+        let back = unseal(&key, &blob).unwrap();
+        assert_eq!(back.title, "Site");
+        assert_eq!(back.password.as_deref(), Some("s3cret"));
+        assert_eq!(back.otp.as_deref(), Some("SEED"));
+        assert_eq!(back.username.as_deref(), Some("alice"));
+        assert_eq!(
+            back.tags.as_deref(),
+            Some(&["work".into(), "eu".into()][..])
+        );
+        assert_eq!(back.extra.unwrap()[0].value, "1234");
+
+        assert_eq!(back.id, "");
+        assert!(back.created_at.is_none());
+        assert!(back.updated_at.is_none());
+        assert!(back.password_updated_at.is_none());
+        assert!(!back.favorite);
+        assert!(back.passkeys.is_none());
+    }
+
+    #[test]
+    fn tampered_ciphertext_does_not_open() {
+        let key = ShareKey::generate();
+        let mut blob = seal(&key, &entry()).unwrap();
+        let last = blob.len() - 1;
+        blob[last] ^= 1;
+        assert_eq!(
+            unseal(&key, &blob).unwrap_err().to_string(),
+            "this link does not open the share"
+        );
+    }
+
+    #[test]
+    fn wrong_key_does_not_open() {
+        let blob = seal(&ShareKey::generate(), &entry()).unwrap();
+        assert!(unseal(&ShareKey::generate(), &blob).is_err());
+    }
+
+    #[test]
+    fn a_newer_envelope_version_is_refused() {
+        let key = ShareKey::generate();
+        let plaintext =
+            serde_json::to_vec(&json!({"v": 2, "entry": {"shape": "unknown"}})).unwrap();
+        let blob = crate::crypto::seal_aead(key.as_ref(), &plaintext).unwrap();
+        assert_eq!(
+            unseal(&key, &blob).unwrap_err().to_string(),
+            "this share was made by a newer version of Swifty"
+        );
+    }
+
+    #[test]
+    fn link_round_trips() {
+        let original = Link {
+            file_id: "1A-bC_dEfG".into(),
+            key: ShareKey::generate(),
+        };
+        let parsed = Link::parse(&original.format()).unwrap();
+        assert_eq!(parsed.file_id, original.file_id);
+        assert_eq!(parsed.key.as_ref(), original.key.as_ref());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        let original = Link {
+            file_id: "fileId".into(),
+            key: ShareKey::generate(),
+        };
+        let pasted = format!("  {}\n", original.format());
+        assert_eq!(Link::parse(&pasted).unwrap().file_id, "fileId");
+    }
+
+    #[test]
+    fn parse_refuses_anything_that_is_not_a_link() {
+        let key = URL_SAFE_NO_PAD.encode([7u8; KEY_LEN]);
+        for input in [
+            "https://example.com/share".to_string(),
+            format!("swifty://open#v1.fileId.{key}"),
+            format!("swifty://share#v1.file!d.{key}"),
+            format!("swifty://share#v1.fileId.{key}.extra"),
+        ] {
+            assert_eq!(
+                Link::parse(&input).unwrap_err().to_string(),
+                "this is not a Swifty share link",
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_refuses_an_incomplete_link() {
+        let key = URL_SAFE_NO_PAD.encode([7u8; KEY_LEN]);
+        for input in [
+            "swifty://share#v1.fileId".to_string(),
+            format!("swifty://share#v1..{key}"),
+            format!("swifty://share#v1.fileId.{}", &key[..20]),
+            format!(
+                "swifty://share#v1.fileId.{}",
+                URL_SAFE_NO_PAD.encode([7u8; 64])
+            ),
+        ] {
+            assert_eq!(
+                Link::parse(&input).unwrap_err().to_string(),
+                "this link is incomplete",
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_refuses_a_newer_link_version() {
+        let key = URL_SAFE_NO_PAD.encode([7u8; KEY_LEN]);
+        assert_eq!(
+            Link::parse(&format!("swifty://share#v2.fileId.{key}"))
+                .unwrap_err()
+                .to_string(),
+            "this link was made by a newer version of Swifty"
+        );
+    }
+
+    #[test]
+    fn expires_a_day_out() {
+        assert_eq!(expires_at(1_000), 1_000 + 24 * 60 * 60 * 1000);
+    }
+}

--- a/src-tauri/src/share/mod.rs
+++ b/src-tauri/src/share/mod.rs
@@ -26,11 +26,11 @@ use crate::models::Entry;
 use envelope::{Link, ShareKey, SHARE_TTL_MS};
 use remote::{
     DriveShareRemote, PublicFetch, ShareFile, ShareRemote, PROP_ENTRY_ID, PROP_EXPIRES_AT,
-    PROP_KIND,
+    PROP_KIND, PROP_SHARE, PROP_SHARE_VALUE,
 };
 
 /// A freshly published share, as the send dialog needs it.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Created {
     /// The whole share in one pasteable token. Never persisted anywhere.
@@ -54,17 +54,20 @@ pub struct ActiveShare {
 
 /// Seal `entry` and publish it, returning the link that opens it.
 pub fn create(remote: &impl ShareRemote, entry: &Entry, now_ms: i64) -> Result<Created> {
+    envelope::check_shareable(entry)?;
     let key = ShareKey::generate();
-    let sealed = envelope::seal(&key, entry)?;
+    let expires_ms = envelope::expires_at(now_ms);
+    let sealed = envelope::seal(&key, entry, expires_ms)?;
 
     // Read off the caller's entry, not the sealed copy: `seal` sanitizes the id
     // away, and this property is precisely what lets the sender's own list name
-    // a share that carries no title.
-    let expires_ms = envelope::expires_at(now_ms);
+    // a share that carries no title. The marker property is how every share is
+    // found again, whichever folder it landed in.
     let file_id = remote.upload(
         &file_name(),
         &sealed,
         &[
+            (PROP_SHARE, PROP_SHARE_VALUE),
             (PROP_ENTRY_ID, entry.id.as_str()),
             (PROP_KIND, entry.kind.as_str()),
             (PROP_EXPIRES_AT, &expires_ms.to_string()),
@@ -90,11 +93,13 @@ pub fn create(remote: &impl ShareRemote, entry: &Entry, now_ms: i64) -> Result<C
     })
 }
 
-/// Turn a link into the entry it carries. The recipient's whole side of this.
-pub fn open(fetch: &impl PublicFetch, link: &str) -> Result<Entry> {
+/// Turn a link into the entry it carries. The recipient's whole side of this:
+/// the result is already sanitized and checked against `now_ms`, so the
+/// frontend can hand it straight to the ordinary new-entry save.
+pub fn open(fetch: &impl PublicFetch, link: &str, now_ms: i64) -> Result<Entry> {
     let link = Link::parse(link)?;
     let sealed = fetch.download(&link.file_id)?;
-    envelope::unseal(&link.key, &sealed)
+    envelope::unseal(&link.key, &sealed, now_ms)
 }
 
 /// Delete one share now, whatever its expiry. The link stops working.

--- a/src-tauri/src/share/mod.rs
+++ b/src-tauri/src/share/mod.rs
@@ -1,0 +1,168 @@
+//! One-time credential sharing: seal one entry, park it in the sender's own
+//! Drive for a day, hand out a link that carries the key.
+//!
+//! [`envelope`] holds the crypto and the link format, [`remote`] the Drive
+//! folder. This module is the verb layer between them — create, open, revoke,
+//! sweep, list — and it is generic over the two transport traits so the whole
+//! lifecycle is testable without a network.
+//!
+//! The link is the only secret: it never reaches Drive, and nothing here stores
+//! it. What Drive holds is ciphertext plus three opaque properties, which is
+//! also the only ledger of outstanding shares — any of the sender's devices can
+//! therefore list, revoke and clean up, and a reinstall loses nothing.
+
+pub mod envelope;
+pub mod remote;
+#[cfg(test)]
+mod tests;
+
+use rand::RngCore;
+use serde::Serialize;
+use tauri::AppHandle;
+
+use crate::crypto::Cryptor;
+use crate::error::Result;
+use crate::models::Entry;
+use envelope::{Link, ShareKey, SHARE_TTL_MS};
+use remote::{
+    DriveShareRemote, PublicFetch, ShareFile, ShareRemote, PROP_ENTRY_ID, PROP_EXPIRES_AT,
+    PROP_KIND,
+};
+
+/// A freshly published share, as the send dialog needs it.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Created {
+    /// The whole share in one pasteable token. Never persisted anywhere.
+    pub link: String,
+    /// Kept so the dialog can revoke without re-parsing the link.
+    pub file_id: String,
+    pub expires_at: String,
+}
+
+/// One outstanding share in the sender's own list.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveShare {
+    pub file_id: String,
+    /// The sender's local entry id, which the UI resolves to a title.
+    pub entry_id: Option<String>,
+    pub kind: Option<String>,
+    pub created_at: String,
+    pub expires_at: String,
+}
+
+/// Seal `entry` and publish it, returning the link that opens it.
+pub fn create(remote: &impl ShareRemote, entry: &Entry, now_ms: i64) -> Result<Created> {
+    let key = ShareKey::generate();
+    let sealed = envelope::seal(&key, entry)?;
+
+    // Read off the caller's entry, not the sealed copy: `seal` sanitizes the id
+    // away, and this property is precisely what lets the sender's own list name
+    // a share that carries no title.
+    let expires_ms = envelope::expires_at(now_ms);
+    let file_id = remote.upload(
+        &file_name(),
+        &sealed,
+        &[
+            (PROP_ENTRY_ID, entry.id.as_str()),
+            (PROP_KIND, entry.kind.as_str()),
+            (PROP_EXPIRES_AT, &expires_ms.to_string()),
+        ],
+    )?;
+
+    // An uploaded file nobody can read is worse than no share at all: the link
+    // would go out and fail, and the orphan would sit in Drive until the sweep
+    // dated it. Take it back before reporting the failure.
+    if let Err(e) = remote.make_public(&file_id) {
+        let _ = remote.delete(&file_id);
+        return Err(e);
+    }
+
+    Ok(Created {
+        expires_at: rfc3339(expires_ms),
+        link: Link {
+            file_id: file_id.clone(),
+            key,
+        }
+        .format(),
+        file_id,
+    })
+}
+
+/// Turn a link into the entry it carries. The recipient's whole side of this.
+pub fn open(fetch: &impl PublicFetch, link: &str) -> Result<Entry> {
+    let link = Link::parse(link)?;
+    let sealed = fetch.download(&link.file_id)?;
+    envelope::unseal(&link.key, &sealed)
+}
+
+/// Delete one share now, whatever its expiry. The link stops working.
+pub fn revoke(remote: &impl ShareRemote, file_id: &str) -> Result<()> {
+    remote.delete(file_id)
+}
+
+/// Delete every share whose expiry is known and has passed; returns how many.
+pub fn sweep(remote: &impl ShareRemote, now_ms: i64) -> Result<usize> {
+    let mut deleted = 0;
+    for file in remote.list()? {
+        // An absent expiry is "not known", never "expired": revoking a link the
+        // sender is still handing out because we failed to date it would be a
+        // far worse failure than leaving one file a day too long.
+        if file.expires_ms.is_some_and(|at| at <= now_ms) {
+            remote.delete(&file.id)?;
+            deleted += 1;
+        }
+    }
+    Ok(deleted)
+}
+
+/// The sender's outstanding shares, swept first so the list is never showing
+/// something a recipient can no longer open.
+pub fn list(remote: &impl ShareRemote, now_ms: i64) -> Result<Vec<ActiveShare>> {
+    sweep(remote, now_ms)?;
+    Ok(remote.list()?.iter().map(active_share).collect())
+}
+
+fn active_share(file: &ShareFile) -> ActiveShare {
+    ActiveShare {
+        file_id: file.id.clone(),
+        entry_id: file.entry_id.clone(),
+        kind: file.kind.clone(),
+        created_at: rfc3339(file.created_ms),
+        // A share we could not date still has to tell the user when it goes:
+        // the TTL from its creation is the expiry it was given, whether or not
+        // the property survived.
+        expires_at: rfc3339(
+            file.expires_ms
+                .unwrap_or_else(|| file.created_ms + SHARE_TTL_MS),
+        ),
+    }
+}
+
+/// A name that says nothing. Drive shows the owner a file list, so the name
+/// carries no title — only enough randomness never to collide.
+fn file_name() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("{}.swshare", hex::encode(bytes))
+}
+
+fn rfc3339(ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(ms)
+        .unwrap_or(chrono::DateTime::UNIX_EPOCH)
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+pub(crate) fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+pub fn drive_remote(app: &AppHandle, cryptor: Cryptor) -> DriveShareRemote {
+    DriveShareRemote::new(app.clone(), cryptor)
+}
+
+/// The sweep as the end of a sync run calls it.
+pub fn sweep_drive(app: &AppHandle, cryptor: Cryptor) -> Result<usize> {
+    sweep(&drive_remote(app, cryptor), now_ms())
+}

--- a/src-tauri/src/share/remote.rs
+++ b/src-tauri/src/share/remote.rs
@@ -28,6 +28,19 @@ pub const SHARES_FOLDER: &str = "Shares";
 pub const PROP_ENTRY_ID: &str = "entryId";
 pub const PROP_KIND: &str = "kind";
 pub const PROP_EXPIRES_AT: &str = "expiresAt";
+/// The marker every share carries, and the only thing a listing selects on:
+/// shares are found by it wherever they sit, so a duplicate `Shares` folder
+/// created by a racing device hides nothing from the sweep or the revoke list.
+pub const PROP_SHARE: &str = "swiftyShare";
+pub const PROP_SHARE_VALUE: &str = "1";
+
+/// The most a share file may be. An entry is a few kilobytes; an `.env` file
+/// a few hundred at the outside. The id in a pasted link can name any public
+/// file on Drive, so the recipient never buffers more than this.
+pub const MAX_SHARE_BYTES: usize = 2 * 1024 * 1024;
+
+/// How long the recipient waits on Drive before giving up.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// One outstanding share, as the sender's UI sees it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -171,10 +184,8 @@ impl ShareRemote for DriveShareRemote {
         block_on(async {
             let client = http_client();
             let token = self.token(&client).await?;
-            let Some(folder) = self.find_folder(&client, &token).await? else {
-                return Ok(Vec::new());
-            };
-            let files = drive::list_children(&client, &token, &folder).await?;
+            let files =
+                drive::find_by_app_property(&client, &token, PROP_SHARE, PROP_SHARE_VALUE).await?;
             Ok(files.iter().map(parse_share_file).collect())
         })
     }
@@ -188,8 +199,14 @@ impl PublicFetch for DrivePublicFetch {
     fn download(&self, file_id: &str) -> Result<Vec<u8>> {
         let key = api_key()?;
         block_on(async {
-            let client = http_client();
-            drive::download_public(&client, &key, file_id).await
+            // Not the shared client: this request is made on a stranger's
+            // say-so, so it gets a deadline the account-bound calls do not.
+            crate::sync::install_crypto_provider();
+            let client = Client::builder()
+                .timeout(FETCH_TIMEOUT)
+                .build()
+                .map_err(|e| Error::Other(e.to_string()))?;
+            drive::download_public(&client, &key, file_id, MAX_SHARE_BYTES).await
         })
     }
 }
@@ -302,12 +319,17 @@ impl ShareRemote for FakeShareRemote {
         Ok(())
     }
 
+    // Selects on the marker exactly as the real listing does, so a caller that
+    // forgets to set it finds out here.
     fn list(&self) -> Result<Vec<ShareFile>> {
         Ok(self
             .files
             .lock()
             .unwrap()
             .iter()
+            .filter(|(_, file)| {
+                file.properties.get(PROP_SHARE).map(String::as_str) == Some(PROP_SHARE_VALUE)
+            })
             .map(|(id, file)| ShareFile {
                 id: id.clone(),
                 entry_id: file.properties.get(PROP_ENTRY_ID).cloned(),
@@ -394,16 +416,23 @@ mod tests {
             .upload(
                 "share.swshare",
                 b"sealed",
-                &[(PROP_ENTRY_ID, "entry-1"), (PROP_KIND, "login")],
+                &[
+                    (PROP_SHARE, PROP_SHARE_VALUE),
+                    (PROP_ENTRY_ID, "entry-1"),
+                    (PROP_KIND, "login"),
+                ],
             )
             .unwrap();
+        // Uploaded without the marker: present, but not a share to the listing.
+        remote.upload("stray.bin", b"x", &[]).unwrap();
 
         let listed = remote.list().unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, id);
         assert_eq!(listed[0].entry_id.as_deref(), Some("entry-1"));
         assert_eq!(listed[0].kind.as_deref(), Some("login"));
-        assert_eq!(remote.ids(), vec![id]);
+        // Both files are held; only one is a share.
+        assert_eq!(remote.ids().len(), 2);
     }
 
     #[test]

--- a/src-tauri/src/share/remote.rs
+++ b/src-tauri/src/share/remote.rs
@@ -1,0 +1,449 @@
+//! Where a one-time share lives while it is outstanding: a `Shares` subfolder
+//! of the same `Swifty` Drive folder sync already uses.
+//!
+//! The sender uploads sealed bytes and makes the file link-readable; the
+//! recipient — who has no Google account — fetches it with a public API key.
+//! Drive only ever holds ciphertext plus opaque bookkeeping (an entry UUID, a
+//! kind, an expiry), so the folder listing tells the *sender's* UI what is
+//! outstanding without telling Google what was shared.
+//!
+//! Like `sync`, this is only the transport: the Drive calls are async and are
+//! driven with `block_on` behind synchronous traits, which is safe because
+//! commands run them on `spawn_blocking` threads, never on a runtime worker.
+
+use std::sync::Mutex;
+
+use reqwest::Client;
+use tauri::{async_runtime::block_on, AppHandle};
+
+use crate::crypto::Cryptor;
+use crate::error::{Error, Result};
+use crate::sync::drive::{self, DriveFile};
+use crate::sync::{access_token, http_client, FOLDER_NAME};
+
+/// The subfolder of `Swifty` that holds outstanding shares.
+pub const SHARES_FOLDER: &str = "Shares";
+
+/// `appProperties` keys on a share file. Values are opaque to Google.
+pub const PROP_ENTRY_ID: &str = "entryId";
+pub const PROP_KIND: &str = "kind";
+pub const PROP_EXPIRES_AT: &str = "expiresAt";
+
+/// One outstanding share, as the sender's UI sees it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShareFile {
+    pub id: String,
+    /// The sender's local entry id from appProperties (`entryId`), if present.
+    /// An opaque UUID: the sender's UI resolves it to a title; Google learns
+    /// nothing.
+    pub entry_id: Option<String>,
+    /// Entry kind from appProperties (`kind`), e.g. "login".
+    pub kind: Option<String>,
+    pub created_ms: i64,
+    /// Absent when the file predates expiry bookkeeping or carries a malformed
+    /// value — treated as "no known expiry" rather than "expired now", so a
+    /// sweep never deletes a share it simply failed to read.
+    pub expires_ms: Option<i64>,
+}
+
+/// The sender-side store of outstanding shares.
+pub trait ShareRemote {
+    /// Upload sealed bytes as a new share file; returns the Drive file id.
+    fn upload(&self, name: &str, bytes: &[u8], properties: &[(&str, &str)]) -> Result<String>;
+    /// Make the file readable by anyone holding its id.
+    fn make_public(&self, id: &str) -> Result<()>;
+    fn delete(&self, id: &str) -> Result<()>;
+    /// Every share file currently in the Shares folder.
+    fn list(&self) -> Result<Vec<ShareFile>>;
+}
+
+/// Recipient side: no account, just the public download.
+pub trait PublicFetch {
+    fn download(&self, file_id: &str) -> Result<Vec<u8>>;
+}
+
+/// Read a listed Drive file as a share. Pure: every field is already in the
+/// listing, so neither the UI nor the sweep needs a second round trip.
+pub fn parse_share_file(file: &DriveFile) -> ShareFile {
+    ShareFile {
+        id: file.id.clone(),
+        entry_id: file.app_properties.get(PROP_ENTRY_ID).cloned(),
+        kind: file.app_properties.get(PROP_KIND).cloned(),
+        created_ms: chrono::DateTime::parse_from_rfc3339(&file.created_time)
+            .map(|t| t.timestamp_millis())
+            .unwrap_or(0),
+        expires_ms: file
+            .app_properties
+            .get(PROP_EXPIRES_AT)
+            .and_then(|v| v.parse().ok()),
+    }
+}
+
+/// [`ShareRemote`] over the `Swifty/Shares` folder of the connected account.
+///
+/// The folder id is resolved once per instance and cached: unlike the sync
+/// pack, a share file is addressed by the id upload just returned, so nothing
+/// here has to observe another device's writes mid-operation.
+pub struct DriveShareRemote {
+    app: AppHandle,
+    cryptor: Cryptor,
+    folder: Mutex<Option<String>>,
+}
+
+impl DriveShareRemote {
+    pub fn new(app: AppHandle, cryptor: Cryptor) -> Self {
+        Self {
+            app,
+            cryptor,
+            folder: Mutex::new(None),
+        }
+    }
+
+    async fn token(&self, client: &Client) -> Result<String> {
+        access_token(client, &self.app, &self.cryptor).await
+    }
+
+    /// `Swifty/Shares`, if it exists. Never creates: every sync run sweeps, and
+    /// most users never share, so a listing must not leave a folder behind in
+    /// an account that has nothing to list.
+    async fn find_folder(&self, client: &Client, token: &str) -> Result<Option<String>> {
+        if let Some(id) = self.folder.lock().unwrap().clone() {
+            return Ok(Some(id));
+        }
+        let Some(root) = drive::folder_id(client, token, FOLDER_NAME).await? else {
+            return Ok(None);
+        };
+        let shares = drive::folder_id_in(client, token, SHARES_FOLDER, &root).await?;
+        if let Some(id) = &shares {
+            *self.folder.lock().unwrap() = Some(id.clone());
+        }
+        Ok(shares)
+    }
+
+    /// Find-or-create `Swifty/Shares`, for the upload path only. Creating is the
+    /// normal case the first time a user shares anything, including before
+    /// they have ever synced.
+    async fn ensure_folder(&self, client: &Client, token: &str) -> Result<String> {
+        if let Some(id) = self.find_folder(client, token).await? {
+            return Ok(id);
+        }
+        let root = match drive::folder_id(client, token, FOLDER_NAME).await? {
+            Some(id) => id,
+            None => drive::create_folder(client, token, FOLDER_NAME).await?,
+        };
+        let shares = drive::create_folder_in(client, token, SHARES_FOLDER, Some(&root)).await?;
+        *self.folder.lock().unwrap() = Some(shares.clone());
+        Ok(shares)
+    }
+}
+
+impl ShareRemote for DriveShareRemote {
+    fn upload(&self, name: &str, bytes: &[u8], properties: &[(&str, &str)]) -> Result<String> {
+        block_on(async {
+            let client = http_client();
+            let token = self.token(&client).await?;
+            let folder = self.ensure_folder(&client, &token).await?;
+            let file = drive::create_file_with_properties(
+                &client, &token, name, &folder, bytes, properties,
+            )
+            .await?;
+            Ok(file.id)
+        })
+    }
+
+    fn make_public(&self, id: &str) -> Result<()> {
+        block_on(async {
+            let client = http_client();
+            let token = self.token(&client).await?;
+            drive::share_with_anyone(&client, &token, id).await
+        })
+    }
+
+    fn delete(&self, id: &str) -> Result<()> {
+        block_on(async {
+            let client = http_client();
+            let token = self.token(&client).await?;
+            drive::delete_file(&client, &token, id).await
+        })
+    }
+
+    fn list(&self) -> Result<Vec<ShareFile>> {
+        block_on(async {
+            let client = http_client();
+            let token = self.token(&client).await?;
+            let Some(folder) = self.find_folder(&client, &token).await? else {
+                return Ok(Vec::new());
+            };
+            let files = drive::list_children(&client, &token, &folder).await?;
+            Ok(files.iter().map(parse_share_file).collect())
+        })
+    }
+}
+
+/// The recipient's fetcher. Holds no account state — an API key is all a
+/// link-shared download needs.
+pub struct DrivePublicFetch;
+
+impl PublicFetch for DrivePublicFetch {
+    fn download(&self, file_id: &str) -> Result<Vec<u8>> {
+        let key = api_key()?;
+        block_on(async {
+            let client = http_client();
+            drive::download_public(&client, &key, file_id).await
+        })
+    }
+}
+
+/// The Google API key this build downloads with, from the environment at run
+/// time or baked in at build time. A public identifier, not a secret: it names
+/// the project for quota and grants nothing on its own. Mirrors the OAuth
+/// client resolution in `sync::auth`.
+fn api_key() -> Result<String> {
+    std::env::var("GOOGLE_API_KEY")
+        .ok()
+        .or_else(|| option_env!("GOOGLE_API_KEY").map(String::from))
+        .filter(|key| !key.is_empty())
+        .ok_or_else(|| Error::Other("Google API key not configured; set GOOGLE_API_KEY".into()))
+}
+
+/// An in-memory stand-in for the Drive folder, implementing both sides of the
+/// exchange so a test can upload, publish and download without a network.
+///
+/// `download` is deliberately strict about the public flag: a share that was
+/// never published is exactly as unreachable to a recipient as one that was
+/// deleted, and it fails with the same message the real client gives.
+#[cfg(test)]
+pub(crate) struct FakeShareRemote {
+    files: Mutex<std::collections::BTreeMap<String, FakeFile>>,
+    /// Doubles as the id source and the createdTime clock, so uploads are
+    /// ordered and ids are stable across a test.
+    next: Mutex<i64>,
+    /// Fails `make_public`, for the caller that has to clean up after it.
+    fail_publishing: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(test)]
+pub(crate) struct FakeFile {
+    pub bytes: Vec<u8>,
+    pub properties: std::collections::BTreeMap<String, String>,
+    pub public: bool,
+    pub created_ms: i64,
+}
+
+#[cfg(test)]
+impl FakeShareRemote {
+    pub(crate) fn new() -> Self {
+        Self {
+            files: Mutex::new(Default::default()),
+            next: Mutex::new(1),
+            fail_publishing: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Make every later `make_public` fail, leaving the upload behind.
+    pub(crate) fn fail_publishing(&self) {
+        self.fail_publishing
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Ids of every file currently held, oldest first.
+    pub(crate) fn ids(&self) -> Vec<String> {
+        self.files.lock().unwrap().keys().cloned().collect()
+    }
+
+    pub(crate) fn is_public(&self, id: &str) -> bool {
+        self.files.lock().unwrap().get(id).is_some_and(|f| f.public)
+    }
+
+    pub(crate) fn bytes(&self, id: &str) -> Option<Vec<u8>> {
+        self.files.lock().unwrap().get(id).map(|f| f.bytes.clone())
+    }
+}
+
+#[cfg(test)]
+impl ShareRemote for FakeShareRemote {
+    fn upload(&self, _name: &str, bytes: &[u8], properties: &[(&str, &str)]) -> Result<String> {
+        let mut next = self.next.lock().unwrap();
+        let id = format!("file-{next}");
+        self.files.lock().unwrap().insert(
+            id.clone(),
+            FakeFile {
+                bytes: bytes.to_vec(),
+                properties: properties
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect(),
+                public: false,
+                created_ms: *next,
+            },
+        );
+        *next += 1;
+        Ok(id)
+    }
+
+    fn make_public(&self, id: &str) -> Result<()> {
+        if self
+            .fail_publishing
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(Error::Other("could not publish the share".into()));
+        }
+        match self.files.lock().unwrap().get_mut(id) {
+            Some(file) => {
+                file.public = true;
+                Ok(())
+            }
+            None => Err(Error::NotFound),
+        }
+    }
+
+    fn delete(&self, id: &str) -> Result<()> {
+        self.files.lock().unwrap().remove(id);
+        Ok(())
+    }
+
+    fn list(&self) -> Result<Vec<ShareFile>> {
+        Ok(self
+            .files
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(id, file)| ShareFile {
+                id: id.clone(),
+                entry_id: file.properties.get(PROP_ENTRY_ID).cloned(),
+                kind: file.properties.get(PROP_KIND).cloned(),
+                created_ms: file.created_ms,
+                expires_ms: file
+                    .properties
+                    .get(PROP_EXPIRES_AT)
+                    .and_then(|v| v.parse().ok()),
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+impl PublicFetch for FakeShareRemote {
+    fn download(&self, file_id: &str) -> Result<Vec<u8>> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(file_id)
+            .filter(|f| f.public)
+            .map(|f| f.bytes.clone())
+            .ok_or_else(|| Error::Other(drive::SHARE_GONE.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn drive_file(created: &str, properties: &[(&str, &str)]) -> DriveFile {
+        DriveFile {
+            id: "f1".into(),
+            name: "share.swshare".into(),
+            created_time: created.into(),
+            head_revision: None,
+            app_properties: properties
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    #[test]
+    fn a_share_file_is_read_out_of_the_listing_alone() {
+        let parsed = parse_share_file(&drive_file(
+            "2024-03-01T12:00:00.000Z",
+            &[
+                (PROP_ENTRY_ID, "entry-uuid"),
+                (PROP_KIND, "login"),
+                (PROP_EXPIRES_AT, "1709300000000"),
+            ],
+        ));
+
+        assert_eq!(parsed.id, "f1");
+        assert_eq!(parsed.entry_id.as_deref(), Some("entry-uuid"));
+        assert_eq!(parsed.kind.as_deref(), Some("login"));
+        assert_eq!(parsed.created_ms, 1_709_294_400_000);
+        assert_eq!(parsed.expires_ms, Some(1_709_300_000_000));
+    }
+
+    #[test]
+    fn a_share_without_properties_reads_as_unknown_rather_than_failing() {
+        let parsed = parse_share_file(&drive_file("2024-03-01T12:00:00.000Z", &[]));
+        assert_eq!(parsed.entry_id, None);
+        assert_eq!(parsed.kind, None);
+        assert_eq!(parsed.expires_ms, None);
+    }
+
+    // A file the sweep cannot date must not read as "expired long ago".
+    #[test]
+    fn malformed_times_degrade_to_epoch_and_no_expiry() {
+        let parsed = parse_share_file(&drive_file("not a time", &[(PROP_EXPIRES_AT, "soon")]));
+        assert_eq!(parsed.created_ms, 0);
+        assert_eq!(parsed.expires_ms, None);
+    }
+
+    #[test]
+    fn an_uploaded_share_is_listed_with_its_properties() {
+        let remote = FakeShareRemote::new();
+        let id = remote
+            .upload(
+                "share.swshare",
+                b"sealed",
+                &[(PROP_ENTRY_ID, "entry-1"), (PROP_KIND, "login")],
+            )
+            .unwrap();
+
+        let listed = remote.list().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+        assert_eq!(listed[0].entry_id.as_deref(), Some("entry-1"));
+        assert_eq!(listed[0].kind.as_deref(), Some("login"));
+        assert_eq!(remote.ids(), vec![id]);
+    }
+
+    #[test]
+    fn publishing_is_what_makes_a_share_downloadable() {
+        let remote = FakeShareRemote::new();
+        let id = remote.upload("share.swshare", b"sealed", &[]).unwrap();
+
+        assert!(!remote.is_public(&id));
+        assert!(remote.download(&id).is_err());
+
+        remote.make_public(&id).unwrap();
+        assert!(remote.is_public(&id));
+        assert_eq!(remote.download(&id).unwrap(), b"sealed");
+        assert_eq!(remote.bytes(&id).unwrap(), b"sealed");
+    }
+
+    #[test]
+    fn an_unknown_or_revoked_share_fails_the_way_the_recipient_is_told() {
+        let remote = FakeShareRemote::new();
+        let id = remote.upload("share.swshare", b"sealed", &[]).unwrap();
+        remote.make_public(&id).unwrap();
+        remote.delete(&id).unwrap();
+
+        for missing in [id.as_str(), "never-existed"] {
+            let err = remote.download(missing).unwrap_err().to_string();
+            assert_eq!(err, "this share has expired or was revoked");
+        }
+    }
+
+    #[test]
+    fn deleting_removes_the_share_and_deleting_twice_is_fine() {
+        let remote = FakeShareRemote::new();
+        let id = remote.upload("share.swshare", b"sealed", &[]).unwrap();
+
+        remote.delete(&id).unwrap();
+        assert!(remote.list().unwrap().is_empty());
+        assert!(remote.ids().is_empty());
+        // Revoke and the expiry sweep race each other; whoever loses still
+        // got what it asked for.
+        remote.delete(&id).unwrap();
+        remote.delete("never-existed").unwrap();
+    }
+}

--- a/src-tauri/src/share/tests.rs
+++ b/src-tauri/src/share/tests.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
 
+use super::envelope::SHARE_EXPIRED;
 use super::remote::FakeShareRemote;
 use super::*;
 
@@ -25,6 +26,16 @@ fn entry() -> Entry {
     .unwrap()
 }
 
+// A share as another writer would leave it: marked, dated, nothing else.
+fn upload_share(remote: &FakeShareRemote, name: &str, expires: Option<i64>) -> String {
+    let expires = expires.map(|e| e.to_string());
+    let mut properties = vec![(PROP_SHARE, PROP_SHARE_VALUE)];
+    if let Some(expires) = &expires {
+        properties.push((PROP_EXPIRES_AT, expires));
+    }
+    remote.upload(name, b"sealed", &properties).unwrap()
+}
+
 #[test]
 fn a_created_share_is_published_ciphertext_with_its_bookkeeping() {
     let remote = FakeShareRemote::new();
@@ -33,6 +44,8 @@ fn a_created_share_is_published_ciphertext_with_its_bookkeeping() {
     assert_eq!(remote.ids(), vec![created.file_id.clone()]);
     assert!(remote.is_public(&created.file_id));
 
+    // The fake lists on the marker like Drive does, so this also proves the
+    // marker was written.
     let listed = remote.list().unwrap();
     assert_eq!(listed[0].entry_id.as_deref(), Some("entry-1"));
     assert_eq!(listed[0].kind.as_deref(), Some("login"));
@@ -50,7 +63,7 @@ fn the_link_opens_the_entry_without_the_sender_s_copy() {
     let remote = FakeShareRemote::new();
     let created = create(&remote, &entry(), NOW).unwrap();
 
-    let opened = open(&remote, &created.link).unwrap();
+    let opened = open(&remote, &created.link, NOW).unwrap();
     assert_eq!(opened.title, "Router");
     assert_eq!(opened.password.as_deref(), Some("hunter2"));
     assert_eq!(opened.id, "");
@@ -58,6 +71,36 @@ fn the_link_opens_the_entry_without_the_sender_s_copy() {
     assert!(opened.updated_at.is_none());
     assert!(!opened.favorite);
     assert!(opened.passkeys.is_none());
+}
+
+// The file may well still be there — the sender's device is what deletes it,
+// and it may be off. The recipient's clock is what turns the link off.
+#[test]
+fn a_link_stops_opening_when_the_share_expires_even_if_the_file_remains() {
+    let remote = FakeShareRemote::new();
+    let created = create(&remote, &entry(), NOW).unwrap();
+
+    assert!(open(&remote, &created.link, NOW + SHARE_TTL_MS - 1).is_ok());
+    assert_eq!(
+        open(&remote, &created.link, NOW + SHARE_TTL_MS)
+            .unwrap_err()
+            .to_string(),
+        SHARE_EXPIRED
+    );
+    assert!(remote.is_public(&created.file_id));
+}
+
+#[test]
+fn a_passkey_only_login_is_refused_before_anything_is_uploaded() {
+    let remote = FakeShareRemote::new();
+    let mut passkey_only = entry();
+    passkey_only.password = None;
+
+    assert_eq!(
+        create(&remote, &passkey_only, NOW).unwrap_err().to_string(),
+        "this login holds only a passkey, and passkeys cannot be shared"
+    );
+    assert!(remote.ids().is_empty());
 }
 
 #[test]
@@ -71,7 +114,7 @@ fn a_link_carrying_the_wrong_key_does_not_open_the_share() {
     .format();
 
     assert_eq!(
-        open(&remote, &impostor).unwrap_err().to_string(),
+        open(&remote, &impostor, NOW).unwrap_err().to_string(),
         "this link does not open the share"
     );
 }
@@ -84,7 +127,7 @@ fn a_revoked_share_reads_as_gone() {
     revoke(&remote, &created.file_id).unwrap();
     assert!(remote.ids().is_empty());
     assert_eq!(
-        open(&remote, &created.link).unwrap_err().to_string(),
+        open(&remote, &created.link, NOW).unwrap_err().to_string(),
         crate::sync::drive::SHARE_GONE
     );
 }
@@ -94,7 +137,7 @@ fn a_revoked_share_reads_as_gone() {
 #[test]
 fn a_link_that_is_not_a_link_fails_before_anything_is_fetched() {
     assert_eq!(
-        open(&FakeShareRemote::new(), "https://example.com/share")
+        open(&FakeShareRemote::new(), "https://example.com/share", NOW)
             .unwrap_err()
             .to_string(),
         "this is not a Swifty share link"
@@ -104,14 +147,9 @@ fn a_link_that_is_not_a_link_fails_before_anything_is_fetched() {
 #[test]
 fn the_sweep_deletes_only_what_is_known_to_have_expired() {
     let remote = FakeShareRemote::new();
-    let (past, future) = ((NOW - 1).to_string(), (NOW + 1).to_string());
-    let expired = remote
-        .upload("a.swshare", b"a", &[(PROP_EXPIRES_AT, &past)])
-        .unwrap();
-    let live = remote
-        .upload("b.swshare", b"b", &[(PROP_EXPIRES_AT, &future)])
-        .unwrap();
-    let undated = remote.upload("c.swshare", b"c", &[]).unwrap();
+    let expired = upload_share(&remote, "a.swshare", Some(NOW - 1));
+    let live = upload_share(&remote, "b.swshare", Some(NOW + 1));
+    let undated = upload_share(&remote, "c.swshare", None);
 
     assert_eq!(sweep(&remote, NOW).unwrap(), 1);
     assert!(!remote.ids().contains(&expired));
@@ -127,7 +165,7 @@ fn the_sweep_deletes_only_what_is_known_to_have_expired() {
 #[test]
 fn a_share_with_no_readable_expiry_is_still_given_one_to_show() {
     let remote = FakeShareRemote::new();
-    remote.upload("a.swshare", b"a", &[]).unwrap();
+    upload_share(&remote, "a.swshare", None);
 
     let listed = list(&remote, NOW).unwrap();
     assert_eq!(listed[0].created_at, "1970-01-01T00:00:00.001Z");

--- a/src-tauri/src/share/tests.rs
+++ b/src-tauri/src/share/tests.rs
@@ -1,0 +1,144 @@
+use serde_json::json;
+
+use super::remote::FakeShareRemote;
+use super::*;
+
+// 2023-11-14T22:13:20Z. A fixed clock so the RFC 3339 strings the frontend
+// renders can be asserted literally rather than recomputed by the code
+// under test.
+const NOW: i64 = 1_700_000_000_000;
+
+fn entry() -> Entry {
+    serde_json::from_value(json!({
+        "id": "entry-1", "type": "login", "title": "Router",
+        "username": "admin", "password": "hunter2",
+        "favorite": true,
+        "createdAt": "2024-01-01T00:00:00Z",
+        "updatedAt": "2024-02-01T00:00:00Z",
+        "passkeys": [{
+            "credentialId": "Y3JlZA", "rpId": "ex.com",
+            "userHandle": "dXNlcg", "userName": "admin",
+            "userDisplayName": "Admin", "privateKey": "cHJpdmF0ZUtleQ",
+            "counter": 0
+        }]
+    }))
+    .unwrap()
+}
+
+#[test]
+fn a_created_share_is_published_ciphertext_with_its_bookkeeping() {
+    let remote = FakeShareRemote::new();
+    let created = create(&remote, &entry(), NOW).unwrap();
+
+    assert_eq!(remote.ids(), vec![created.file_id.clone()]);
+    assert!(remote.is_public(&created.file_id));
+
+    let listed = remote.list().unwrap();
+    assert_eq!(listed[0].entry_id.as_deref(), Some("entry-1"));
+    assert_eq!(listed[0].kind.as_deref(), Some("login"));
+    assert_eq!(listed[0].expires_ms, Some(NOW + SHARE_TTL_MS));
+
+    assert_eq!(created.expires_at, "2023-11-15T22:13:20.000Z");
+    assert_eq!(Link::parse(&created.link).unwrap().file_id, created.file_id);
+
+    let stored = remote.bytes(&created.file_id).unwrap();
+    assert!(!stored.windows(7).any(|w| w == b"hunter2"));
+}
+
+#[test]
+fn the_link_opens_the_entry_without_the_sender_s_copy() {
+    let remote = FakeShareRemote::new();
+    let created = create(&remote, &entry(), NOW).unwrap();
+
+    let opened = open(&remote, &created.link).unwrap();
+    assert_eq!(opened.title, "Router");
+    assert_eq!(opened.password.as_deref(), Some("hunter2"));
+    assert_eq!(opened.id, "");
+    assert!(opened.created_at.is_none());
+    assert!(opened.updated_at.is_none());
+    assert!(!opened.favorite);
+    assert!(opened.passkeys.is_none());
+}
+
+#[test]
+fn a_link_carrying_the_wrong_key_does_not_open_the_share() {
+    let remote = FakeShareRemote::new();
+    let created = create(&remote, &entry(), NOW).unwrap();
+    let impostor = Link {
+        file_id: created.file_id,
+        key: ShareKey::generate(),
+    }
+    .format();
+
+    assert_eq!(
+        open(&remote, &impostor).unwrap_err().to_string(),
+        "this link does not open the share"
+    );
+}
+
+#[test]
+fn a_revoked_share_reads_as_gone() {
+    let remote = FakeShareRemote::new();
+    let created = create(&remote, &entry(), NOW).unwrap();
+
+    revoke(&remote, &created.file_id).unwrap();
+    assert!(remote.ids().is_empty());
+    assert_eq!(
+        open(&remote, &created.link).unwrap_err().to_string(),
+        crate::sync::drive::SHARE_GONE
+    );
+}
+
+// The fake answers an unknown id with SHARE_GONE, so getting the parse error
+// back is the proof that nothing was fetched.
+#[test]
+fn a_link_that_is_not_a_link_fails_before_anything_is_fetched() {
+    assert_eq!(
+        open(&FakeShareRemote::new(), "https://example.com/share")
+            .unwrap_err()
+            .to_string(),
+        "this is not a Swifty share link"
+    );
+}
+
+#[test]
+fn the_sweep_deletes_only_what_is_known_to_have_expired() {
+    let remote = FakeShareRemote::new();
+    let (past, future) = ((NOW - 1).to_string(), (NOW + 1).to_string());
+    let expired = remote
+        .upload("a.swshare", b"a", &[(PROP_EXPIRES_AT, &past)])
+        .unwrap();
+    let live = remote
+        .upload("b.swshare", b"b", &[(PROP_EXPIRES_AT, &future)])
+        .unwrap();
+    let undated = remote.upload("c.swshare", b"c", &[]).unwrap();
+
+    assert_eq!(sweep(&remote, NOW).unwrap(), 1);
+    assert!(!remote.ids().contains(&expired));
+
+    let listed = list(&remote, NOW).unwrap();
+    assert_eq!(
+        listed.iter().map(|s| &s.file_id).collect::<Vec<_>>(),
+        vec![&live, &undated]
+    );
+}
+
+// The fake's ids double as its clock, so this file was created at 1ms.
+#[test]
+fn a_share_with_no_readable_expiry_is_still_given_one_to_show() {
+    let remote = FakeShareRemote::new();
+    remote.upload("a.swshare", b"a", &[]).unwrap();
+
+    let listed = list(&remote, NOW).unwrap();
+    assert_eq!(listed[0].created_at, "1970-01-01T00:00:00.001Z");
+    assert_eq!(listed[0].expires_at, "1970-01-02T00:00:00.001Z");
+}
+
+#[test]
+fn a_share_that_cannot_be_published_leaves_no_orphan() {
+    let remote = FakeShareRemote::new();
+    remote.fail_publishing();
+
+    assert!(create(&remote, &entry(), NOW).is_err());
+    assert!(remote.ids().is_empty());
+}

--- a/src-tauri/src/sync/drive.rs
+++ b/src-tauri/src/sync/drive.rs
@@ -6,6 +6,8 @@
 //! `.swsync` pack — SQLCipher ciphertext with a binary header — and routing it
 //! through `String` would either corrupt it or fail to decode.
 
+use std::collections::BTreeMap;
+
 use reqwest::Client;
 use serde_json::{json, Value};
 
@@ -15,20 +17,25 @@ const FILES: &str = "https://www.googleapis.com/drive/v3/files";
 const UPLOAD: &str = "https://www.googleapis.com/upload/drive/v3/files";
 // `createdTime` drives the deterministic pick below; `headRevisionId` is the
 // change token the engine uses to detect a push that landed under it.
-const LIST_FIELDS: &str = "files(id, name, createdTime, headRevisionId)";
-const FILE_FIELDS: &str = "id, createdTime, headRevisionId";
+const LIST_FIELDS: &str = "files(id, name, createdTime, headRevisionId, appProperties)";
+const FILE_FIELDS: &str = "id, name, createdTime, headRevisionId, appProperties";
 const FILE_MIME: &str = "application/octet-stream";
 const FOLDER_MIME: &str = "application/vnd.google-apps.folder";
 
-/// One Drive object, with the two fields selection and race detection need.
+/// One Drive object, with the fields selection and race detection need.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriveFile {
     pub id: String,
+    pub name: String,
     pub created_time: String,
     /// Absent on folders, and on a file Drive has not yet assigned a revision
     /// to. The engine treats an absent revision as "unknown", which only costs
     /// it a race check, never correctness.
     pub head_revision: Option<String>,
+    /// `appProperties`: private per-file metadata, visible only to this OAuth
+    /// client. Sharing stores its bookkeeping (entry id, kind, expiry) here so
+    /// a listing alone answers what a share is, without downloading it.
+    pub app_properties: BTreeMap<String, String>,
 }
 
 fn other<E: std::fmt::Display>(e: E) -> Error {
@@ -71,9 +78,25 @@ async fn find_all(client: &Client, token: &str, q: &str) -> Result<Vec<DriveFile
 fn parse_file(value: &Value) -> Option<DriveFile> {
     Some(DriveFile {
         id: value["id"].as_str()?.to_string(),
+        name: value["name"].as_str().unwrap_or("").to_string(),
         created_time: value["createdTime"].as_str().unwrap_or("").to_string(),
         head_revision: value["headRevisionId"].as_str().map(String::from),
+        app_properties: parse_properties(&value["appProperties"]),
     })
+}
+
+// Drive declares appProperties as string->string, but a value that is not a
+// string is simply dropped rather than stringified: a caller reading one back
+// expects what it wrote, and `"1"` and `1` are not the same key to it.
+fn parse_properties(value: &Value) -> BTreeMap<String, String> {
+    value
+        .as_object()
+        .map(|map| {
+            map.iter()
+                .filter_map(|(k, v)| Some((k.clone(), v.as_str()?.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// The oldest match, `id` breaking an exact tie.
@@ -103,6 +126,28 @@ pub async fn folder_id(client: &Client, token: &str, name: &str) -> Result<Optio
         escape(name)
     );
     Ok(oldest(find_all(client, token, &q).await?).map(|f| f.id))
+}
+
+/// [`folder_id`], scoped to one parent — the same oldest-wins rule, so two
+/// devices racing to create the same subfolder still settle on one.
+pub async fn folder_id_in(
+    client: &Client,
+    token: &str,
+    name: &str,
+    parent: &str,
+) -> Result<Option<String>> {
+    let q = format!(
+        "name = '{}' and mimeType = '{FOLDER_MIME}' and trashed = false and '{}' in parents",
+        escape(name),
+        escape(parent)
+    );
+    Ok(oldest(find_all(client, token, &q).await?).map(|f| f.id))
+}
+
+/// Every non-trashed file directly under `parent`.
+pub async fn list_children(client: &Client, token: &str, parent: &str) -> Result<Vec<DriveFile>> {
+    let q = format!("'{}' in parents and trashed = false", escape(parent));
+    find_all(client, token, &q).await
 }
 
 pub async fn find_file(
@@ -138,11 +183,26 @@ pub async fn read_file(client: &Client, token: &str, id: &str) -> Result<Vec<u8>
     Ok(body.to_vec())
 }
 
+/// A folder in the account root.
 pub async fn create_folder(client: &Client, token: &str, name: &str) -> Result<String> {
+    create_folder_in(client, token, name, None).await
+}
+
+/// A folder, optionally inside `parent`.
+pub async fn create_folder_in(
+    client: &Client,
+    token: &str,
+    name: &str,
+    parent: Option<&str>,
+) -> Result<String> {
+    let mut metadata = json!({ "name": name, "mimeType": FOLDER_MIME });
+    if let Some(parent) = parent {
+        metadata["parents"] = json!([parent]);
+    }
     let resp = client
         .post(FILES)
         .bearer_auth(token)
-        .json(&json!({ "name": name, "mimeType": FOLDER_MIME }))
+        .json(&metadata)
         .send()
         .await
         .map_err(other)?;
@@ -154,9 +214,6 @@ pub async fn create_folder(client: &Client, token: &str, name: &str) -> Result<S
 }
 
 /// multipart/related upload: a JSON metadata part, then the raw pack bytes.
-///
-/// The envelope is assembled by hand because the body is binary — it is spliced
-/// in between UTF-8 boundary lines rather than formatted into a `String`.
 pub async fn create_file(
     client: &Client,
     token: &str,
@@ -164,18 +221,27 @@ pub async fn create_file(
     parent: &str,
     content: &[u8],
 ) -> Result<DriveFile> {
-    let metadata = json!({ "name": name, "mimeType": FILE_MIME, "parents": [parent] });
-    let boundary = "swifty-boundary";
-    let head = format!(
-        "--{boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{metadata}\r\n\
-         --{boundary}\r\nContent-Type: {FILE_MIME}\r\n\r\n"
-    );
-    let tail = format!("\r\n--{boundary}--");
+    create_file_with_properties(client, token, name, parent, content, &[]).await
+}
 
-    let mut body = Vec::with_capacity(head.len() + content.len() + tail.len());
-    body.extend_from_slice(head.as_bytes());
-    body.extend_from_slice(content);
-    body.extend_from_slice(tail.as_bytes());
+/// [`create_file`] plus `appProperties` — private metadata the listing carries
+/// back, so a caller can tell its files apart without downloading them.
+pub async fn create_file_with_properties(
+    client: &Client,
+    token: &str,
+    name: &str,
+    parent: &str,
+    content: &[u8],
+    properties: &[(&str, &str)],
+) -> Result<DriveFile> {
+    let mut metadata = json!({ "name": name, "mimeType": FILE_MIME, "parents": [parent] });
+    if !properties.is_empty() {
+        metadata["appProperties"] = properties
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), Value::from(*v)))
+            .collect::<serde_json::Map<_, _>>()
+            .into();
+    }
 
     let resp = client
         .post(UPLOAD)
@@ -183,13 +249,93 @@ pub async fn create_file(
         .query(&[("uploadType", "multipart"), ("fields", FILE_FIELDS)])
         .header(
             reqwest::header::CONTENT_TYPE,
-            format!("multipart/related; boundary={boundary}"),
+            format!("multipart/related; boundary={BOUNDARY}"),
         )
-        .body(body)
+        .body(multipart_body(&metadata, content))
         .send()
         .await
         .map_err(other)?;
     parse_file(&check(resp).await?).ok_or_else(|| Error::Other("Drive API returned no id".into()))
+}
+
+const BOUNDARY: &str = "swifty-boundary";
+
+/// The envelope is assembled by hand because the body is binary — it is spliced
+/// in between UTF-8 boundary lines rather than formatted into a `String`.
+fn multipart_body(metadata: &Value, content: &[u8]) -> Vec<u8> {
+    let head = format!(
+        "--{BOUNDARY}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{metadata}\r\n\
+         --{BOUNDARY}\r\nContent-Type: {FILE_MIME}\r\n\r\n"
+    );
+    let tail = format!("\r\n--{BOUNDARY}--");
+
+    let mut body = Vec::with_capacity(head.len() + content.len() + tail.len());
+    body.extend_from_slice(head.as_bytes());
+    body.extend_from_slice(content);
+    body.extend_from_slice(tail.as_bytes());
+    body
+}
+
+/// Grant read access to anyone holding the file's id — what turns an uploaded
+/// share into a link the recipient can fetch without a Google account.
+///
+/// The bytes are sealed before they are uploaded, so "anyone with the link" is
+/// only as open as the key the sender hands over out of band.
+pub async fn share_with_anyone(client: &Client, token: &str, id: &str) -> Result<()> {
+    let resp = client
+        .post(format!("{FILES}/{id}/permissions"))
+        .bearer_auth(token)
+        .json(&json!({ "type": "anyone", "role": "reader" }))
+        .send()
+        .await
+        .map_err(other)?;
+    check(resp).await.map(|_| ())
+}
+
+/// Delete a file. Already gone counts as deleted — that is the state the caller
+/// asked for, and revoke/sweep both race other devices doing the same thing.
+pub async fn delete_file(client: &Client, token: &str, id: &str) -> Result<()> {
+    let resp = client
+        .delete(format!("{FILES}/{id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(other)?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    check(resp).await.map(|_| ())
+}
+
+/// What a recipient is told when the file behind their link is gone. Shared so
+/// the test doubles in `share::remote` fail the same way the real client does.
+pub(crate) const SHARE_GONE: &str = "this share has expired or was revoked";
+
+/// Download a link-shared file with only an API key — the recipient side, which
+/// has no Google account and therefore no bearer token. The key identifies the
+/// calling project for quota; it grants nothing on its own.
+pub async fn download_public(client: &Client, api_key: &str, id: &str) -> Result<Vec<u8>> {
+    let resp = client
+        .get(format!("{FILES}/{id}"))
+        .query(&[("alt", "media"), ("key", api_key)])
+        .send()
+        .await
+        .map_err(other)?;
+    let status = resp.status();
+    let body = resp.bytes().await.map_err(other)?;
+    if status == reqwest::StatusCode::NOT_FOUND {
+        // The only two ways a share the recipient was given disappears, and
+        // Drive cannot tell them apart — nor could the recipient act on the
+        // difference.
+        return Err(Error::Other(SHARE_GONE.into()));
+    }
+    if !status.is_success() {
+        return Err(Error::Other(format!(
+            "Drive API {status}: {}",
+            String::from_utf8_lossy(&body)
+        )));
+    }
+    Ok(body.to_vec())
 }
 
 /// Overwrite a file's content, returning its new head revision.
@@ -217,7 +363,8 @@ pub async fn update_file(
 
 #[cfg(test)]
 mod tests {
-    use super::{escape, oldest, DriveFile};
+    use super::{escape, multipart_body, oldest, parse_file, parse_properties, DriveFile};
+    use serde_json::json;
 
     #[test]
     fn escapes_quotes_and_backslashes() {
@@ -231,8 +378,10 @@ mod tests {
     fn file(id: &str, created: &str) -> DriveFile {
         DriveFile {
             id: id.into(),
+            name: String::new(),
             created_time: created.into(),
             head_revision: None,
+            app_properties: Default::default(),
         }
     }
 
@@ -256,5 +405,58 @@ mod tests {
     #[test]
     fn no_matches_selects_nothing() {
         assert_eq!(oldest(vec![]), None);
+    }
+
+    #[test]
+    fn a_listed_file_carries_its_name_and_properties() {
+        let parsed = parse_file(&json!({
+            "id": "f1",
+            "name": "share-1.swshare",
+            "createdTime": "2024-01-01T00:00:00.000Z",
+            "headRevisionId": "r1",
+            "appProperties": { "kind": "login", "expiresAt": "1700000000000" },
+        }))
+        .unwrap();
+
+        assert_eq!(parsed.name, "share-1.swshare");
+        assert_eq!(parsed.app_properties["kind"], "login");
+        assert_eq!(parsed.app_properties["expiresAt"], "1700000000000");
+        assert_eq!(parsed.head_revision.as_deref(), Some("r1"));
+    }
+
+    // The sync engine selects neither field, so every existing caller still
+    // parses — it just reads them as empty.
+    #[test]
+    fn a_file_without_name_or_properties_still_parses() {
+        let parsed = parse_file(&json!({ "id": "f1" })).unwrap();
+        assert_eq!(parsed.name, "");
+        assert!(parsed.app_properties.is_empty());
+    }
+
+    #[test]
+    fn non_string_property_values_are_dropped() {
+        let props = parse_properties(&json!({ "kind": "login", "count": 3, "on": true }));
+        assert_eq!(props.len(), 1);
+        assert_eq!(props["kind"], "login");
+    }
+
+    #[test]
+    fn no_properties_object_is_no_properties() {
+        assert!(parse_properties(&json!(null)).is_empty());
+        assert!(parse_properties(&json!("nonsense")).is_empty());
+    }
+
+    // Binary content must survive the envelope byte for byte — the share is
+    // ciphertext, and a lossy round trip through `String` would corrupt it.
+    #[test]
+    fn the_upload_envelope_splices_raw_bytes_between_the_boundaries() {
+        let content = [0x00u8, 0xff, 0x1a, b'\r', b'\n'];
+        let body = multipart_body(&json!({ "name": "x" }), &content);
+
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.starts_with("--swifty-boundary\r\n"));
+        assert!(text.contains("{\"name\":\"x\"}"));
+        assert!(body.ends_with(b"\r\n--swifty-boundary--"));
+        assert!(body.windows(content.len()).any(|w| w == content));
     }
 }

--- a/src-tauri/src/sync/drive.rs
+++ b/src-tauri/src/sync/drive.rs
@@ -61,18 +61,44 @@ async fn check(resp: reqwest::Response) -> Result<Value> {
 
 // Run a files.list query and return *every* match.
 async fn find_all(client: &Client, token: &str, q: &str) -> Result<Vec<DriveFile>> {
-    let resp = client
-        .get(FILES)
-        .bearer_auth(token)
-        .query(&[("q", q), ("fields", LIST_FIELDS)])
-        .send()
-        .await
-        .map_err(other)?;
-    let data = check(resp).await?;
-    Ok(data["files"]
+    // Drive pages the listing whenever it likes, not only past `pageSize`, so
+    // one request is never the whole answer: a share left on a later page would
+    // be invisible to both the sweep and the revoke list.
+    let mut files = Vec::new();
+    let mut page_token: Option<String> = None;
+    loop {
+        let mut query = vec![("q", q), ("fields", LIST_FIELDS), ("pageSize", "100")];
+        if let Some(token) = &page_token {
+            query.push(("pageToken", token));
+        }
+        let resp = client
+            .get(FILES)
+            .bearer_auth(token)
+            .query(&query)
+            .send()
+            .await
+            .map_err(other)?;
+        let (page, next) = parse_listing(&check(resp).await?);
+        files.extend(page);
+        match next {
+            Some(next) => page_token = Some(next),
+            None => return Ok(files),
+        }
+    }
+}
+
+/// One page of a `files.list` response: its files and the token for the next
+/// page, if Drive says there is one.
+fn parse_listing(data: &Value) -> (Vec<DriveFile>, Option<String>) {
+    let files = data["files"]
         .as_array()
         .map(|files| files.iter().filter_map(parse_file).collect())
-        .unwrap_or_default())
+        .unwrap_or_default();
+    let next = data["nextPageToken"]
+        .as_str()
+        .filter(|t| !t.is_empty())
+        .map(String::from);
+    (files, next)
 }
 
 fn parse_file(value: &Value) -> Option<DriveFile> {
@@ -144,9 +170,21 @@ pub async fn folder_id_in(
     Ok(oldest(find_all(client, token, &q).await?).map(|f| f.id))
 }
 
-/// Every non-trashed file directly under `parent`.
-pub async fn list_children(client: &Client, token: &str, parent: &str) -> Result<Vec<DriveFile>> {
-    let q = format!("'{}' in parents and trashed = false", escape(parent));
+/// Every non-trashed file this app can see that carries `key = value` in its
+/// `appProperties`, wherever it sits. Addressing by marker rather than by
+/// folder is what makes a listing complete when two devices raced to create
+/// the same folder and each uploaded into its own.
+pub async fn find_by_app_property(
+    client: &Client,
+    token: &str,
+    key: &str,
+    value: &str,
+) -> Result<Vec<DriveFile>> {
+    let q = format!(
+        "appProperties has {{ key='{}' and value='{}' }} and trashed = false",
+        escape(key),
+        escape(value)
+    );
     find_all(client, token, &q).await
 }
 
@@ -314,15 +352,28 @@ pub(crate) const SHARE_GONE: &str = "this share has expired or was revoked";
 /// Download a link-shared file with only an API key — the recipient side, which
 /// has no Google account and therefore no bearer token. The key identifies the
 /// calling project for quota; it grants nothing on its own.
-pub async fn download_public(client: &Client, api_key: &str, id: &str) -> Result<Vec<u8>> {
-    let resp = client
+pub(crate) const SHARE_TOO_LARGE: &str = "this share is larger than Swifty allows";
+
+/// Fetch a link-shared file with no account, refusing anything over
+/// `max_bytes`.
+///
+/// The id comes out of a pasted link, so it can name any public Drive file at
+/// all — the cap is checked against the declared length first and then
+/// enforced while streaming, so a body that lies about its size still cannot
+/// be buffered whole before the ciphertext is even looked at.
+pub async fn download_public(
+    client: &Client,
+    api_key: &str,
+    id: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>> {
+    let mut resp = client
         .get(format!("{FILES}/{id}"))
         .query(&[("alt", "media"), ("key", api_key)])
         .send()
         .await
         .map_err(other)?;
     let status = resp.status();
-    let body = resp.bytes().await.map_err(other)?;
     if status == reqwest::StatusCode::NOT_FOUND {
         // The only two ways a share the recipient was given disappears, and
         // Drive cannot tell them apart — nor could the recipient act on the
@@ -330,12 +381,30 @@ pub async fn download_public(client: &Client, api_key: &str, id: &str) -> Result
         return Err(Error::Other(SHARE_GONE.into()));
     }
     if !status.is_success() {
+        let body = read_capped(&mut resp, max_bytes).await.unwrap_or_default();
         return Err(Error::Other(format!(
             "Drive API {status}: {}",
             String::from_utf8_lossy(&body)
         )));
     }
-    Ok(body.to_vec())
+    if resp
+        .content_length()
+        .is_some_and(|len| len > max_bytes as u64)
+    {
+        return Err(Error::Other(SHARE_TOO_LARGE.into()));
+    }
+    read_capped(&mut resp, max_bytes).await
+}
+
+async fn read_capped(resp: &mut reqwest::Response, max_bytes: usize) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+    while let Some(chunk) = resp.chunk().await.map_err(other)? {
+        if body.len() + chunk.len() > max_bytes {
+            return Err(Error::Other(SHARE_TOO_LARGE.into()));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 /// Overwrite a file's content, returning its new head revision.
@@ -363,7 +432,9 @@ pub async fn update_file(
 
 #[cfg(test)]
 mod tests {
-    use super::{escape, multipart_body, oldest, parse_file, parse_properties, DriveFile};
+    use super::{
+        escape, multipart_body, oldest, parse_file, parse_listing, parse_properties, DriveFile,
+    };
     use serde_json::json;
 
     #[test]
@@ -400,6 +471,24 @@ mod tests {
         let b = file("bbb", "2024-01-01T00:00:00.000Z");
         assert_eq!(oldest(vec![b.clone(), a.clone()]), Some(a.clone()));
         assert_eq!(oldest(vec![a, b]).unwrap().id, "aaa");
+    }
+
+    #[test]
+    fn a_listing_page_yields_its_files_and_the_next_token() {
+        let (files, next) = parse_listing(&serde_json::json!({
+            "nextPageToken": "page-2",
+            "files": [{"id": "a", "createdTime": "2024-01-01T00:00:00.000Z"}]
+        }));
+        assert_eq!(files.len(), 1);
+        assert_eq!(next.as_deref(), Some("page-2"));
+
+        let (files, next) = parse_listing(&serde_json::json!({"files": []}));
+        assert!(files.is_empty());
+        assert_eq!(next, None);
+
+        // An empty token is Drive's way of saying "last page" too.
+        let (_, next) = parse_listing(&serde_json::json!({"nextPageToken": "", "files": []}));
+        assert_eq!(next, None);
     }
 
     #[test]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -8,7 +8,8 @@
 //! never on a command thread, and never on a runtime worker.
 
 mod auth;
-mod drive;
+// Crate-visible: `share::remote` drives the same Drive REST surface.
+pub(crate) mod drive;
 pub mod engine;
 pub mod pack;
 pub mod restore;
@@ -16,13 +17,24 @@ pub mod restore;
 use std::sync::Mutex;
 
 use reqwest::Client;
-use tauri::{async_runtime::block_on, AppHandle};
+use tauri::{async_runtime::block_on, AppHandle, Manager};
 
 use crate::crypto::Cryptor;
 use crate::error::{Error, Result};
+use crate::state::AppState;
 use engine::{Remote, RemoteFile, SessionVault, SyncOutcome};
 
-const FOLDER_NAME: &str = "Swifty";
+pub(crate) const FOLDER_NAME: &str = "Swifty";
+
+/// A valid Drive access token for the connected account, refreshed if needed.
+/// Crate-visible so `share::remote` can act on the same account.
+pub(crate) async fn access_token(
+    client: &Client,
+    app: &AppHandle,
+    cryptor: &Cryptor,
+) -> Result<String> {
+    auth::access_token(client, app, cryptor).await
+}
 
 /// Install the ring rustls provider, once per process.
 ///
@@ -72,7 +84,24 @@ pub fn run(app: &AppHandle, cryptor: Cryptor) -> Result<SyncOutcome> {
     }
     let remote = DriveRemote::new(app.clone(), cryptor);
     let local = SessionVault::capture(app)?;
-    engine::sync(&remote, &local, now_ms())
+    let outcome = engine::sync(&remote, &local, now_ms())?;
+    sweep_shares(app);
+    Ok(outcome)
+}
+
+/// Drop expired one-time shares, riding along on a run that has just proved the
+/// account reachable. Best effort: a locked vault or a failed listing is not a
+/// sync failure, and the next run sweeps again.
+fn sweep_shares(app: &AppHandle) {
+    // `run` moved its own cryptor into the remote and `Cryptor` is not `Clone`,
+    // so take a second from the session — which is also how we notice the vault
+    // locked while the sync was in flight.
+    let Ok(cryptor) = app.state::<AppState>().session.lock().unwrap().cryptor() else {
+        return;
+    };
+    if let Err(e) = crate::share::sweep_drive(app, cryptor) {
+        log::warn!("share sweep failed: {e}");
+    }
 }
 
 fn now_ms() -> i64 {


### PR DESCRIPTION
## What

One-time credential sharing, backend half. A share is one entry, sanitized, sealed under a fresh random AES-256-GCM key and uploaded to a `Swifty/Shares` folder in the sender's own Drive as an "anyone with the link" file. The link `swifty://share#v1.<fileId>.<key>` is the only secret: Google holds ciphertext plus opaque bookkeeping (entry id, kind, expiry). The recipient needs no Google account; the file is fetched with a public Drive API key and unsealed locally.

Design: `docs/share-design.md`. Threat model gained a "Sharing a secret" section. Frontend follows in a stacked PR.

## Changes

- `share/envelope.rs` — key generation, seal/unseal via the existing `seal_aead`, link codec, sanitizing (id, timestamps, favorite, passkeys stripped).
- `share/remote.rs` — `ShareRemote` / `PublicFetch` traits, Drive implementation over `Swifty/Shares` (only the upload path creates the folder, so the sweep never leaves one behind), in-memory fake for tests.
- `share/mod.rs` — `create`, `open`, `revoke`, `sweep`, `list`. Fixed 24h TTL. A failed publish deletes the uploaded file. Unknown expiry is never treated as expired.
- `commands/share.rs` — `share_create`, `share_open`, `share_revoke`, `share_list`. Session lock is released before any network call; Drive work runs on `spawn_blocking` like sync.
- `sync/mod.rs` — best-effort sweep of expired shares after every successful sync run.
- `sync/drive.rs` — `appProperties` on `DriveFile`, `create_file_with_properties`, `share_with_anyone`, `delete_file`, `list_children`, `folder_id_in`, `create_folder_in`, `download_public`.
- `.env.example`, both release workflows — new `GOOGLE_API_KEY` (public identifier, restricted to the Drive API).

## Setup needed

Receiving is disabled until a real key exists: create an API key in Cloud Console restricted to the Drive API, put it in `.env`, and add a `GOOGLE_API_KEY` repository secret.

## Tests

`cargo test`: 330 passed. `cargo clippy --all-targets` and `cargo fmt --check` clean. New tests cover envelope round-trip, tamper and wrong-key failure, link parsing, sanitizing, publish + properties, open after revoke, sweep of expired/live/undated files, and cleanup after a failed publish.